### PR TITLE
fix: esm issues round 2

### DIFF
--- a/.changeset/tame-plants-know.md
+++ b/.changeset/tame-plants-know.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+---
+
+fix esm build issues with mjs files

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,14 +6,15 @@
   "author": "@knocklabs",
   "license": "MIT",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "typings": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.mjs",
       "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.js"
+      "default": "./dist/esm/index.mjs"
     }
   },
   "files": [
@@ -39,8 +40,8 @@
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "build": "yarn clean && yarn build:cjs && yarn build:esm",
-    "build:esm": "BUILD_TARGET=esm; tsc && vite build",
-    "build:cjs": "BUILD_TARGET=cjs; tsc && vite build",
+    "build:esm": "BUILD_TARGET=esm;  vite build",
+    "build:cjs": "BUILD_TARGET=cjs;  vite build",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -1,4 +1,4 @@
-import { EventEmitter2 as EventEmitter } from "eventemitter2";
+import EventEmitter from "eventemitter2";
 import { Channel } from "phoenix";
 import { StoreApi } from "zustand";
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -21,16 +21,15 @@ export default defineConfig(({ mode }) => {
       outDir: CJS ? "dist/cjs" : "dist/esm",
       sourcemap: true,
       lib: {
-        entry: resolve(__dirname, "src/index.ts"),
+        entry: resolve(__dirname, "src"),
+        fileName: `[name]`,
         name: "client",
         formats,
       },
       rollupOptions: {
         output: {
-          interop: "compat",
-          format: formats[0],
           entryFileNames: () => {
-            return "[name].js";
+            return `[name].${CJS ? "js" : "mjs"}`;
           },
           // Override to allow named and default exports in the same file
           exports: "named",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -5,14 +5,15 @@
   "version": "0.1.5",
   "license": "MIT",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "typings": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.mjs",
       "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.js"
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [
@@ -23,8 +24,8 @@
     "clean": "rimraf dist",
     "dev": "tsc && vite build --watch  --emptyOutDir false",
     "build": "yarn clean && yarn build:esm && yarn build:cjs",
-    "build:esm": "BUILD_TARGET=esm; tsc && vite build",
-    "build:cjs": "BUILD_TARGET=cjs; tsc && vite build",
+    "build:esm": "BUILD_TARGET=esm; vite build",
+    "build:cjs": "BUILD_TARGET=cjs; vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
     "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",

--- a/packages/react-core/vite.config.ts
+++ b/packages/react-core/vite.config.ts
@@ -1,9 +1,9 @@
 /// <reference types="vitest" />
-import { defineConfig, LibraryFormats, loadEnv } from "vite";
-import { resolve } from "path";
 import react from "@vitejs/plugin-react";
-import noBundlePlugin from "vite-plugin-no-bundle";
+import { resolve } from "path";
+import { LibraryFormats, defineConfig, loadEnv } from "vite";
 import dts from "vite-plugin-dts";
+import noBundlePlugin from "vite-plugin-no-bundle";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -23,7 +23,8 @@ export default defineConfig(({ mode }) => {
       outDir: CJS ? "dist/cjs" : "dist/esm",
       sourcemap: true,
       lib: {
-        entry: resolve(__dirname, "src/index.ts"),
+        entry: resolve(__dirname, "src"),
+        fileName: `[name]`,
         name: "react-core",
         formats,
       },
@@ -32,12 +33,11 @@ export default defineConfig(({ mode }) => {
         external: ["react"],
         output: {
           interop: "compat",
-          format: formats[0],
           globals: {
             react: "React",
           },
           entryFileNames: () => {
-            return "[name].js";
+            return `[name].${CJS ? "js" : "mjs"}`;
           },
         },
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.8",
   "license": "MIT",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "typings": "dist/types/index.d.ts",
   "style": "dist/index.css",
@@ -14,8 +14,8 @@
     ".": {
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm.js"
+      "import": "./dist/esm/index.mjs",
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [
@@ -28,8 +28,8 @@
     "//": "dev:local runs a dev server and lets you test components at localhost:5173",
     "dev:local": "vite",
     "build": "yarn clean && yarn build:esm && yarn build:cjs",
-    "build:esm": "BUILD_TARGET=esm; tsc && vite build",
-    "build:cjs": "BUILD_TARGET=cjs; tsc && vite build",
+    "build:esm": "BUILD_TARGET=esm; vite build",
+    "build:cjs": "BUILD_TARGET=cjs; vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
     "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",


### PR DESCRIPTION
Customers were having issues with the latest builds of our packages. This was because they were trying to resolve `.es.js` files as modules which the JS compiler doesn't know how to interpret. The correct file extension for modules is `.mjs` so this PR modifies the vite config to accomplish this.

See this similar issue for more info: https://github.com/FortAwesome/Font-Awesome/issues/16439