### PR TITLE
fix: swap usequery with swr for react 16 support

### DIFF
--- a/.changeset/forty-bears-jog.md
+++ b/.changeset/forty-bears-jog.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+---
+
+fix: remove react-query and replace with swr for react 16+ support

--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -1,39 +1,39 @@
 {
-	"name": "nextjs-example",
-	"version": "1.0.15",
-	"private": true,
-	"scripts": {
-		"dev": "next dev",
-		"build": "next build",
-		"start": "next start",
-		"lint": "eslint . --max-warnings 0"
-	},
-	"dependencies": {
-		"@chakra-ui/react": "^2.8.2",
-		"@emotion/react": "^11.11.1",
-		"@emotion/styled": "^11.11.0",
-		"@faker-js/faker": "^8.3.1",
-		"@knocklabs/node": "^0.6.4",
-		"@knocklabs/react": "workspace:^",
-		"framer-motion": "^10.16.5",
-		"next": "14.0.4",
-		"next-seo": "^6.4.0",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
-		"react-icons": "^4.12.0",
-		"swr": "^2.2.4",
-		"uuid": "^9.0.1"
-	},
-	"devDependencies": {
-		"@knocklabs/eslint-config": "workspace:^",
-		"@knocklabs/typescript-config": "workspace:^",
-		"@next/eslint-plugin-next": "^14.0.2",
-		"@types/eslint": "^8.44.7",
-		"@types/node": "^20",
-		"@types/react": "^18.2.37",
-		"@types/react-dom": "^18.2.15",
-		"@types/uuid": "^9.0.7",
-		"eslint": "^8.53.0",
-		"typescript": "^5.2.2"
-	}
+  "name": "nextjs-example",
+  "version": "1.0.15",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "@chakra-ui/react": "^2.8.2",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@faker-js/faker": "^8.3.1",
+    "@knocklabs/node": "^0.6.4",
+    "@knocklabs/react": "workspace:^",
+    "framer-motion": "^10.16.5",
+    "next": "14.0.4",
+    "next-seo": "^6.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-icons": "^4.12.0",
+    "swr": "^2.2.5",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@knocklabs/eslint-config": "workspace:^",
+    "@knocklabs/typescript-config": "workspace:^",
+    "@next/eslint-plugin-next": "^14.0.2",
+    "@types/eslint": "^8.44.7",
+    "@types/node": "^20",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@types/uuid": "^9.0.7",
+    "eslint": "^8.53.0",
+    "typescript": "^5.2.2"
+  }
 }

--- a/packages/client/src/clients/slack/index.ts
+++ b/packages/client/src/clients/slack/index.ts
@@ -4,6 +4,7 @@ import Knock from "../../knock";
 import {
   AuthCheckInput,
   GetSlackChannelsInput,
+  GetSlackChannelsResponse,
   RevokeAccessTokenInput,
 } from "./interfaces";
 
@@ -32,7 +33,9 @@ class SlackClient {
     return this.handleResponse(result);
   }
 
