### PR TITLE
feat(kno-5341): close window on auth error

### DIFF
--- a/packages/react/src/modules/slack/components/SlackAuthButton/SlackAuthButton.tsx
+++ b/packages/react/src/modules/slack/components/SlackAuthButton/SlackAuthButton.tsx
@@ -67,6 +67,10 @@ export const SlackAuthButton: React.FC<Props> = ({
         if (event.data === "authComplete") {
           setConnectionStatus("connected");
         }
+
+        if (event.data === "authFailed") {
+          setConnectionStatus("error")
+        }
       } catch (error) {
         setConnectionStatus("error");
       }


### PR DESCRIPTION
Closes the window and sets as error when receiving a failing auth. Relies on https://github.com/knocklabs/switchboard/pull/1984/files