### PR TITLE
feat: support in-app actions in `NotificationCell`

### DIFF
--- a/examples/nextjs-example/components/SendNotificationForm.tsx
+++ b/examples/nextjs-example/components/SendNotificationForm.tsx
@@ -3,9 +3,11 @@ import {
   Checkbox,
   FormControl,
   FormLabel,
+  Select,
   Textarea,
 } from "@chakra-ui/react";
 import { useState } from "react";
+
 import { notify } from "../lib/api";
 
 interface Props {
@@ -13,15 +15,22 @@ interface Props {
   tenant: any;
 }
 
+enum TemplateType {
+  Standard = "standard",
+  SingleAction = "single-action",
+  MultiAction = "multi-action",
+}
+
 const SendNotificationForm = ({ userId, tenant }: Props) => {
   const [message, setMessage] = useState("");
   const [showToast, setShowToast] = useState(true);
+  const [templateType, setTemplateType] = useState(TemplateType.Standard);
   const [isLoading, setIsLoading] = useState(false);
 
   const onSubmit = async (e: any) => {
     e.preventDefault();
     setIsLoading(true);
-    await notify({ message, showToast, userId, tenant });
+    await notify({ message, showToast, userId, tenant, templateType });
     setIsLoading(false);
 
     e.target.reset();
@@ -40,6 +49,19 @@ const SendNotificationForm = ({ userId, tenant }: Props) => {
           size="sm"
           onChange={(e) => setMessage(e.target.value)}
         />
+      </FormControl>
+      <FormControl mb={4}>
+        <FormLabel fontSize={14}>Template type</FormLabel>
+        <Select
+          mr={3}
+          size="sm"
+          value={templateType}
+          onChange={(e) => setTemplateType(e.target.value as TemplateType)}
+        >
+          <option value={TemplateType.Standard}>Standard</option>
+          <option value={TemplateType.SingleAction}>Single-action</option>
+          <option value={TemplateType.MultiAction}>Multi-action</option>
+        </Select>
       </FormControl>
       <FormControl mb={4}>
         <FormLabel fontSize={14} display="flex" alignItems="center">

--- a/examples/nextjs-example/pages/api/notify.ts
+++ b/examples/nextjs-example/pages/api/notify.ts
@@ -18,7 +18,7 @@ export default async function handler(
       .json({ error: `${req.method} method is not accepted.` });
   }
 
-  const { message, showToast, userId, tenant } = req.body;
+  const { message, showToast, userId, tenant, templateType } = req.body;
 
   try {
     await knockClient.notify(KNOCK_WORKFLOW, {
@@ -28,6 +28,7 @@ export default async function handler(
       data: {
         message,
         showToast,
+        templateType,
       },
     });
 

--- a/packages/client/src/clients/feed/interfaces.ts
+++ b/packages/client/src/clients/feed/interfaces.ts
@@ -49,7 +49,7 @@ export interface ButtonBlock {
 
 export interface ButtonSetContentBlock extends ContentBlockBase {
   type: "button_set";
-  actions: ButtonBlock[];
+  buttons: ButtonBlock[];
 }
 
 export interface TextContentBlock extends ContentBlockBase {

--- a/packages/client/src/clients/feed/interfaces.ts
+++ b/packages/client/src/clients/feed/interfaces.ts
@@ -1,4 +1,5 @@
 import { GenericData, PageInfo } from "@knocklabs/types";
+
 import { Activity, Recipient } from "../../interfaces";
 import { NetworkStatus } from "../../networkStatus";
 
@@ -35,17 +36,43 @@ export type FetchFeedOptions = {
   __fetchSource?: "socket" | "http";
 } & Omit<FeedClientOptions, "__experimentalCrossBrowserUpdates">;
 
-export interface ContentBlock {
-  content: string;
-  rendered: string;
-  type: "markdown" | "text";
+export interface ContentBlockBase {
   name: string;
+  type: "markdown" | "text" | "button_set";
+}
+
+export interface ButtonBlock {
+  name: string;
+  label: string;
+  action: string;
+}
+
+export interface ButtonSetContentBlock extends ContentBlockBase {
+  type: "button_set";
+  actions: ButtonBlock[];
+}
+
+export interface TextContentBlock extends ContentBlockBase {
+  type: "text";
+  rendered: string;
+  content: string;
+}
+
+export interface MarkdownContentBlock extends ContentBlockBase {
+  type: "markdown";
+  rendered: string;
+  content: string;
 }
 
 export interface NotificationSource {
   key: string;
   version_id: string;
 }
+
+export type ContentBlock =
+  | MarkdownContentBlock
+  | TextContentBlock
+  | ButtonSetContentBlock;
 
 export interface FeedItem<T = GenericData> {
   __cursor: string;

--- a/packages/client/src/clients/feed/interfaces.ts
+++ b/packages/client/src/clients/feed/interfaces.ts
@@ -41,7 +41,7 @@ export interface ContentBlockBase {
   type: "markdown" | "text" | "button_set";
 }
 
-export interface ButtonBlock {
+export interface ActionButton {
   name: string;
   label: string;
   action: string;
@@ -49,7 +49,7 @@ export interface ButtonBlock {
 
 export interface ButtonSetContentBlock extends ContentBlockBase {
   type: "button_set";
-  buttons: ButtonBlock[];
+  buttons: ActionButton[];
 }
 
 export interface TextContentBlock extends ContentBlockBase {

--- a/packages/react/src/modules/feed/components/NotificationCell/NotificationCell.tsx
+++ b/packages/react/src/modules/feed/components/NotificationCell/NotificationCell.tsx
@@ -59,7 +59,7 @@ export const NotificationCell = React.forwardRef<
     }, [item]);
 
     const actionUrl = (blocksByName.action_url as TextContentBlock)?.rendered;
-    const actions = blocksByName.actions as ButtonSetContentBlock;
+    const buttonSet = blocksByName.actions as ButtonSetContentBlock;
 
     const onContainerClickHandler = React.useCallback(() => {
       // Mark as interacted + read once we click the item
@@ -128,18 +128,20 @@ export const NotificationCell = React.forwardRef<
               />
             )}
 
-            {actions && (
-              <ButtonGroup>
-                {actions.actions.map((button, i) => (
-                  <Button
-                    variant={i === 0 ? "primary" : "secondary"}
-                    key={button.name}
-                    onClick={(e) => onButtonClickHandler(e, button)}
-                  >
-                    {button.label}
-                  </Button>
-                ))}
-              </ButtonGroup>
+            {buttonSet && (
+              <div className="rnf-notification-cell__button-group">
+                <ButtonGroup>
+                  {buttonSet.buttons.map((button, i) => (
+                    <Button
+                      variant={i === 0 ? "primary" : "secondary"}
+                      key={button.name}
+                      onClick={(e) => onButtonClickHandler(e, button)}
+                    >
+                      {button.label}
+                    </Button>
+                  ))}
+                </ButtonGroup>
+              </div>
             )}
 
             {children && (

--- a/packages/react/src/modules/feed/components/NotificationCell/NotificationCell.tsx
+++ b/packages/react/src/modules/feed/components/NotificationCell/NotificationCell.tsx
@@ -1,5 +1,5 @@
 import {
-  ButtonBlock,
+  ActionButton,
   ButtonSetContentBlock,
   ContentBlock,
   FeedItem,
@@ -25,7 +25,7 @@ export interface NotificationCellProps {
   // Invoked when the outer container is clicked
   onItemClick?: (item: FeedItem) => void;
   // Invoked when a button in the notification cell is clicked
-  onButtonClick?: (item: FeedItem, action: ButtonBlock) => void;
+  onButtonClick?: (item: FeedItem, action: ActionButton) => void;
   avatar?: ReactNode;
   children?: ReactNode;
   archiveButton?: ReactNode;
@@ -71,7 +71,7 @@ export const NotificationCell = React.forwardRef<
     }, [item, actionUrl, onItemClick, feedClient]);
 
     const onButtonClickHandler = React.useCallback(
-      (e: React.MouseEvent, button: ButtonBlock) => {
+      (e: React.MouseEvent, button: ActionButton) => {
         feedClient.markAsInteracted(item);
 
         if (onButtonClick) return onButtonClick(item, button);

--- a/packages/react/src/modules/feed/components/NotificationCell/styles.css
+++ b/packages/react/src/modules/feed/components/NotificationCell/styles.css
@@ -152,7 +152,8 @@
   line-height: var(--rnf-font-size-lg);
 }
 
-.rnf-notification-cell__child-content {
+.rnf-notification-cell__child-content,
+.rnf-notification-cell__button-group {
   margin: 0.75em 0 0.5em 0;
 }
 

--- a/packages/react/src/modules/feed/components/NotificationFeed/NotificationFeed.tsx
+++ b/packages/react/src/modules/feed/components/NotificationFeed/NotificationFeed.tsx
@@ -1,4 +1,11 @@
-import { FeedItem, isRequestInFlight, NetworkStatus } from "@knocklabs/client";
+import { FeedItem, NetworkStatus, isRequestInFlight } from "@knocklabs/client";
+import {
+  ColorMode,
+  FilterStatus,
+  useFeedSettings,
+  useKnockFeed,
+  useTranslations,
+} from "@knocklabs/react-core";
 import React, {
   ReactElement,
   ReactNode,
@@ -7,30 +14,25 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { EmptyFeed } from "../EmptyFeed";
-import {
-  useKnockFeed,
-  useFeedSettings,
-  ColorMode,
-  FilterStatus,
-  useTranslations,
-} from "@knocklabs/react-core";
+
 import { Spinner } from "../../../core/components/Spinner";
-import { NotificationCell } from "../NotificationCell";
+import useOnBottomScroll from "../../../core/hooks/useOnBottomScroll";
+import { EmptyFeed } from "../EmptyFeed";
+import { NotificationCell, NotificationCellProps } from "../NotificationCell";
+
 import {
   NotificationFeedHeader,
   NotificationFeedHeaderProps,
 } from "./NotificationFeedHeader";
-
 import "./styles.css";
-import useOnBottomScroll from "../../../core/hooks/useOnBottomScroll";
 
-export type OnNotificationClick = (item: FeedItem) => void;
-export type RenderItem = ({ item }: RenderItemProps) => ReactNode;
 export type RenderItemProps = {
   item: FeedItem;
-  onItemClick?: OnNotificationClick;
+  onItemClick?: NotificationCellProps["onItemClick"];
+  onButtonClick?: NotificationCellProps["onButtonClick"];
 };
+
+export type RenderItem = (props: RenderItemProps) => ReactNode;
 
 export interface NotificationFeedProps {
   EmptyComponent?: ReactNode;
@@ -40,7 +42,8 @@ export interface NotificationFeedProps {
   header?: ReactElement<any>;
   renderItem?: RenderItem;
   renderHeader?: (props: NotificationFeedHeaderProps) => ReactNode;
-  onNotificationClick?: OnNotificationClick;
+  onNotificationClick?: NotificationCellProps["onItemClick"];
+  onNotificationButtonClick?: NotificationCellProps["onButtonClick"];
   onMarkAllAsReadClick?: (e: React.MouseEvent, unreadItems: FeedItem[]) => void;
   initialFilterStatus?: FilterStatus;
 }
@@ -70,6 +73,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   EmptyComponent = <EmptyFeed />,
   renderItem = defaultRenderItem,
   onNotificationClick,
+  onNotificationButtonClick,
   onMarkAllAsReadClick,
   initialFilterStatus = FilterStatus.All,
   header,
@@ -129,7 +133,11 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
         <div className="rnf-notification-feed__feed-items-container">
           {networkStatus !== NetworkStatus.loading &&
             items.map((item: FeedItem) =>
-              renderItem({ item, onItemClick: onNotificationClick }),
+              renderItem({
+                item,
+                onItemClick: onNotificationClick,
+                onButtonClick: onNotificationButtonClick,
+              }),
             )}
         </div>
 

--- a/packages/react/src/modules/feed/components/NotificationFeedPopover/NotificationFeedPopover.tsx
+++ b/packages/react/src/modules/feed/components/NotificationFeedPopover/NotificationFeedPopover.tsx
@@ -1,12 +1,13 @@
+import { Feed, FeedStoreState } from "@knocklabs/client";
+import { useKnockFeed } from "@knocklabs/react-core";
+import { Placement } from "@popperjs/core";
 import React, { RefObject, useEffect } from "react";
 import { usePopper } from "react-popper";
-import { Placement } from "@popperjs/core";
-import { NotificationFeed, NotificationFeedProps } from "../NotificationFeed";
+
 import useComponentVisible from "../../../core/hooks/useComponentVisible";
+import { NotificationFeed, NotificationFeedProps } from "../NotificationFeed";
 
 import "./styles.css";
-import { useKnockFeed } from "@knocklabs/react-core";
-import { Feed, FeedStoreState } from "@knocklabs/client";
 
 type OnOpenOptions = {
   store: FeedStoreState;
@@ -69,7 +70,7 @@ export const NotificationFeedPopover: React.FC<
     if (isVisible && onOpen) {
       onOpen({ store, feedClient });
     }
-  }, [isVisible]);
+  }, [isVisible, onOpen, store, feedClient]);
 
   return (
     <div
@@ -77,6 +78,7 @@ export const NotificationFeedPopover: React.FC<
       style={{
         ...styles.popper,
         visibility: isVisible ? "visible" : "hidden",
+        opacity: isVisible ? 1 : 0,
       }}
       ref={popperRef}
       {...attributes.popper}


### PR DESCRIPTION
- Adds support for rendering `actions` as buttons in the notification cell
- Adds `onNotificationButtonClick` and `onButtonClick` handlers
- Adds support for sending different template types in the example app