### PR TITLE
Move isRequestInFlight to client prop

### DIFF
--- a/examples/client-example/src/App.js
+++ b/examples/client-example/src/App.js
@@ -5,101 +5,101 @@ import create from "zustand";
 import "./App.css";
 
 const knockClient = new Knock(process.env.REACT_APP_KNOCK_API_KEY, {
-	host: process.env.REACT_APP_KNOCK_HOST,
+  host: process.env.REACT_APP_KNOCK_HOST,
 });
 
 knockClient.authenticate(process.env.REACT_APP_KNOCK_USER_ID);
 
 const useNotificationFeed = (knockClient, feedId) => {
-	return useMemo(() => {
-		// Create the notification feed instance
-		const notificationFeed = knockClient.feeds.initialize(feedId, {
-			auto_manage_socket_connection: true,
-			auto_manage_socket_connection_delay: 500,
-		});
-		const notificationStore = create(notificationFeed.store);
-		notificationFeed.fetch();
+  return useMemo(() => {
+    // Create the notification feed instance
+    const notificationFeed = knockClient.feeds.initialize(feedId, {
+      auto_manage_socket_connection: true,
+      auto_manage_socket_connection_delay: 500,
+    });
+    const notificationStore = create(notificationFeed.store);
+    notificationFeed.fetch();
 
-		return [notificationFeed, notificationStore];
-	}, [knockClient, feedId]);
+    return [notificationFeed, notificationStore];
+  }, [knockClient, feedId]);
 };
 
 function App() {
-	const [feedClient, feedStore] = useNotificationFeed(
-		knockClient,
-		process.env.REACT_APP_KNOCK_CHANNEL_ID,
-	);
+  const [feedClient, feedStore] = useNotificationFeed(
+    knockClient,
+    process.env.REACT_APP_KNOCK_CHANNEL_ID,
+  );
 
-	useEffect(() => {
-		knockClient.preferences
-			.get()
-			.then((p) => {
-				console.log(p);
-			})
-			.catch((e) => {
-				console.error(e);
-			});
-	}, []);
+  useEffect(() => {
+    knockClient.preferences
+      .get()
+      .then((p) => {
+        console.log(p);
+      })
+      .catch((e) => {
+        console.error(e);
+      });
+  }, []);
 
-	useEffect(() => {
-		const teardown = feedClient.listenForUpdates();
+  useEffect(() => {
+    const teardown = feedClient.listenForUpdates();
 
-		feedClient.on("messages.new", (data) => {
-			console.log(data);
-		});
+    feedClient.on("messages.new", (data) => {
+      console.log(data);
+    });
 
-		feedClient.on("items.received.*", (data) => {
-			console.log(data);
-		});
+    feedClient.on("items.received.*", (data) => {
+      console.log(data);
+    });
 
-		feedClient.on("items.archived", (data) => {
-			console.log(data);
-		});
+    feedClient.on("items.archived", (data) => {
+      console.log(data);
+    });
 
-		return () => teardown?.();
-	}, [feedClient]);
+    return () => teardown?.();
+  }, [feedClient]);
 
-	const { loading, items, pageInfo } = feedStore((state) => state);
+  const { loading, items, pageInfo } = feedStore((state) => state);
 
-	return (
-		<div className="App">
-			<h1>Feed items</h1>
-			<pre>{JSON.stringify(process.env, null, 2)}</pre>
+  return (
+    <div className="App">
+      <h1>Feed items</h1>
+      <pre>{JSON.stringify(process.env, null, 2)}</pre>
 
-			{loading && <span>Loading...</span>}
+      {loading && <span>Loading...</span>}
 
-			{items.map((item) => (
-				<div key={item.id} className="feed-item">
-					ID: {item.id}
-					<br />
-					Actor ID: {item.actors?.[0]?.id}
-					<br />
-					Actor email: {item.actors?.[0]?.email}
-					<br />
-					Inserted:{" "}
-					{new Intl.DateTimeFormat("en-US", {
-						dateStyle: "short",
-						timeStyle: "medium",
-					}).format(new Date(item.inserted_at))}
-					<br />
-					<button
-						onClick={() => {
-							feedClient.markAsArchived(item);
-						}}
-					>
-						Mark as archived
-					</button>
-				</div>
-			))}
+      {items.map((item) => (
+        <div key={item.id} className="feed-item">
+          ID: {item.id}
+          <br />
+          Actor ID: {item.actors?.[0]?.id}
+          <br />
+          Actor email: {item.actors?.[0]?.email}
+          <br />
+          Inserted:{" "}
+          {new Intl.DateTimeFormat("en-US", {
+            dateStyle: "short",
+            timeStyle: "medium",
+          }).format(new Date(item.inserted_at))}
+          <br />
+          <button
+            onClick={() => {
+              feedClient.markAsArchived(item);
+            }}
+          >
+            Mark as archived
+          </button>
+        </div>
+      ))}
 
-			<button
-				disabled={!pageInfo.after || loading}
-				onClick={() => feedClient.fetchNextPage()}
-			>
-				Load more items
-			</button>
-		</div>
-	);
+      <button
+        disabled={!pageInfo.after || loading}
+        onClick={() => feedClient.fetchNextPage()}
+      >
+        Load more items
+      </button>
+    </div>
+  );
 }
 
 export default App;

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -3,7 +3,7 @@ import { Channel } from "phoenix";
 import { StoreApi } from "zustand";
 
 import Knock from "../../knock";
