### PR TITLE
feat(kno-5241): if max channels reached, use text input to add channel

### DIFF
--- a/packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts
+++ b/packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts
@@ -15,6 +15,7 @@ type UseSlackChannelOutput = {
   ) => void;
   loading: boolean;
   error: string | null;
+  updating: boolean;
 };
 
 function useConnectedSlackChannels({
@@ -27,6 +28,7 @@ function useConnectedSlackChannels({
   >(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false)
 
   const fetchAndSetConnectedChannels = useCallback(() => {
     setIsLoading(true);
@@ -74,6 +76,7 @@ function useConnectedSlackChannels({
   const updateConnectedChannels = async (
     channelsToSendToKnock: SlackChannelConnection[],
   ) => {
+    setIsUpdating(true)
     try {
       await knock.objects.setChannelData({
         objectId,
@@ -83,13 +86,15 @@ function useConnectedSlackChannels({
       });
       fetchAndSetConnectedChannels();
     } catch (error) {
-      setError("Error setting channels.");
+      setError("Error setting channel.");
     }
+    setIsUpdating(false)
   };
 
   return {
     data: connectedChannels,
     updateConnectedChannels,
+    updating: isUpdating,
     loading: isLoading,
     error,
   };

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/AddConnectedSlackChannelInput.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/AddConnectedSlackChannelInput.tsx
@@ -1,0 +1,72 @@
+import { SlackChannelConnection } from "@knocklabs/client";
+import { useState } from "react";
+
+import { SlackIcon } from "../SlackIcon";
+
+import ConnectionErrorInfoBoxes from "./ConnectionErrorInfoBoxes";
+import "./styles.css";
+
+const AddConnectedSlackChannelInput = ({
+  isErrorState,
+  connectedChannels = [],
+  updateConnectedChannels,
+  connectedChannelsError,
+  connectedChannelsUpdating,
+}: {
+  isErrorState: boolean;
+  connectedChannels: SlackChannelConnection[];
+  updateConnectedChannels: (channels: SlackChannelConnection[]) => void;
+  connectedChannelsError: string | null;
+  connectedChannelsUpdating: boolean;
+}) => {
+  const [value, setValue] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const submitChannel = () => {
+    if (!value) {
+      return;
+    }
+
+    if (localError) {
+      setLocalError(null);
+    }
+
+    const alreadyConnected = connectedChannels.find(
+      (channel) => channel.channel_id === value,
+    );
+
+    if (alreadyConnected) {
+      setValue("");
+      return setLocalError(`"${value}" already connected.`);
+    }
+
+    const channelsToSendToKnock = [...connectedChannels, { channel_id: value }];
+    updateConnectedChannels(channelsToSendToKnock);
+    setValue("");
+  };
+
+  return (
+    <div className="rnf-connect-channel-input-container">
+      <input
+        className={`rnf-input ${((isErrorState || !!localError) && !value) && "rnf-input-error"}`}
+        tabIndex={-1}
+        id="slack-channel-search"
+        type="text"
+        placeholder={localError || connectedChannelsError || "Slack channel ID"}
+        onChange={(e) => setValue(e.target.value)}
+        value={value || ""}
+      />
+      <button className="rnf-button" onClick={submitChannel}>
+        {connectedChannelsUpdating ? (
+          <div className="rnf-spinner"></div>
+        ) : (
+          <SlackIcon height="16px" width="16px" />
+        )}
+        Connect channel
+      </button>
+      <ConnectionErrorInfoBoxes />
+    </div>
+  );
+};
+
+export default AddConnectedSlackChannelInput;

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/ConnectionErrorInfoBoxes.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/ConnectionErrorInfoBoxes.tsx
@@ -1,0 +1,27 @@
+import { useKnockSlackClient } from "@knocklabs/react-core";
+
+import InfoIcon from "./icons/InfoIcon";
+
+const ConnectionErrorInfoBoxes = () => {
+  const { connectionStatus } = useKnockSlackClient();
+
+  if (connectionStatus === "disconnected" || connectionStatus === "error") {
+    return (
+      <div className="rnf-disconnected-info-container">
+        <span>
+          <InfoIcon />
+        </span>
+
+        <div className="rnf-info-container-text">
+          {connectionStatus === "disconnected"
+            ? "There was an error connecting to Slack. Try reconnecting to find and select channels from your workspace."
+            : "Try reconnecting to Slack to find and select channels from your workspace."}
+        </div>
+      </div>
+    );
+  }
+
+  return <div />;
+};
+
+export default ConnectionErrorInfoBoxes;

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/styles.css
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/styles.css
@@ -8,6 +8,33 @@
   width: 100%;
 }
 
+.rnf-input {
+  padding-left: 0.5rem;
+  width: 270px;
+  height: 32px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.rnf-button {
+  height: 24px;
+  border-radius: 6px;
+  border-color: #dddee1;
+  background-color: #fff;
+  color: #000;
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px;
+  text-decoration: none;
+  font-family: Inter, sans-serif;
+  gap: 8px;
+}
+
+.rnf-button:hover {
+  background-color: rgba(247, 247, 248, 1);
+}
+
 .rnf-input-with-icon {
   padding-left: 2rem;
   height: 32px;
@@ -15,6 +42,12 @@
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+
+.rnf-input-error {
+  background-color: rgba(255, 255, 240, 1);
+  border: 1px solid rgba(247, 212, 102, 1);
+}
+
 .rnf-input-with-icon-error {
   background-color: rgba(255, 255, 240, 1);
   border: 1px solid rgba(247, 212, 102, 1);
@@ -88,4 +121,28 @@
   font-style: normal;
   font-weight: 400;
   line-height: normal;
+}
+
+.rnf-connect-channel-input-container {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.rnf-spinner {
+  border: 1px solid #000000;
+  border-radius: 50%;
+  border-bottom: 1px solid transparent;
+  width: 14px;
+  height: 14px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
This is a v1 text input for adding channels that I'd like to get in for us to play with and see what it needs. 
Basically we want to restrict using the combobox to only work if you have fewer than 1000 slack channels. if you have more than that, we'll intentionally degrade the experience to help with performance, which is where we have this input box come in.

It's very stupid, it just takes a text string and posts it to the setChannelData endpoint as an entry in channel data. It does not check if it belongs to a real slack channel (and it shouldn't this is out of scope). It does check if the channel id already exists in the connected channel ids. Once it's in, we can tweak the design.
https://www.loom.com/share/7fda538f23fc4fd789bd837f2eb3cc44