### PR TITLE
fix: use jsx classic runtime to avoid issues on react < 18

### DIFF
--- a/.changeset/warm-cooks-work.md
+++ b/.changeset/warm-cooks-work.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/react": patch
+---
+
+fix: move away from jsx runtime to support react 16 + 17

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -59,6 +59,7 @@
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",
+    "babel-plugin-react-require": "^4.0.2",
     "eslint": "^8.53.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",

--- a/packages/react-core/vite.config.ts
+++ b/packages/react-core/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig(({ mode }) => {
       dts({
         outDir: "dist/types",
       }),
-      react(),
+      react({
+        jsxRuntime: "classic",
+        babel: {
+          plugins: ["react-require"],
+        },
+      }),
       noBundlePlugin({ root: "./src" }),
     ],
     build: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,6 +67,7 @@
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",
+    "babel-plugin-react-require": "^4.0.2",
     "eslint": "^8.53.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -17,7 +17,12 @@ export default defineConfig(({ mode }) => {
       dts({
         outDir: "dist/types",
       }),
-      react(),
+      react({
+        jsxRuntime: "classic",
+        babel: {
+          plugins: ["react-require"],
+        },
+      }),
       noBundlePlugin({ root: resolve(__dirname, "src") }),
     ],
     build: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4843,6 +4843,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
     "@vitejs/plugin-react": "npm:^4.2.0"
+    babel-plugin-react-require: "npm:^4.0.2"
     date-fns: "npm:^3.3.1"
     eslint: "npm:^8.53.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"
@@ -4918,6 +4919,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
     "@vitejs/plugin-react": "npm:^4.2.0"
+    babel-plugin-react-require: "npm:^4.0.2"
     eslint: "npm:^8.53.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     eslint-plugin-react-refresh: "npm:^0.4.4"
@@ -8703,6 +8705,13 @@ __metadata:
   version: 0.18.12
   resolution: "babel-plugin-react-native-web@npm:0.18.12"
   checksum: 10c0/f04df9a822c207c00b7b66560e6a33a17c922b96471b7da07ca66003a70599f739b4ef6ad9018bc85205783282b85f7fc193b38d85306cc4158e66d328b6f3c4
+  languageName: node
+  linkType: hard
+
+"babel-plugin-react-require@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "babel-plugin-react-require@npm:4.0.2"
+  checksum: 10c0/b3d205f201cf0433ffab3f4d92f5701c577e52184463a42c388bff2bac39d97356f4aab7fd50cac4541d0829eda17cc9cd963076627cae09f691abbabf4dad1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When using React < 18 users will run into this error: 

```
Module not found: Error: Can't resolve 'react/jsx-runtime' in '[FILE]'
Did you mean 'jsx-runtime.js'?
BREAKING CHANGE: The request 'react/jsx-runtime' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

The issue is described in this thread: https://github.com/facebook/react/issues/20235

The fix was implemented in React 18, but the only "fixes" that exist if we're using the JSX runtime are to patch webpack configs, which is not great.

Instead, this PR implements an option to use the "classic" JSX runtime, which is the `createElement` API as a workaround so that `react/jsx-runtime` is never referenced. To do so, we also needed to ensure that `import React from "react"` was at the top of all of our JSX components, which is what the `babel-plugin-require-react` does.

I tested this locally in our example apps with a build and everything works
