### PR TITLE
fix: check if visibilitychange listener is present before adding

### DIFF
--- a/.changeset/healthy-lemons-begin.md
+++ b/.changeset/healthy-lemons-begin.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: avoid adding duplicate visibiliy change event listeners

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -44,6 +44,7 @@ class Feed {
   private disconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private hasSubscribedToRealTimeUpdates: Boolean = false;
   private visibilityChangeHandler: () => void = () => {};
+  private visibilityChangeListenerConnected: Boolean = false;
 
   // The raw store instance, used for binding in React and other environments
   public store: StoreApi<FeedStoreState>;
@@ -728,7 +729,10 @@ class Feed {
    * or reconnect the socket after a delay
    */
   private setupAutoSocketManager() {
+    if (this.visibilityChangeListenerConnected) return;
+
     this.visibilityChangeHandler = this.handleVisibilityChange.bind(this);
+    this.visibilityChangeListenerConnected = true;
     document.addEventListener("visibilitychange", this.visibilityChangeHandler);
   }
 
@@ -737,6 +741,7 @@ class Feed {
       "visibilitychange",
       this.visibilityChangeHandler,
     );
+    this.visibilityChangeListenerConnected = false;
   }
 
   private emitEvent(


### PR DESCRIPTION
With `auto_manage_socket_connection` on, we disconnect and reconnect websockets for idle tabs. This is detected with the `visibilitychange` event listener which gets added when the feed instance is created or reinitialized. The event listener is cleaned up when the feed instance is torn down. 

There was an issue where we were also adding the listener in `handleVisibilityChange` when we reinitialize the realtime connection when the tab becomes active again (`document.visibilityState === "visible"`). This PR adds a flag so we can check if the listener was already added and early returns if it has been so we don't accidentally keep re-adding the event listener. 

You can test this by :
1. running the Nextjs example and enabling `auto_manage_socket_connection`
1. open the demo app in multiple tabs
1. switch to a different tab so that the socket disconnects
1. switch back and forth between the Next app
1. watch the devtools Performance Monitor to see the number of active event listeners. Before these changes, if you switched back and forth for a minute or so, there'd eventually be tens of thousands of listeners and the tab would crash. With these changes, it should be relatively stable. 