-import { NetworkStatus, isRequestInFlight } from "../../networkStatus";
+import { NetworkStatus } from "../../networkStatus";
 
 import {
   FeedClientOptions,
@@ -436,10 +436,10 @@ class Feed {
   /* Fetches the feed content, appending it to the store */
   async fetch(options: FetchFeedOptions = {}) {
     const { setState, getState } = this.store;
-    const { networkStatus } = getState();
+    const { isRequestInFlight } = getState();
 
     // If there's an existing request in flight, then do nothing
-    if (isRequestInFlight(networkStatus)) {
+    if (isRequestInFlight) {
       return;
     }
 
@@ -620,7 +620,7 @@ class Feed {
     // Note: we do this after the update to ensure that the server event actually completed
     this.broadcaster.emit(`items.${type}`, { items });
 
-    // Note: `items.type` format is being deprecated in favor over the `items:type` format, 
+    // Note: `items.type` format is being deprecated in favor over the `items:type` format,
     // but emit both formats to make it backward compatible for now.
     this.broadcaster.emit(`items:${type}`, { items });
     this.broadcastOverChannel(`items:${type}`, { items });

--- a/packages/client/src/clients/feed/store.ts
+++ b/packages/client/src/clients/feed/store.ts
@@ -39,11 +39,15 @@ export default function createStore() {
     // The network status indicates what's happening with the request
     networkStatus: NetworkStatus.ready,
     loading: false,
+    isRequestInFlight: false,
 
     setNetworkStatus: (networkStatus: NetworkStatus) =>
       set(() => ({
         networkStatus,
         loading: networkStatus === NetworkStatus.loading,
+        isRequestInFlight:
+          networkStatus === NetworkStatus.loading ||
+          networkStatus === NetworkStatus.fetchMore,
       })),
 
     setResult: (
@@ -61,6 +65,7 @@ export default function createStore() {
           metadata: meta,
           pageInfo: options.shouldSetPage ? page_info : state.pageInfo,
           loading: false,
+          isRequestInFlight: false,
           networkStatus: NetworkStatus.ready,
         };
       }),

--- a/packages/client/src/clients/feed/types.ts
+++ b/packages/client/src/clients/feed/types.ts
@@ -15,6 +15,7 @@ export type FeedStoreState = {
   metadata: FeedMetadata;
   loading: boolean;
   networkStatus: NetworkStatus;
+  isRequestInFlight: boolean;
   setResult: (response: FeedResponse, opts?: StoreFeedResultOptions) => void;
   setMetadata: (metadata: FeedMetadata) => void;
   setNetworkStatus: (networkStatus: NetworkStatus) => void;

--- a/packages/client/src/networkStatus.ts
+++ b/packages/client/src/networkStatus.ts
@@ -11,9 +11,3 @@ export enum NetworkStatus {
   // The last operation failed with an error
   error = "error",
 }
-
-export function isRequestInFlight(networkStatus: NetworkStatus): boolean {
-  return [NetworkStatus.loading, NetworkStatus.fetchMore].includes(
-    networkStatus,
-  );
-}

--- a/packages/react/src/modules/feed/components/NotificationFeed/NotificationFeed.tsx
+++ b/packages/react/src/modules/feed/components/NotificationFeed/NotificationFeed.tsx
@@ -1,4 +1,11 @@
-import { FeedItem, isRequestInFlight, NetworkStatus } from "@knocklabs/client";
+import { FeedItem, NetworkStatus } from "@knocklabs/client";
+import {
+  ColorMode,
+  FilterStatus,
+  useFeedSettings,
+  useKnockFeed,
+  useTranslations,
+} from "@knocklabs/react-core";
 import React, {
   ReactElement,
   ReactNode,
@@ -7,23 +14,17 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { EmptyFeed } from "../EmptyFeed";
-import {
-  useKnockFeed,
-  useFeedSettings,
-  ColorMode,
-  FilterStatus,
-  useTranslations,
-} from "@knocklabs/react-core";
+
 import { Spinner } from "../../../core/components/Spinner";
+import useOnBottomScroll from "../../../core/hooks/useOnBottomScroll";
+import { EmptyFeed } from "../EmptyFeed";
 import { NotificationCell } from "../NotificationCell";
+
 import {
   NotificationFeedHeader,
   NotificationFeedHeaderProps,
 } from "./NotificationFeedHeader";
-
 import "./styles.css";
-import useOnBottomScroll from "../../../core/hooks/useOnBottomScroll";
 
 export type OnNotificationClick = (item: FeedItem) => void;
 export type RenderItem = ({ item }: RenderItemProps) => ReactNode;
@@ -80,7 +81,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   const { settings } = useFeedSettings(feedClient);
   const { t } = useTranslations();
 
-  const { pageInfo, items, networkStatus } = useFeedStore();
+  const { pageInfo, items, networkStatus, isRequestInFlight } = useFeedStore();
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -93,7 +94,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   }, [feedClient, status]);
 
   const noItems = items.length === 0;
-  const requestInFlight = isRequestInFlight(networkStatus);
+  const requestInFlight = isRequestInFlight;
 
   // Handle fetching more once we reach the bottom of the list
   const onBottomCallback = useCallback(() => {


### PR DESCRIPTION
If it's useful for people to derive the state of the client using `isRequestInFlight` using the helper function I wanted to see what this would look like as a property of the feed store, so I worked up this PR to add that to the store and updated our internal usage.