-  async getChannels(input: GetSlackChannelsInput) {
+  async getChannels(
+    input: GetSlackChannelsInput,
+  ): Promise<GetSlackChannelsResponse> {
     const { knockChannelId, tenant } = input;
     const queryOptions = input.queryOptions || {};
 

--- a/packages/client/src/clients/slack/interfaces.ts
+++ b/packages/client/src/clients/slack/interfaces.ts
@@ -27,6 +27,11 @@ export type RevokeAccessTokenInput = {
   knockChannelId: string;
 };
 
+export type GetSlackChannelsResponse = {
+  slack_channels: SlackChannel[];
+  next_cursor: string | null;
+};
+
 export type SlackChannel = {
   name: string;
   id: string;

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -45,12 +45,12 @@
     "url": "https://github.com/knocklabs/javascript/issues"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@knocklabs/client": "workspace:^",
-    "@tanstack/react-query": "^5.18.1",
     "date-fns": "^3.3.1",
+    "swr": "^2.2.5",
     "zustand": "^3.7.2"
   },
   "devDependencies": {

--- a/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx
+++ b/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx
@@ -1,12 +1,9 @@
 import { useSlackConnectionStatus } from "..";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 
 import { slackProviderKey } from "../../core";
 import { useKnockClient } from "../../core";
 import { ConnectionStatus } from "../hooks/useSlackConnectionStatus";
-
-const queryClient = new QueryClient();
 
 export interface KnockSlackProviderState {
   knockSlackChannelId: string;
@@ -63,7 +60,7 @@ export const KnockSlackProvider: React.FC<KnockSlackProviderProps> = ({
         tenant,
       }}
     >
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      {children}
     </SlackProviderStateContext.Provider>
   );
 };

--- a/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
+++ b/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
@@ -1,13 +1,15 @@
 import { SlackChannelQueryOptions, useKnockSlackClient } from "..";
-import { SlackChannel } from "@knocklabs/client";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { GetSlackChannelsResponse, SlackChannel } from "@knocklabs/client";
 import { useEffect, useMemo } from "react";
+import useSWRInfinite from "swr/infinite";
 
 import { useKnockClient } from "../../core";
 
 const MAX_COUNT = 1000;
 const LIMIT_PER_PAGE = 200;
 const CHANNEL_TYPES = "private_channel,public_channel";
+
+const QUERY_KEY = "SLACK_CHANNELS";
 
 type UseSlackChannelsProps = {
   queryOptions?: SlackChannelQueryOptions;
@@ -19,6 +21,26 @@ type UseSlackChannelOutput = {
   refetch: () => void;
 };
 
+type QueryKey = [key: string, cursor: string] | null;
+
+function getQueryKey(
+  pageIndex: number,
+  previousPageData: GetSlackChannelsResponse,
+): QueryKey {
+  // First page so just pass empty
+  if (pageIndex === 0) {
+    return [QUERY_KEY, ""];
+  }
+
+  // If there's no more data then return an empty next cursor
+  if (previousPageData && ["", null].includes(previousPageData.next_cursor)) {
+    return null;
+  }
+
+  // Next cursor exists so pass it
+  return [QUERY_KEY, previousPageData.next_cursor];
+}
+
 function useSlackChannels({
   queryOptions,
 }: UseSlackChannelsProps): UseSlackChannelOutput {
@@ -26,42 +48,39 @@ function useSlackChannels({
   const { knockSlackChannelId, tenant, connectionStatus } =
     useKnockSlackClient();
 
-  const fetchChannels = ({ pageParam }: { pageParam: string }) => {
+  const fetchChannels = (queryKey: QueryKey) => {
     return knock.slack.getChannels({
       tenant,
       knockChannelId: knockSlackChannelId,
       queryOptions: {
         ...queryOptions,
-        cursor: pageParam,
+        cursor: queryKey ? queryKey[1] : "",
         limit: queryOptions?.limitPerPage || LIMIT_PER_PAGE,
         types: queryOptions?.types || CHANNEL_TYPES,
       },
     });
   };
 
-  const {
-    data,
-    isLoading,
-    isFetching,
-    fetchNextPage,
-    hasNextPage,
-    refetch,
-    error,
-  } = useInfiniteQuery({
-    queryKey: ["slackChannels"],
-    queryFn: fetchChannels,
-    initialPageParam: "",
-    getNextPageParam: (lastPage) =>
-      lastPage?.next_cursor === "" ? null : lastPage?.next_cursor,
-  });
+  const { data, error, isLoading, isValidating, size, setSize, mutate } =
+    useSWRInfinite<GetSlackChannelsResponse>(getQueryKey, fetchChannels, {
+      initialSize: 0,
+    });
 
-  const slackChannels = useMemo(() => {
-    return (
-      data?.pages
-        ?.flatMap((page) => page?.slack_channels)
-        .filter((channel) => !!channel) || []
-    );
-  }, [data?.pages]);
+  const currentPage = data?.length || 0;
+
+  const hasNextPage =
+    currentPage === 0 ||
+    (data &&
+      data[currentPage]?.next_cursor &&
+      data[currentPage]?.next_cursor !== "");
+
+  const slackChannels: SlackChannel[] = useMemo(
+    () =>
+      (data ?? [])
+        .flatMap((page) => page?.slack_channels)
+        .filter((channel) => !!channel),
+    [data],
+  );
 
   const maxCount = queryOptions?.maxCount || MAX_COUNT;
 
@@ -70,22 +89,31 @@ function useSlackChannels({
       connectionStatus === "connected" &&
       !error &&
       hasNextPage &&
-      !isFetching &&
-      slackChannels?.length < maxCount
+      !isLoading &&
+      !isValidating &&
+      slackChannels.length < maxCount
     ) {
-      fetchNextPage();
+      // Fetch a page at a time until we have nothing else left to fetch
+      // or we've already hit the max amount of channels to fetch
+      setSize(size + 1);
     }
   }, [
-    slackChannels?.length,
-    fetchNextPage,
+    slackChannels.length,
+    setSize,
+    size,
     hasNextPage,
-    isFetching,
+    isLoading,
+    isValidating,
     maxCount,
     error,
     connectionStatus,
   ]);
 
-  return { data: slackChannels, isLoading, refetch };
+  return {
+    data: slackChannels,
+    isLoading: isLoading || isValidating,
+    refetch: () => mutate(),
+  };
 }
 
 export default useSlackChannels;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,8 +46,8 @@
     "url": "https://github.com/knocklabs/javascript/issues"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": "^16.11.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.11.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@knocklabs/client": "workspace:^",
@@ -55,13 +55,11 @@
     "@popperjs/core": "^2.11.8",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-visually-hidden": "^1.0.3",
-    "@tanstack/react-query": "^5.18.1",
     "lodash.debounce": "^4.0.8",
     "react-popper": "^2.3.0",
     "react-popper-tooltip": "^4.4.2"
   },
   "devDependencies": {
-    "@tanstack/react-query-devtools": "^5.20.1",
     "@testing-library/react": "^14.2.0",
     "@types/lodash.debounce": "^4.0.9",
     "@types/react": "^18.2.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17247,7 +17247,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-icons: "npm:^4.12.0"
-    swr: "npm:^2.2.4"
+    swr: "npm:^2.2.5"
     typescript: "npm:^5.2.2"
     uuid: "npm:^9.0.1"
   languageName: unknown
@@ -21932,7 +21932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swr@npm:^2.2.4, swr@npm:^2.2.5":
+"swr@npm:^2.2.5":
   version: 2.2.5
   resolution: "swr@npm:2.2.5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4838,7 +4838,6 @@ __metadata:
   resolution: "@knocklabs/react-core@workspace:packages/react-core"
   dependencies:
     "@knocklabs/client": "workspace:^"
-    "@tanstack/react-query": "npm:^5.18.1"
     "@testing-library/react": "npm:^14.2.0"
     "@types/react": "npm:^18.2.37"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
@@ -4852,6 +4851,7 @@ __metadata:
     react: "npm:^18.2.0"
     rimraf: "npm:^5.0.5"
     rollup-plugin-execute: "npm:^1.1.1"
+    swr: "npm:^2.2.5"
     typescript: "npm:^5.2.2"
     vite: "npm:^5.0.0"
     vite-plugin-dts: "npm:^3.6.3"
@@ -4859,7 +4859,7 @@ __metadata:
     vitest: "npm:^1.2.2"
     zustand: "npm:^3.7.2"
   peerDependencies:
-    react: ">=16.8.0"
+    react: ^16.11.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -4911,8 +4911,6 @@ __metadata:
     "@popperjs/core": "npm:^2.11.8"
     "@radix-ui/react-popover": "npm:^1.0.7"
     "@radix-ui/react-visually-hidden": "npm:^1.0.3"
-    "@tanstack/react-query": "npm:^5.18.1"
-    "@tanstack/react-query-devtools": "npm:^5.20.1"
     "@testing-library/react": "npm:^14.2.0"
     "@types/lodash.debounce": "npm:^4.0.9"
     "@types/react": "npm:^18.2.37"
@@ -4937,8 +4935,8 @@ __metadata:
     vite-plugin-no-bundle: "npm:^3.0.0"
     vitest: "npm:^1.2.2"
   peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    react: ^16.11.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.11.0 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -6579,43 +6577,6 @@ __metadata:
   dependencies:
     defer-to-connect: "npm:^2.0.1"
   checksum: 10c0/4629d2fbb2ea67c2e9dc03af235c0991c79ebdddcbc19aed5d5732fb29ce01c13331e9b1a491584b9069bd6ecde6581dcbf871f11b7eefdebbab34de6cf2197e
-  languageName: node
-  linkType: hard
-
-"@tanstack/query-core@npm:5.28.2":
-  version: 5.28.2
-  resolution: "@tanstack/query-core@npm:5.28.2"
-  checksum: 10c0/4e93c7be19195f0e404c3486d92b8e19cf1605eadf863f442a1be3dae302b67c617781f47e74a5f5c1f9771fb0dd0f2fa2b3dd56f78bc32e70294cf0f6968ed0
-  languageName: node
-  linkType: hard
-
-"@tanstack/query-devtools@npm:5.27.8":
-  version: 5.27.8
-  resolution: "@tanstack/query-devtools@npm:5.27.8"
-  checksum: 10c0/6be9cb45f114b04a567aee142e30db366ea75a14746ee1005d06014c55f65c780a8ebeeb9a7622763374a9038ec2765b930b8f930c6e7da4613273302e70cf5d
-  languageName: node
-  linkType: hard
-
-"@tanstack/react-query-devtools@npm:^5.20.1":
-  version: 5.28.2
-  resolution: "@tanstack/react-query-devtools@npm:5.28.2"
-  dependencies:
-    "@tanstack/query-devtools": "npm:5.27.8"
-  peerDependencies:
-    "@tanstack/react-query": ^5.28.2
-    react: ^18.0.0
-  checksum: 10c0/6ebcb79bb8e9818cf76cec618d054d83147be33948c0f5e755f18db90b55a90a1b8bd7e73b9f703b8de9e0fde16b680ddcfa6f7462aab7507acdf0bcc948b171
-  languageName: node
-  linkType: hard
-
-"@tanstack/react-query@npm:^5.18.1":
-  version: 5.28.2
-  resolution: "@tanstack/react-query@npm:5.28.2"
-  dependencies:
-    "@tanstack/query-core": "npm:5.28.2"
-  peerDependencies:
-    react: ^18.0.0
-  checksum: 10c0/204e90d43a2919298efc5e189456a15b6b6990282f9d6ff4f295e03f0e6506334c2e6f17141bcb67a8daabc4c78dc649bf7334f3d6ec943fd40584be57c9c7f5
   languageName: node
   linkType: hard
 
@@ -21971,7 +21932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swr@npm:^2.2.4":
+"swr@npm:^2.2.4, swr@npm:^2.2.5":
   version: 2.2.5
   resolution: "swr@npm:2.2.5"
   dependencies:


### PR DESCRIPTION
* Ditches `@tankstack/react-query` for `swr` which supports React 16.11+
* Removes the dependencies and use of `react-query`
* Fixes the react peerDep version in our package.json files