### PR TITLE
fix(kno-5450): make slack combobox list box opaque

### DIFF
--- a/.changeset/poor-otters-whisper.md
+++ b/.changeset/poor-otters-whisper.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+Make the SlackCombobox background opaque so that elements underneath aren't visible when it's popped out.

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/styles.css
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/styles.css
@@ -64,6 +64,7 @@
 
 /* List box */
 .rsk-combobox__list-box {
+  background-color: var(--rsk-color-white);
   border-radius: var(--rsk-border-radius-sm);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.06),
     0px 1px 3px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Makes the list box opaque so that it covers any elements underneath it.