### PR TITLE
fix(kno-5521): handle connection: false error

### DIFF
--- a/.changeset/gorgeous-shirts-camp.md
+++ b/.changeset/gorgeous-shirts-camp.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+Handle auth disconnected status.

--- a/packages/react-core/src/modules/slack/hooks/useSlackConnectionStatus.ts
+++ b/packages/react-core/src/modules/slack/hooks/useSlackConnectionStatus.ts
@@ -56,6 +56,10 @@ function useSlackConnectionStatus(
           return setConnectionStatus("connected");
         }
 
+        if (!authRes.connection?.ok) {
+          return setConnectionStatus("disconnected");
+        }
+
         // This is a normal response for a tenant that doesn't have an access
         // token set on it, meaning it's not connected to Slack, so we
         // give it a "disconnected" status instead of an error status.


### PR DESCRIPTION
If the API returns `connection: {ok: false}` it should just show disconnected instead of an error. This relates to this Switchboard change where we're explicitly returning this: https://github.com/knocklabs/switchboard/pull/2077