### PR TITLE
feat(kno-5138): enable popup window for slack auth flow

### DIFF
--- a/examples/slack-connect-example/lib/api.ts
+++ b/examples/slack-connect-example/lib/api.ts
@@ -12,8 +12,6 @@ export async function setToken(params = {}) {
 
     return jsonResponse;
   } catch (e) {
-    console.error(e);
-
     return { error: "Error sending request" };
   }
 }

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -8,7 +8,7 @@ import { KnockOptions } from "./interfaces";
 const DEFAULT_HOST = "https://api.knock.app";
 
 class Knock {
-  private host: string;
+  public host: string;
   private apiClient: ApiClient | null = null;
   public userId: string | undefined;
   public userToken: string | undefined;
@@ -18,7 +18,10 @@ class Knock {
   readonly slack = new SlackClient(this);
   readonly user = new UserClient(this);
 
-  constructor(readonly apiKey: string, options: KnockOptions = {}) {
+  constructor(
+    readonly apiKey: string,
+    options: KnockOptions = {},
+  ) {
     this.host = options.host || DEFAULT_HOST;
 
     // Fail loudly if we're using the wrong API key

--- a/packages/react/src/modules/slack/components/ConnectToSlackButton/ConnectToSlackButton.tsx
+++ b/packages/react/src/modules/slack/components/ConnectToSlackButton/ConnectToSlackButton.tsx
@@ -2,6 +2,8 @@ import { SlackIcon } from "../SlackIcon";
 import "./styles.css";
 
 import { useManageSlackConnection } from "../../hooks/useManageSlackConnection";
+import { useEffect } from "react";
+import { useKnockClient } from "@knocklabs/react-core";
 
 type Props = {
   tenant: string;
@@ -10,19 +12,74 @@ type Props = {
   redirectUrl?: string;
 };
 
+const openSlackOauthPopup = (url: string) => {
+  const width = 600;
+  const height = 800;
+  // Calculate the position to center the window
+  const screenLeft = window.screenLeft ?? window.screenX;
+  const screenTop = window.screenTop ?? window.screenY;
+
+  const innerWidth =
+    window.innerWidth ?? document.documentElement.clientWidth ?? screen.width;
+  const innerHeight =
+    window.innerHeight ??
+    document.documentElement.clientHeight ??
+    screen.height;
+
+  const left = innerWidth / 2 - width / 2 + screenLeft;
+  const top = innerHeight / 2 - height / 2 + screenTop;
+
+  // Window features
+  const features = `width=${width},height=${height},top=${top},left=${left}`;
+
+  window.open(url, "Slack OAuth", features);
+};
+
 export const ConnectToSlackButton: React.FC<Props> = ({
   tenant,
   knockSlackChannelId,
   slackClientId,
   redirectUrl,
 }) => {
-  const { connectionStatus, actionLabel, errorLabel, setActionLabel, buildSlackAuthUrl, disconnectFromSlack } =
-    useManageSlackConnection(
-      knockSlackChannelId,
-      tenant,
-      slackClientId,
-      redirectUrl,
-    );
+  const knock = useKnockClient();
+
+  const {
+    connectionStatus,
+    actionLabel,
+    errorLabel,
+    setConnectionStatus,
+    setActionLabel,
+    buildSlackAuthUrl,
+    disconnectFromSlack,
+  } = useManageSlackConnection(
+    knockSlackChannelId,
+    tenant,
+    slackClientId,
+    redirectUrl,
+  );
+
+  useEffect(() => {
+    const receiveMessage = (event: MessageEvent) => {
+      if (event.origin !== knock.host) {
+        return;
+      }
+
+      try {
+        if (event.data === "authComplete") {
+          setConnectionStatus("connected");
+        }
+      } catch (error) {
+        setConnectionStatus("error");
+      }
+    };
+
+    window.addEventListener("message", receiveMessage, false);
+
+    // Cleanup the event listener when the component unmounts
+    return () => {
+      window.removeEventListener("message", receiveMessage);
+    };
+  }, [knock.host, setConnectionStatus]);
 
   // Loading states
   if (connectionStatus === "loading" || connectionStatus === "disconnecting") {
@@ -41,8 +98,8 @@ export const ConnectToSlackButton: React.FC<Props> = ({
   // Error state
   if (connectionStatus === "error") {
     return (
-      <a
-        href={buildSlackAuthUrl()}
+      <button
+        onClick={() => openSlackOauthPopup(buildSlackAuthUrl())}
         className="rnf-slackConnect-button rnf-slackConnect-button--error"
         onMouseEnter={() => setActionLabel("Reconnect")}
         onMouseLeave={() => setActionLabel("")}
@@ -51,26 +108,26 @@ export const ConnectToSlackButton: React.FC<Props> = ({
         <span className="rnf-slackConnect-text--error">
           {actionLabel || errorLabel || "Error"}
         </span>
-      </a>
+      </button>
     );
   }
 
   // Disconnected state
   if (connectionStatus === "disconnected") {
     return (
-      <a
-        href={buildSlackAuthUrl()}
+      <button
+        onClick={() => openSlackOauthPopup(buildSlackAuthUrl())}
         className="rnf-slackConnect-button rnf-slackConnect-button--disconnected"
       >
         <SlackIcon height="16px" width="16px" />
         <span>Connect to Slack</span>
-      </a>
+      </button>
     );
   }
 
   // Connected state
   return (
-    <a
+    <button
       onClick={disconnectFromSlack}
       className="rnf-slackConnect-button rnf-slackConnect-button--connected"
       onMouseEnter={() => setActionLabel("Disconnect")}
@@ -80,6 +137,6 @@ export const ConnectToSlackButton: React.FC<Props> = ({
       <span className="rnf-slackConnect-text--connected">
         {actionLabel || "Connected"}
       </span>
-    </a>
+    </button>
   );
 };

--- a/packages/react/src/modules/slack/hooks/useManageSlackConnection.ts
+++ b/packages/react/src/modules/slack/hooks/useManageSlackConnection.ts
@@ -15,6 +15,7 @@ type ConnectionStatus =
 
 type UseManageSlackConnectionProps = {
   connectionStatus: ConnectionStatus;
+  setConnectionStatus: (status: ConnectionStatus) => void;
   errorLabel: string | null;
   setErrorLabel: (errorLabel: string) => void;
   actionLabel: string | null;
@@ -84,7 +85,6 @@ export function useManageSlackConnection(
         // This is for any Knock errors that would require a reconnect.
         setConnectionStatus("error");
       } catch (error) {
-        console.error(error);
         setConnectionStatus("error");
       }
     };
@@ -106,7 +106,6 @@ export function useManageSlackConnection(
         setConnectionStatus("error");
       }
     } catch (error) {
-      console.error("Error revoking token:", error);
       setConnectionStatus("error");
     }
   }, [tenant, knockSlackChannelId, setConnectionStatus, knock.slack]);
@@ -138,6 +137,7 @@ export function useManageSlackConnection(
 
   return {
     connectionStatus,
+    setConnectionStatus,
     errorLabel,
     setErrorLabel,
     actionLabel,

--- a/packages/react/src/modules/slack/hooks/useSlackChannels.ts
+++ b/packages/react/src/modules/slack/hooks/useSlackChannels.ts
@@ -56,7 +56,6 @@ export function useSlackChannels(
               return;
             });
         } catch (error) {
-          console.error(error);
           setErrorMessage("Something went wrong.");
         }
       };


### PR DESCRIPTION
Adds a pop up window for the slack auth flow rather than using a redirect for this. Relies on switchboard PR to return the window close html: https://github.com/knocklabs/switchboard/pull/1909