### PR TITLE
fix(kno-5254): hide inaccessible channels

### DIFF
--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelOption.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelOption.tsx
@@ -31,15 +31,15 @@ const SlackChannelOption = ({
   const [submittedId, setSubmittedId] = useState<string | null>(null);
 
   const icon = () => {
-    if (submittedId === channel.id && isUpdating) {
-      return <Spinner size="15px" thickness={3} />;
+    if (submittedId === channel.id && (isUpdating || isLoading)) {
+      return <Spinner thickness={3} />;
     }
 
     if (isHovered || isConnected) {
       return <CheckmarkIcon isConnected={isConnected} />;
     }
 
-    return <div style={{ width: "15px", height: "18.5px" }} />;
+    return <div />;
   };
 
   const handleOptionClick = (channelId: string) => {
@@ -51,12 +51,12 @@ const SlackChannelOption = ({
     if (submittedId && !isUpdating) {
       return setSubmittedId(null);
     }
-  }, [isUpdating, submittedId]);
+  }, [isLoading, isUpdating, submittedId]);
 
   return (
     <button
       key={channel.id}
-      className="rnf-channel-option"
+      className="rnf-channel-option-button"
       onClick={() => !isLoading && handleOptionClick(channel.id)}
       disabled={isLoading || isUpdating}
       onMouseEnter={() => setIsHovered(true)}
@@ -64,10 +64,12 @@ const SlackChannelOption = ({
       tabIndex={tabIndex}
       {...channelOptionProps}
     >
-      <div style={{ marginRight: "0.25rem" }}>{icon()}</div>
-      <span className="rnf-icon">
-        {channel.is_private ? <LockIcon /> : <HashtagIcon />}
-      </span>
+      <div className="rnf-slack-channel-option-text-with-icon">
+        <div className="rnf-connected-status-icon">{icon()}</div>
+        <div className="rnf-icon">
+          {channel.is_private ? <LockIcon /> : <HashtagIcon />}
+        </div>
+      </div>
       {channel.name}
     </button>
   );

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/icons/CheckmarkIcon.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/icons/CheckmarkIcon.tsx
@@ -1,10 +1,19 @@
-const CheckmarkIcon = ({ isConnected }: { isConnected: boolean }) => (
+const CheckmarkIcon = ({
+  isConnected,
+  size = "1rem",
+  ...props
+}: {
+  isConnected: boolean;
+  size?: string;
+}) => (
   <svg
-    width="14"
-    height="15"
+    height={size}
+    width={size}
+    role="img"
     viewBox="0 0 14 15"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <path
       d="M11.3751 3.9996L5.25006 10.9996L2.62506 8.3746"

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/styles.css
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/styles.css
@@ -87,21 +87,26 @@
     0px 1px 3px 0px rgba(0, 0, 0, 0.1);
 }
 
-.rnf-channel-option {
+.rnf-channel-option-button {
   display: flex;
-  padding: 0.5rem 1rem 0.5rem 0.5rem;
+  padding: 0.5rem 0rem 0.5rem 0rem;
   background-color: white;
   border-width: 0px;
 }
 
-.rnf-channel-option:disabled {
+.rnf-channel-option-button:disabled {
   color: #3c4257;
   cursor: not-allowed;
 }
 
 .rnf-icon {
   display: flex;
-  margin-right: 4px;
+  margin-right: 0.15rem;
+  margin-top: 0.15rem;
+}
+
+.rnf-connected-status-icon {
+  width: 20px;
 }
 
 .rnf-disconnected-info-container {
@@ -129,4 +134,10 @@
   display: flex;
   gap: 4px;
   align-items: center;
+}
+
+.rnf-slack-channel-option-text-with-icon {
+  display: flex;
+  gap: 0.25rem;
+  height: 20px;
 }


### PR DESCRIPTION
This handles the case where a user has a slack channel connected in Knock, but it isn't found in the list of Slack channels from the API, potentially because the bot doesn't have access to it (like a private channel it doesn't belong to). In this case it also wouldn't be able to post to the channel so it is accurate to show to the user that it is not connected.

It also updates some minor styling issues.