### PR TITLE
fix: Add correct release script to pkg json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
-    "release": "turbo run build && changeset version && changeset publish",
+    "release": "yarn build:packages && yarn release:publish && yarn changeset tag",
+    "release:publish": "yarn workspaces foreach -Rpt --no-private --from '@knocklabs/*' npm publish --access public --tolerate-republish",
     "postinstall": "manypkg check"
   },
   "prettier": "@knocklabs/prettier-config",


### PR DESCRIPTION
The release process was utilizing `changeset publish` which isn't compatible with yarn workspaces. 

See notes:
Changeset runs npm publish under the hood, can see here: https://github.com/changesets/changesets/blob/418551020e9ff409878ca2c06944f03098d0f126/packages/cli/src/commands/publish/npm-utils.ts#L191

Which would run this: https://yarnpkg.com/cli/npm/publish

This cli command isn't aware of workspaces. So to publish with workspaces context you need to run yarn workspaces foreach . This command goes into each workspace (with the context of the other workspaces), so if you run yarn npm publish within that command then yarn can successfully swap workspace:^ for the correct version number. Contrary to what changeset does which is cd into the package folder and runs yarn npm publish.