### PR TITLE
fix: add correct dependencies for types and fix types for react 16

### DIFF
--- a/examples/slack-connect-example/package.json
+++ b/examples/slack-connect-example/package.json
@@ -12,6 +12,7 @@
     "@knocklabs/react": "*",
     "jsonwebtoken": "^9.0.2",
     "next": "14.0.4",
+    "next-seo": "^6.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     "@manypkg/cli": "^0.21.2",
     "prettier": "^3.1.0",
     "turbo": "^1.10.16"
+  },
+  "resolutions": {
+    "@types/react": "^16.14",
+    "@types/react-dom": "^16.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "manypkg": {
     "defaultBranch": "main",
     "ignoredRules": [
+      "EXTERNAL_MISMATCH",
       "INTERNAL_MISMATCH"
     ]
   },
@@ -40,9 +41,5 @@
     "@manypkg/cli": "^0.21.2",
     "prettier": "^3.1.0",
     "turbo": "^1.10.16"
-  },
-  "resolutions": {
-    "@types/react": "^16.14",
-    "@types/react-dom": "^16.9"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -55,9 +55,7 @@
     "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@knocklabs/types": "0.1.3",
     "@types/jsonwebtoken": "^9.0.5",
-    "@types/phoenix": "^1.5.4",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "cross-env": "^7.0.3",
@@ -73,6 +71,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.9",
+    "@knocklabs/types": "workspace:^",
+    "@types/phoenix": "^1.5.4",
     "axios": "^1.6.0",
     "axios-retry": "^3.1.9",
     "eventemitter2": "^6.4.5",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -45,7 +45,13 @@
     "url": "https://github.com/knocklabs/javascript/issues"
   },
   "peerDependencies": {
+    "@types/react": "^16.11.0 || ^17.0.0 || ^18.0.0",
     "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@knocklabs/client": "workspace:^",

--- a/packages/react-native/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
+++ b/packages/react-native/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { View } from "react-native";
 
-export const NotificationFeedContainer: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
+export const NotificationFeedContainer: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   return <View>{children}</View>;
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,8 +72,8 @@
   "devDependencies": {
     "@testing-library/react": "^14.2.0",
     "@types/lodash.debounce": "^4.0.9",
-    "@types/react": "^18.2.37",
-    "@types/react-dom": "^18.2.15",
+    "@types/react": "^16.11",
+    "@types/react-dom": "^16.9",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,8 +62,8 @@
   "devDependencies": {
     "@testing-library/react": "^14.2.0",
     "@types/lodash.debounce": "^4.0.9",
-    "@types/react": "^18.2.37",
-    "@types/react-dom": "^18.2.15",
+    "@types/react": "^16.14",
+    "@types/react-dom": "^16.9",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,8 +46,18 @@
     "url": "https://github.com/knocklabs/javascript/issues"
   },
   "peerDependencies": {
+    "@types/react": "^16.11.0 || ^17.0.0 || ^18.0.0",
+    "@types/react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
     "react": "^16.11.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.11.0 || ^17.0.0 || ^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@knocklabs/client": "workspace:^",
@@ -62,8 +72,8 @@
   "devDependencies": {
     "@testing-library/react": "^14.2.0",
     "@types/lodash.debounce": "^4.0.9",
-    "@types/react": "^16.14 || ^18.2.37",
-    "@types/react-dom": "^16.9 || 18.2.15",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,8 +62,8 @@
   "devDependencies": {
     "@testing-library/react": "^14.2.0",
     "@types/lodash.debounce": "^4.0.9",
-    "@types/react": "^16.14",
-    "@types/react-dom": "^16.9",
+    "@types/react": "^16.14 || ^18.2.37",
+    "@types/react-dom": "^16.9 || 18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/packages/react/src/modules/core/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/modules/core/components/Button/ButtonGroup.tsx
@@ -1,7 +1,7 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 
 import "./styles.css";
 
-export const ButtonGroup: React.FC<PropsWithChildren> = ({ children }) => (
-  <div className="rnf-button-group">{children}</div>
-);
+export const ButtonGroup: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => <div className="rnf-button-group">{children}</div>;

--- a/packages/react/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
+++ b/packages/react/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
@@ -1,8 +1,9 @@
-import { PropsWithChildren } from "react";
+import React from "react";
+
 import "./styles.css";
 
-export const NotificationFeedContainer: React.FC<PropsWithChildren> = ({
-  children,
-}) => {
+export const NotificationFeedContainer: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   return <div className="rnf-feed-provider">{children}</div>;
 };

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -14,14 +14,14 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [
-      dts({
-        outDir: "dist/types",
-      }),
       react({
         jsxRuntime: "classic",
         babel: {
           plugins: ["react-require"],
         },
+      }),
+      dts({
+        outDir: "dist/types",
       }),
       noBundlePlugin({ root: resolve(__dirname, "src") }),
     ],
@@ -36,7 +36,15 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
         // External packages that should not be bundled
-        external: ["react", "react-dom"],
+        external: [
+          "react",
+          "react-dom",
+          // These packages were getting bundled into our build (?)
+          /@radix-ui/,
+          /@floating-ui/,
+          "react-popper",
+          "react-popper-tooltip",
+        ],
         output: {
           interop: "compat",
           globals: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4914,8 +4914,8 @@ __metadata:
     "@radix-ui/react-visually-hidden": "npm:^1.0.3"
     "@testing-library/react": "npm:^14.2.0"
     "@types/lodash.debounce": "npm:^4.0.9"
-    "@types/react": "npm:^16.14"
-    "@types/react-dom": "npm:^16.9"
+    "@types/react": "npm:^16.14 || ^18.2.37"
+    "@types/react-dom": "npm:^16.9 || 18.2.15"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
     "@vitejs/plugin-react": "npm:^4.2.0"
@@ -7049,12 +7049,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^16.9":
-  version: 16.9.24
-  resolution: "@types/react-dom@npm:16.9.24"
+"@types/react-dom@npm:^16.9 || 18.2.15":
+  version: 18.2.15
+  resolution: "@types/react-dom@npm:18.2.15"
   dependencies:
-    "@types/react": "npm:^16"
-  checksum: 10c0/987ee2ba06e49064cbc498d6631c14634628558cf90c2efee4b53b0df96c24f54e5dc8a7794d28a92ef47ade39c6ac4fa79329dc8807cb508c6bbb3ab62b852d
+    "@types/react": "npm:*"
+  checksum: 10c0/70e86f15f69f89b8f179139ab2e8a8aa9765e742789f5dd5a46fec40d4300ada8fe3349cceda42b9964a018982d7ccb7d791b47f781966c992bfd37da909fbd3
   languageName: node
   linkType: hard
 
@@ -7078,14 +7078,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^16, @types/react@npm:^16.14":
-  version: 16.14.60
-  resolution: "@types/react@npm:16.14.60"
+"@types/react@npm:^16.14 || ^18.2.37":
+  version: 18.2.79
+  resolution: "@types/react@npm:18.2.79"
   dependencies:
     "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:^0.16"
     csstype: "npm:^3.0.2"
-  checksum: 10c0/4cb5d42c00dea95d530ad6a7a72c645aeb06ce6d4773cedfbb9632e53834ee13e8c53c9335202d82060ea4beb1247453dd65d721aaf447e273bd32fb8c524511
+  checksum: 10c0/c8a8a005d8830a48cc1ef93c3510c4935a2a03e5557dbecaa8f1038450cbfcb18eb206fa7fba7077d54b8da21faeb25577e897a333392770a7797f625b62c78a
   languageName: node
   linkType: hard
 
@@ -7105,7 +7104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/scheduler@npm:*, @types/scheduler@npm:^0.16":
+"@types/scheduler@npm:*":
   version: 0.16.8
   resolution: "@types/scheduler@npm:0.16.8"
   checksum: 10c0/f86de504945b8fc41b1f391f847444d542e2e4067cf7e5d9bfeb5d2d2393d3203b1161bc0ef3b1e104d828dabfb60baf06e8d2c27e27ff7e8258e6e618d8c4ec

--- a/yarn.lock
+++ b/yarn.lock
@@ -4763,7 +4763,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.16.7"
     "@babel/preset-typescript": "npm:^7.16.7"
     "@babel/runtime": "npm:^7.23.9"
-    "@knocklabs/types": "npm:0.1.3"
+    "@knocklabs/types": "workspace:^"
     "@types/jsonwebtoken": "npm:^9.0.5"
     "@types/phoenix": "npm:^1.5.4"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
@@ -4914,8 +4914,8 @@ __metadata:
     "@radix-ui/react-visually-hidden": "npm:^1.0.3"
     "@testing-library/react": "npm:^14.2.0"
     "@types/lodash.debounce": "npm:^4.0.9"
-    "@types/react": "npm:^18.2.37"
-    "@types/react-dom": "npm:^18.2.15"
+    "@types/react": "npm:^16.14"
+    "@types/react-dom": "npm:^16.9"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
     "@vitejs/plugin-react": "npm:^4.2.0"
@@ -4942,7 +4942,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@knocklabs/types@npm:0.1.3, @knocklabs/types@workspace:packages/types":
+"@knocklabs/types@workspace:^, @knocklabs/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@knocklabs/types@workspace:packages/types"
   dependencies:
@@ -7049,6 +7049,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-dom@npm:^16.9":
+  version: 16.9.24
+  resolution: "@types/react-dom@npm:16.9.24"
+  dependencies:
+    "@types/react": "npm:^16"
+  checksum: 10c0/987ee2ba06e49064cbc498d6631c14634628558cf90c2efee4b53b0df96c24f54e5dc8a7794d28a92ef47ade39c6ac4fa79329dc8807cb508c6bbb3ab62b852d
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:^18.0.0, @types/react-dom@npm:^18.2.15":
   version: 18.2.22
   resolution: "@types/react-dom@npm:18.2.22"
@@ -7069,6 +7078,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react@npm:^16, @types/react@npm:^16.14":
+  version: 16.14.60
+  resolution: "@types/react@npm:16.14.60"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    "@types/scheduler": "npm:^0.16"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/4cb5d42c00dea95d530ad6a7a72c645aeb06ce6d4773cedfbb9632e53834ee13e8c53c9335202d82060ea4beb1247453dd65d721aaf447e273bd32fb8c524511
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:1.17.1":
   version: 1.17.1
   resolution: "@types/resolve@npm:1.17.1"
@@ -7085,7 +7105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/scheduler@npm:*":
+"@types/scheduler@npm:*, @types/scheduler@npm:^0.16":
   version: 0.16.8
   resolution: "@types/scheduler@npm:0.16.8"
   checksum: 10c0/f86de504945b8fc41b1f391f847444d542e2e4067cf7e5d9bfeb5d2d2393d3203b1161bc0ef3b1e104d828dabfb60baf06e8d2c27e27ff7e8258e6e618d8c4ec

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,8 +4918,8 @@ __metadata:
     "@radix-ui/react-visually-hidden": "npm:^1.0.3"
     "@testing-library/react": "npm:^14.2.0"
     "@types/lodash.debounce": "npm:^4.0.9"
-    "@types/react": "npm:^18.2.37"
-    "@types/react-dom": "npm:^18.2.15"
+    "@types/react": "npm:^16.11"
+    "@types/react-dom": "npm:^16.9"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
     "@vitejs/plugin-react": "npm:^4.2.0"
@@ -7069,7 +7069,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^16.14":
+"@types/react-dom@npm:^18.0.0, @types/react-dom@npm:^18.2.15":
+  version: 18.2.25
+  resolution: "@types/react-dom@npm:18.2.25"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10c0/87604407eca6884c5b4d4657cb511dc5ba28ea1cfa5d0ce1fc2d659a7ad1b64ae85dcda60e3f010641f9a52a6a60dfcaa6be3b0d0de9d624475052a13dae01f4
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:*, @types/react@npm:^18.2.37":
+  version: 18.2.79
+  resolution: "@types/react@npm:18.2.79"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/c8a8a005d8830a48cc1ef93c3510c4935a2a03e5557dbecaa8f1038450cbfcb18eb206fa7fba7077d54b8da21faeb25577e897a333392770a7797f625b62c78a
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^16, @types/react@npm:^16.11":
   version: 16.14.60
   resolution: "@types/react@npm:16.14.60"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -17194,7 +17194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-seo@npm:^6.4.0":
+"next-seo@npm:^6.4.0, next-seo@npm:^6.5.0":
   version: 6.5.0
   resolution: "next-seo@npm:6.5.0"
   peerDependencies:
@@ -21096,6 +21096,7 @@ __metadata:
     eslint-config-next: "npm:14.0.4"
     jsonwebtoken: "npm:^9.0.2"
     next: "npm:14.0.4"
+    next-seo: "npm:^6.5.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     typescript: "npm:^5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4860,7 +4860,11 @@ __metadata:
     vitest: "npm:^1.2.2"
     zustand: "npm:^3.7.2"
   peerDependencies:
+    "@types/react": ^16.11.0 || ^17.0.0 || ^18.0.0
     react: ^16.11.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4914,8 +4918,8 @@ __metadata:
     "@radix-ui/react-visually-hidden": "npm:^1.0.3"
     "@testing-library/react": "npm:^14.2.0"
     "@types/lodash.debounce": "npm:^4.0.9"
-    "@types/react": "npm:^16.14 || ^18.2.37"
-    "@types/react-dom": "npm:^16.9 || 18.2.15"
+    "@types/react": "npm:^18.2.37"
+    "@types/react-dom": "npm:^18.2.15"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
     "@vitejs/plugin-react": "npm:^4.2.0"
@@ -4937,8 +4941,15 @@ __metadata:
     vite-plugin-no-bundle: "npm:^3.0.0"
     vitest: "npm:^1.2.2"
   peerDependencies:
+    "@types/react": ^16.11.0 || ^17.0.0 || ^18.0.0
+    "@types/react-dom": ^16.9.0 || ^17.0.0 || ^18.0.0
     react: ^16.11.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.11.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -7049,42 +7060,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^16.9 || 18.2.15":
-  version: 18.2.15
-  resolution: "@types/react-dom@npm:18.2.15"
+"@types/react-dom@npm:^16.9":
+  version: 16.9.24
+  resolution: "@types/react-dom@npm:16.9.24"
   dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/70e86f15f69f89b8f179139ab2e8a8aa9765e742789f5dd5a46fec40d4300ada8fe3349cceda42b9964a018982d7ccb7d791b47f781966c992bfd37da909fbd3
+    "@types/react": "npm:^16"
+  checksum: 10c0/987ee2ba06e49064cbc498d6631c14634628558cf90c2efee4b53b0df96c24f54e5dc8a7794d28a92ef47ade39c6ac4fa79329dc8807cb508c6bbb3ab62b852d
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.0.0, @types/react-dom@npm:^18.2.15":
-  version: 18.2.22
-  resolution: "@types/react-dom@npm:18.2.22"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/cd85b5f402126e44b8c7b573e74737389816abcc931b2b14d8f946ba81cce8637ea490419488fcae842efb1e2f69853bc30522e43fd8359e1007d4d14b8d8146
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*, @types/react@npm:^18.2.37":
-  version: 18.2.66
-  resolution: "@types/react@npm:18.2.66"
+"@types/react@npm:^16.14":
+  version: 16.14.60
+  resolution: "@types/react@npm:16.14.60"
   dependencies:
     "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
+    "@types/scheduler": "npm:^0.16"
     csstype: "npm:^3.0.2"
-  checksum: 10c0/56e4b841f2daf03a0b3268d4f2bcf5841167fe56742b9f1c076fad66587fb59191bdaba4d5727dbfbcff750d5e8797fdd4e57d8d9704b0bfc6ad31ee1e268a70
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^16.14 || ^18.2.37":
-  version: 18.2.79
-  resolution: "@types/react@npm:18.2.79"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/c8a8a005d8830a48cc1ef93c3510c4935a2a03e5557dbecaa8f1038450cbfcb18eb206fa7fba7077d54b8da21faeb25577e897a333392770a7797f625b62c78a
+  checksum: 10c0/4cb5d42c00dea95d530ad6a7a72c645aeb06ce6d4773cedfbb9632e53834ee13e8c53c9335202d82060ea4beb1247453dd65d721aaf447e273bd32fb8c524511
   languageName: node
   linkType: hard
 
@@ -7104,7 +7096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/scheduler@npm:*":
+"@types/scheduler@npm:^0.16":
   version: 0.16.8
   resolution: "@types/scheduler@npm:0.16.8"
   checksum: 10c0/f86de504945b8fc41b1f391f847444d542e2e4067cf7e5d9bfeb5d2d2393d3203b1161bc0ef3b1e104d828dabfb60baf06e8d2c27e27ff7e8258e6e618d8c4ec


### PR DESCRIPTION
Ok a bunch of weird stuff:

* On React 16, trying to use `JSX.Element` from `@react/jsx-runtime` never worked so I switched the types in the build to be based on React 16.14 which seems to resolve
* Needed to add `@knocklabs/types` and `@types/phoenix` to the deps for the client
* It turns out that our bundles were including some external packages bundled alongside (wat)