### PR TITLE
fix: gracefully handle credential changes

### DIFF
--- a/examples/nextjs-example/hooks/useLocalStorage.tsx
+++ b/examples/nextjs-example/hooks/useLocalStorage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export function useLocalStorage(key: any, initialValue: any) {
   const initialize = (key: any) => {
@@ -15,7 +15,7 @@ export function useLocalStorage(key: any, initialValue: any) {
     }
   };
 
-  const [state, setState] = useState(null);
+  const [state, setState] = useState<any>(null);
 
   useEffect(() => {
     setState(initialize(key));

--- a/examples/nextjs-example/pages/api/identify.ts
+++ b/examples/nextjs-example/pages/api/identify.ts
@@ -1,7 +1,7 @@
-import { Knock } from "@knocklabs/node";
-import { v4 as uuidv4 } from "uuid";
 import { faker } from "@faker-js/faker";
+import { Knock } from "@knocklabs/node";
 import { NextApiRequest, NextApiResponse } from "next";
+import { v4 as uuidv4 } from "uuid";
 
 const knockClient = new Knock(process.env.KNOCK_SECRET_API_KEY, {
   host: process.env.NEXT_PUBLIC_KNOCK_HOST,

--- a/examples/nextjs-example/pages/index.tsx
+++ b/examples/nextjs-example/pages/index.tsx
@@ -13,7 +13,7 @@ import {
   KnockProvider,
   NotificationFeedContainer,
 } from "@knocklabs/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { IoDocument, IoLogoGithub } from "react-icons/io5";
 
 import NotificationFeed from "../components/NotificationFeed";
@@ -33,26 +33,17 @@ const TenantLabels = {
 
 export default function Home() {
   const { userId, isLoading, userToken } = useIdentify();
-  const [currentUserToken, setCurrentUserToken] = useState(null);
   const [tenant, setTenant] = useState(Tenants.TeamA);
-
-  useEffect(() => {
-    if (userToken) {
-      setCurrentUserToken(userToken);
-    }
-  }, [userToken]);
 
   const tokenRefreshHandler = useCallback(async () => {
     // Refresh the user token 1s before it expires
     const res = await fetch(`/api/auth?id=${userId}`);
     const json = await res.json();
 
-    setCurrentUserToken(json.userToken);
+    return json.userToken;
+  }, [userId]);
 
-    return;
-  }, [userId, setCurrentUserToken]);
-
-  if (isLoading || !currentUserToken) {
+  if (isLoading || !userToken) {
     return (
       <Flex
         alignItems="center"
@@ -68,7 +59,7 @@ export default function Home() {
   return (
     <KnockProvider
       userId={userId}
-      userToken={currentUserToken || undefined}
+      userToken={userToken}
       apiKey={process.env.NEXT_PUBLIC_KNOCK_PUBLIC_API_KEY!}
       host={process.env.NEXT_PUBLIC_KNOCK_HOST}
       onUserTokenExpiring={tokenRefreshHandler}

--- a/examples/nextjs-example/pages/index.tsx
+++ b/examples/nextjs-example/pages/index.tsx
@@ -13,7 +13,7 @@ import {
   KnockProvider,
   NotificationFeedContainer,
 } from "@knocklabs/react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { IoDocument, IoLogoGithub } from "react-icons/io5";
 
 import NotificationFeed from "../components/NotificationFeed";
@@ -33,9 +33,26 @@ const TenantLabels = {
 
 export default function Home() {
   const { userId, isLoading, userToken } = useIdentify();
+  const [currentUserToken, setCurrentUserToken] = useState(null);
   const [tenant, setTenant] = useState(Tenants.TeamA);
 
-  if (isLoading || !userToken) {
+  useEffect(() => {
+    if (userToken) {
+      setCurrentUserToken(userToken);
+    }
+  }, [userToken]);
+
+  const tokenRefreshHandler = useCallback(async () => {
+    // Refresh the user token 1s before it expires
+    const res = await fetch(`/api/auth?id=${userId}`);
+    const json = await res.json();
+
+    setCurrentUserToken(json.userToken);
+
+    return;
+  }, [userId, setCurrentUserToken]);
+
+  if (isLoading || !currentUserToken) {
     return (
       <Flex
         alignItems="center"
@@ -50,25 +67,17 @@ export default function Home() {
 
   return (
     <KnockProvider
-      userId={userId as any}
-      userToken={userToken}
+      userId={userId}
+      userToken={currentUserToken || undefined}
       apiKey={process.env.NEXT_PUBLIC_KNOCK_PUBLIC_API_KEY!}
       host={process.env.NEXT_PUBLIC_KNOCK_HOST}
-      onUserTokenExpiring={async () => {
-        // Refresh the user token 1s before it expires
-        const res = await fetch(`/api/auth?id=${userId}`);
-        const json = await res.json();
-        return json.userToken;
-      }}
-      timeBeforeExpirationInMs={1000}
+      onUserTokenExpiring={tokenRefreshHandler}
+      timeBeforeExpirationInMs={5000}
+      logLevel="debug"
     >
       <KnockFeedProvider
         feedId={process.env.NEXT_PUBLIC_KNOCK_FEED_CHANNEL_ID!}
-        defaultFeedOptions={{
-          tenant,
-          auto_manage_socket_connection: true,
-          auto_manage_socket_connection_delay: 2500,
-        }}
+        defaultFeedOptions={{ tenant }}
       >
         <NotificationFeedContainer>
           <Box maxW="520px" mx="auto" py={12}>

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import { AxiosError } from "axios";
 import axiosRetry from "axios-retry";
 import { Socket } from "phoenix";
-import { AxiosError } from "axios";
 
 type ApiClientOptions = {
   host: string;
@@ -83,18 +83,6 @@ class ApiClient {
         body: undefined,
         error: e,
       };
-    }
-  }
-
-  reconnectSocket() {
-    if (this.socket && !this.socket.isConnected()) {
-      this.socket.connect();
-    }
-  }
-
-  disconnectSocket() {
-    if (this.socket) {
-      this.socket.disconnect();
     }
   }
 

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -1,5 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
-import { AxiosError } from "axios";
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
 import axiosRetry from "axios-retry";
 import { Socket } from "phoenix";
 

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -42,19 +42,23 @@ class ApiClient {
       },
     });
 
-    if (typeof window !== "undefined") {
-      this.socket = new Socket(`${this.host.replace("http", "ws")}/ws/v1`, {
-        params: {
-          user_token: this.userToken,
-          api_key: this.apiKey,
-        },
-      });
-    }
+    this.initializeSocket();
 
     axiosRetry(this.axiosClient, {
       retries: 3,
       retryCondition: this.canRetryRequest,
       retryDelay: axiosRetry.exponentialDelay,
+    });
+  }
+
+  initializeSocket() {
+    if (typeof window === "undefined") return;
+
+    this.socket = new Socket(`${this.host.replace("http", "ws")}/ws/v1`, {
+      params: {
+        user_token: this.userToken,
+        api_key: this.apiKey,
+      },
     });
   }
 

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -42,14 +42,6 @@ class ApiClient {
       },
     });
 
-    this.initializeSocket();
-
-    axiosRetry(this.axiosClient, {
-      retries: 3,
-      retryCondition: this.canRetryRequest,
-      retryDelay: axiosRetry.exponentialDelay,
-    });
-
     if (typeof window !== "undefined") {
       this.socket = new Socket(`${this.host.replace("http", "ws")}/ws/v1`, {
         params: {
@@ -58,6 +50,12 @@ class ApiClient {
         },
       });
     }
+
+    axiosRetry(this.axiosClient, {
+      retries: 3,
+      retryCondition: this.canRetryRequest,
+      retryDelay: axiosRetry.exponentialDelay,
+    });
   }
 
   async makeRequest(req: AxiosRequestConfig): Promise<ApiResponse> {

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -49,17 +49,15 @@ class ApiClient {
       retryCondition: this.canRetryRequest,
       retryDelay: axiosRetry.exponentialDelay,
     });
-  }
 
-  initializeSocket() {
-    if (typeof window === "undefined") return;
-
-    this.socket = new Socket(`${this.host.replace("http", "ws")}/ws/v1`, {
-      params: {
-        user_token: this.userToken,
-        api_key: this.apiKey,
-      },
-    });
+    if (typeof window !== "undefined") {
+      this.socket = new Socket(`${this.host.replace("http", "ws")}/ws/v1`, {
+        params: {
+          user_token: this.userToken,
+          api_key: this.apiKey,
+        },
+      });
+    }
   }
 
   async makeRequest(req: AxiosRequestConfig): Promise<ApiResponse> {

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -83,9 +83,6 @@ class Feed {
 
     // Reinitialize our broadcast channel
     this.setupBroadcastChannel();
-
-    // Refetch the store state
-    this.fetch();
   }
 
   /**
@@ -115,7 +112,6 @@ class Feed {
     this.knock.log("[Feed] Disposing of feed instance");
     this.teardown();
     this.broadcaster.removeAllListeners();
-    this.store.setState((store) => store.resetStore());
     this.knock.feeds.removeInstance(this);
   }
 
@@ -765,7 +761,6 @@ class Feed {
         // If the socket is not connected, try to reconnect
         if (!client.socket?.isConnected()) {
           this.initializeRealtimeConnection();
-          this.fetch();
         }
       }
     });

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -742,10 +742,12 @@ class Feed {
       autoManageSocketConnectionDelay ?? DEFAULT_DISCONNECT_DELAY;
 
     document.addEventListener("visibilitychange", () => {
+      const client = this.knock.client();
+
       if (document.visibilityState === "hidden") {
         // When the tab is hidden, clean up the socket connection after a delay
         this.disconnectTimer = setTimeout(() => {
-          // this.knock.client().disconnectSocket();
+          client.socket?.disconnect();
           this.disconnectTimer = null;
         }, disconnectDelay);
       } else if (document.visibilityState === "visible") {
@@ -755,8 +757,6 @@ class Feed {
           clearTimeout(this.disconnectTimer);
           this.disconnectTimer = null;
         }
-
-        const client = this.knock.client();
 
         // If the socket is not connected, try to reconnect
         if (!client.socket?.isConnected()) {

--- a/packages/client/src/clients/feed/index.ts
+++ b/packages/client/src/clients/feed/index.ts
@@ -15,7 +15,7 @@ class FeedClient {
     const feedInstance = new Feed(this.instance, feedChannelId, options);
     this.feedInstances.push(feedInstance);
 
-    return this.feedInstances;
+    return feedInstance;
   }
 
   removeInstance(feed: Feed) {
@@ -30,7 +30,7 @@ class FeedClient {
 
   reinitializeInstances() {
     for (const feed of this.feedInstances) {
-      feed.initializeRealtimeConnection();
+      feed.reinitialize();
     }
   }
 }

--- a/packages/client/src/clients/feed/index.ts
+++ b/packages/client/src/clients/feed/index.ts
@@ -5,13 +5,33 @@ import { FeedClientOptions } from "./interfaces";
 
 class FeedClient {
   private instance: Knock;
+  private feedInstances: Feed[] = [];
 
   constructor(instance: Knock) {
     this.instance = instance;
   }
 
   initialize(feedChannelId: string, options: FeedClientOptions = {}) {
-    return new Feed(this.instance, feedChannelId, options);
+    const feedInstance = new Feed(this.instance, feedChannelId, options);
+    this.feedInstances.push(feedInstance);
+
+    return this.feedInstances;
+  }
+
+  removeInstance(feed: Feed) {
+    this.feedInstances = this.feedInstances.filter((f) => f !== feed);
+  }
+
+  teardownInstances() {
+    for (const feed of this.feedInstances) {
+      feed.teardown();
+    }
+  }
+
+  reinitializeInstances() {
+    for (const feed of this.feedInstances) {
+      feed.initializeRealtimeConnection();
+    }
   }
 }
 

--- a/packages/client/src/clients/feed/store.ts
+++ b/packages/client/src/clients/feed/store.ts
@@ -1,5 +1,7 @@
 import create from "zustand/vanilla";
+
 import { NetworkStatus } from "../../networkStatus";
+
 import { FeedItem } from "./interfaces";
 import { FeedStoreState } from "./types";
 import { deduplicateItems, sortItems } from "./utils";
@@ -37,9 +39,6 @@ export default function createStore() {
     // The network status indicates what's happening with the request
     networkStatus: NetworkStatus.ready,
     loading: false,
-    // TODO: remove this function from the store as we're now using the
-    // `setNetworkStatus` function to derive this information instead
-    setLoading: (loading) => set(() => ({ loading })),
 
     setNetworkStatus: (networkStatus: NetworkStatus) =>
       set(() => ({

--- a/packages/client/src/clients/feed/types.ts
+++ b/packages/client/src/clients/feed/types.ts
@@ -1,5 +1,7 @@
 import { PageInfo } from "@knocklabs/types";
+
 import { NetworkStatus } from "../../networkStatus";
+
 import { FeedItem, FeedMetadata, FeedResponse } from "./interfaces";
 
 export type StoreFeedResultOptions = {
@@ -15,7 +17,6 @@ export type FeedStoreState = {
   networkStatus: NetworkStatus;
   setResult: (response: FeedResponse, opts?: StoreFeedResultOptions) => void;
   setMetadata: (metadata: FeedMetadata) => void;
-  setLoading: (loading: boolean) => void;
   setNetworkStatus: (networkStatus: NetworkStatus) => void;
   setItemAttrs: (itemIds: string[], attrs: object) => void;
   resetStore: (metadata?: FeedMetadata) => void;

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -1,7 +1,10 @@
 import { GenericData } from "@knocklabs/types";
 
+export type LogLevel = "debug";
+
 export interface KnockOptions {
   host?: string;
+  logLevel?: LogLevel;
 }
 
 export interface KnockObject<T = GenericData> {
@@ -41,7 +44,7 @@ export interface ChannelData<T = any> {
 export type UserTokenExpiringCallback = (
   currentToken: string,
   decodedToken: any,
-) => Promise<string> | string;
+) => Promise<string | void>;
 
 export interface AuthenticateOptions {
   onUserTokenExpiring?: UserTokenExpiringCallback;

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -1,4 +1,4 @@
-import Knock, { AuthenticateOptions } from "@knocklabs/client";
+import Knock, { AuthenticateOptions, LogLevel } from "@knocklabs/client";
 import * as React from "react";
 
 import { I18nContent, KnockI18nProvider } from "../../i18n";
@@ -27,11 +27,14 @@ export interface KnockProviderProps {
 
   // i18n translations
   i18n?: I18nContent;
+
+  logLevel?: LogLevel;
 }
 
 export const KnockProvider: React.FC<KnockProviderProps> = ({
   apiKey,
   host,
+  logLevel,
   userId,
   userToken,
   onUserTokenExpiring,
@@ -39,11 +42,25 @@ export const KnockProvider: React.FC<KnockProviderProps> = ({
   children,
   i18n,
 }) => {
-  const knock = useAuthenticatedKnockClient(apiKey, userId, userToken, {
-    host,
-    onUserTokenExpiring,
-    timeBeforeExpirationInMs,
-  });
+  // We memoize the options here so that we don't create a new object on every re-render
+  // TODO: we probably need to put this optimization into the `useAuthenticatedKnockClient`
+  // hook itself to fix this
+  const authenticateOptions = React.useMemo(
+    () => ({
+      host,
+      onUserTokenExpiring,
+      timeBeforeExpirationInMs,
+      logLevel,
+    }),
+    [host, onUserTokenExpiring, timeBeforeExpirationInMs, logLevel],
+  );
+
+  const knock = useAuthenticatedKnockClient(
+    apiKey,
+    userId,
+    userToken,
+    authenticateOptions,
+  );
 
   return (
     <ProviderStateContext.Provider

--- a/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
+++ b/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
@@ -1,5 +1,17 @@
-import React, { useMemo } from "react";
 import Knock, { AuthenticateOptions, KnockOptions } from "@knocklabs/client";
+import React, { useMemo } from "react";
+
+function authenticateWithOptions(
+  knock: Knock,
+  userId: string,
+  userToken?: string,
+  options: AuthenticateOptions = {},
+) {
+  knock.authenticate(userId, userToken, {
+    onUserTokenExpiring: options?.onUserTokenExpiring,
+    timeBeforeExpirationInMs: options?.timeBeforeExpirationInMs,
+  });
+}
 
 function useAuthenticatedKnockClient(
   apiKey: string,
@@ -10,13 +22,25 @@ function useAuthenticatedKnockClient(
   const knockRef = React.useRef<Knock | null>();
 
   return useMemo(() => {
-    if (knockRef.current) knockRef.current.teardown();
+    const currentKnock = knockRef.current;
 
+    // If the userId and the userToken changes then just reauth
+    if (
+      currentKnock &&
+      currentKnock.isAuthenticated() &&
+      (currentKnock.userId !== userId || currentKnock.userToken !== userToken)
+    ) {
+      authenticateWithOptions(currentKnock, userId, userToken, options);
+      return currentKnock;
+    }
+
+    if (currentKnock) {
+      currentKnock.teardown();
+    }
+
+    // Otherwise instantiate a new Knock client
     const knock = new Knock(apiKey, options);
-    knock.authenticate(userId, userToken, {
-      onUserTokenExpiring: options?.onUserTokenExpiring,
-      timeBeforeExpirationInMs: options?.timeBeforeExpirationInMs,
-    });
+    authenticateWithOptions(knock, userId, userToken, options);
     knockRef.current = knock;
 
     return knock;

--- a/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx
+++ b/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx
@@ -1,20 +1,20 @@
-import * as React from "react";
 import Knock, {
   Feed,
   FeedClientOptions,
   FeedStoreState,
 } from "@knocklabs/client";
-import create, { StoreApi, UseStore } from "zustand";
+import * as React from "react";
+import create, { UseBoundStore } from "zustand";
 
-import { ColorMode } from "../../core/constants";
-import useNotifications from "../hooks/useNotifications";
-import { feedProviderKey } from "../../core/utils";
 import { useKnockClient } from "../../core";
+import { ColorMode } from "../../core/constants";
+import { feedProviderKey } from "../../core/utils";
+import useNotifications from "../hooks/useNotifications";
 
 export interface KnockFeedProviderState {
   knock: Knock;
   feedClient: Feed;
-  useFeedStore: UseStore<FeedStoreState>;
+  useFeedStore: UseBoundStore<FeedStoreState>;
   colorMode: ColorMode;
 }
 
@@ -41,9 +41,8 @@ export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
   colorMode = "light",
 }) => {
   const knock = useKnockClient();
-
   const feedClient = useNotifications(knock, feedId, defaultFeedOptions);
-  const useFeedStore = create(feedClient.store as StoreApi<FeedStoreState>);
+  const useFeedStore = create<FeedStoreState>(feedClient.store);
 
   return (
     <FeedStateContext.Provider

--- a/packages/react-core/src/modules/feed/hooks/useNotifications.ts
+++ b/packages/react-core/src/modules/feed/hooks/useNotifications.ts
@@ -3,15 +3,17 @@ import { useMemo, useRef } from "react";
 
 function useNotifications(
   knock: Knock,
-  feedId: string,
+  feedChannelId: string,
   options: FeedClientOptions = {},
 ) {
   const feedClientRef = useRef<Feed | null>();
 
   return useMemo(() => {
-    if (feedClientRef.current) feedClientRef.current.dispose();
+    if (feedClientRef.current) {
+      feedClientRef.current.dispose();
+    }
 
-    const feedClient = knock.feeds.initialize(feedId, options);
+    const feedClient = knock.feeds.initialize(feedChannelId, options);
 
     feedClient.listenForUpdates();
     feedClientRef.current = feedClient;
@@ -19,7 +21,7 @@ function useNotifications(
     return feedClient;
   }, [
     knock,
-    feedId,
+    feedChannelId,
     options.source,
     options.tenant,
     options.has_tenant,

--- a/packages/react-core/src/modules/feed/hooks/useNotifications.ts
+++ b/packages/react-core/src/modules/feed/hooks/useNotifications.ts
@@ -9,7 +9,7 @@ function useNotifications(
   const feedClientRef = useRef<Feed | null>();
 
   return useMemo(() => {
-    if (feedClientRef.current) feedClientRef.current.teardown();
+    if (feedClientRef.current) feedClientRef.current.dispose();
 
     const feedClient = knock.feeds.initialize(feedId, options);
 


### PR DESCRIPTION
This is quite a few updates, but it essentially boils down to:

- Gracefully handling userId and userToken changes by reauthenticating and reconnecting real-time connections
- Memoizing options to prevent the API client from being recreated when unnecessary
- Removing `store.destroy()` when tearing down a feed instance which was causing the state management to get disconnected

