### PR TITLE
fix: feed events should all be items. and fixed types

### DIFF
--- a/.changeset/four-icons-provide.md
+++ b/.changeset/four-icons-provide.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: event types to use items. and fix types

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -751,7 +751,8 @@ class Feed {
     items: FeedItem[],
   ) {
     // Handle both `items.` and `items:` format for events for compatibility reasons
-    this.broadcaster.emit([`items.${type}`, `items:${type}`], { items });
+    this.broadcaster.emit(`items.${type}`, { items });
+    this.broadcaster.emit(`items:${type}`, { items });
     // Internal events only need `items:`
     this.broadcastOverChannel(`items:${type}`, { items });
   }

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -206,9 +206,7 @@ class Feed {
 
     // Issue the API request to the bulk status change API
     const result = await this.makeBulkStatusUpdate("seen");
-
-    this.broadcaster.emit(`items:all_seen`, { items });
-    this.broadcastOverChannel(`items:all_seen`, { items });
+    this.emitEvent("all_seen", items);
 
     return result;
   }
@@ -276,9 +274,7 @@ class Feed {
 
     // Issue the API request to the bulk status change API
     const result = await this.makeBulkStatusUpdate("read");
-
-    this.broadcaster.emit(`items:all_read`, { items });
-    this.broadcastOverChannel(`items:all_read`, { items });
+    this.emitEvent("all_read", items);
 
     return result;
   }
@@ -416,9 +412,7 @@ class Feed {
 
     // Issue the API request to the bulk status change API
     const result = await this.makeBulkStatusUpdate("archive");
-
-    this.broadcaster.emit(`items:all_archived`, { items });
-    this.broadcastOverChannel(`items:all_archived`, { items });
+    this.emitEvent("all_archived", items);
 
     return result;
   }
@@ -615,12 +609,7 @@ class Feed {
 
     // Emit the event that these items had their statuses changed
     // Note: we do this after the update to ensure that the server event actually completed
-    this.broadcaster.emit(`items.${type}`, { items });
-
-    // Note: `items.type` format is being deprecated in favor over the `items:type` format,
-    // but emit both formats to make it backward compatible for now.
-    this.broadcaster.emit(`items:${type}`, { items });
-    this.broadcastOverChannel(`items:${type}`, { items });
+    this.emitEvent(type, items);
 
     return result;
   }
@@ -748,6 +737,23 @@ class Feed {
       "visibilitychange",
       this.visibilityChangeHandler,
     );
+  }
+
+  private emitEvent(
+    type:
+      | MessageEngagementStatus
+      | "all_read"
+      | "all_seen"
+      | "all_archived"
+      | "unread"
+      | "unseen"
+      | "unarchived",
+    items: FeedItem[],
+  ) {
+    // Handle both `items.` and `items:` format for events for compatibility reasons
+    this.broadcaster.emit([`items.${type}`, `items:${type}`], { items });
+    // Internal events only need `items:`
+    this.broadcastOverChannel(`items:${type}`, { items });
   }
 
   private handleVisibilityChange() {

--- a/packages/client/src/clients/feed/interfaces.ts
+++ b/packages/client/src/clients/feed/interfaces.ts
@@ -94,8 +94,8 @@ export interface FeedMetadata {
   unseen_count: number;
 }
 
-export interface FeedResponse {
-  entries: FeedItem[];
+export interface FeedResponse<T = any> {
+  entries: FeedItem<T>[];
   meta: FeedMetadata;
   page_info: PageInfo;
 }

--- a/packages/client/src/clients/feed/types.ts
+++ b/packages/client/src/clients/feed/types.ts
@@ -9,7 +9,7 @@ export type StoreFeedResultOptions = {
   shouldAppend?: boolean;
 };
 
-export type FeedStoreState = {
+export interface FeedStoreState {
   items: FeedItem[];
   pageInfo: PageInfo;
   metadata: FeedMetadata;
@@ -20,11 +20,11 @@ export type FeedStoreState = {
   setNetworkStatus: (networkStatus: NetworkStatus) => void;
   setItemAttrs: (itemIds: string[], attrs: object) => void;
   resetStore: (metadata?: FeedMetadata) => void;
-};
+}
 
-export type FeedMessagesReceivedPayload = {
+export interface FeedMessagesReceivedPayload {
   metadata: FeedMetadata;
-};
+}
 
 /*
 Event types:
@@ -51,11 +51,11 @@ export type FeedEvent =
 // Because we can bind to wild card feed events, this is here to accomodate whatever can be bound to
 export type BindableFeedEvent = FeedEvent | "items.received.*" | "items.*";
 
-export type FeedEventPayload = {
+export interface FeedEventPayload<T = any> {
   event: Omit<FeedEvent, "messages.new">;
-  items: FeedItem[];
+  items: FeedItem<T>[];
   metadata: FeedMetadata;
-};
+}
 
 export type FeedRealTimeCallback = (resp: FeedResponse) => void;
 


### PR DESCRIPTION
* feed events should all be `items.${type}` as well as `items:${type}`
* make some generic types interfaces
* allow `FeedEventPayload` to accept a generic