### PR TITLE
fix: esm import issues

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -4,13 +4,13 @@
   "author": "@knocklabs",
   "version": "0.1.2",
   "license": "MIT",
-  "main": "dist/cjs/index.js",
+  "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "typings": "dist/types/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/cjs/index.js",
+      "require": "./dist/cjs/index.cjs",
       "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     }

--- a/packages/react-core/vite.config.ts
+++ b/packages/react-core/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig(({ mode }) => {
             react: "React",
           },
           entryFileNames: () => {
-            return "[name].js";
+            return CJS ? "[name].cjs" : "[name].js";
           },
         },
       },


### PR DESCRIPTION
When importing `@knocklabs/react` as esm, `@knocklabs/react-core` gets imported as common js where it should be esm. This updates the build to output `.cjs` files in the cjs build and `.js` in the esm build. Updates package.json to disambiguate the imports. 