### PR TITLE
fix: don't use propswithchildren w/o props

### DIFF
--- a/.changeset/brown-deers-cough.md
+++ b/.changeset/brown-deers-cough.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-native": patch
+"@knocklabs/react": patch
+---
+
+fix: don't use propswithchildren w/o props

--- a/packages/react-native/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
+++ b/packages/react-native/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
@@ -1,8 +1,6 @@
-import React from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { View } from "react-native";
 
-export const NotificationFeedContainer: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
-  return <View>{children}</View>;
-};
+export const NotificationFeedContainer: FunctionComponent<{
+  children?: ReactNode | undefined;
+}> = ({ children }) => <View>{children}</View>;

--- a/packages/react/src/modules/core/components/Button/ButtonGroup.tsx
+++ b/packages/react/src/modules/core/components/Button/ButtonGroup.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent, PropsWithChildren } from "react";
+import { FunctionComponent, ReactNode } from "react";
 
 import "./styles.css";
 
-export const ButtonGroup: FunctionComponent<PropsWithChildren> = ({
-  children,
-}) => <div className="rnf-button-group">{children}</div>;
+export const ButtonGroup: FunctionComponent<{
+  children?: ReactNode | undefined;
+}> = ({ children }) => <div className="rnf-button-group">{children}</div>;

--- a/packages/react/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
+++ b/packages/react/src/modules/feed/components/NotificationFeedContainer/NotificationFeedContainer.tsx
@@ -1,8 +1,7 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent, ReactNode } from "react";
+
 import "./styles.css";
 
-export const NotificationFeedContainer: React.FC<PropsWithChildren> = ({
-  children,
-}) => {
-  return <div className="rnf-feed-provider">{children}</div>;
-};
+export const NotificationFeedContainer: FunctionComponent<{
+  children?: ReactNode | undefined;
+}> = ({ children }) => <div className="rnf-feed-provider">{children}</div>;


### PR DESCRIPTION
react 16 type don't let you use `PropsWithChildren` with empty