### PR TITLE
fix: eslint-config devDeps not accessible, moving to deps

### DIFF
--- a/.changeset/popular-days-worry.md
+++ b/.changeset/popular-days-worry.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/eslint-config": patch
+---
+
+fix: move eslint-config devDeps to deps so they're accessible when installed

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -6,7 +6,7 @@
     "next.js",
     "react-internal.js"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vercel/style-guide": "^5.1.0",


### PR DESCRIPTION
When installing `@knocklabs/eslint-config` because the dependencies are set to `devDependencies`, they're not installed along with the config. This means each of those dependencies would need to be installed on their own. 

This moves these `devDependencies` to `dependencies` to make install smoother.