### PR TITLE
fix: add @babel/runtime dependency

### DIFF
--- a/.changeset/rotten-hairs-bathe.md
+++ b/.changeset/rotten-hairs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: add @babel/runtime dependency

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -64,6 +64,7 @@
     "vitest": "^1.2.1"
   },
   "dependencies": {
+    "@babel/runtime": "^7.23.9",
     "axios": "^1.6.0",
     "axios-retry": "^3.1.9",
     "eventemitter2": "^6.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,6 +1244,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.23.9":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
+  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.0.0", "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"


### PR DESCRIPTION
Adds `@babel/runtime` as a dependency since it's required by the [babel-plugin-transform-runtime](https://babeljs.io/docs/babel-plugin-transform-runtime) plugin we use. 