### PR TITLE
fix: subscribe to state updates for notifications

### DIFF
--- a/.changeset/nervous-lizards-press.md
+++ b/.changeset/nervous-lizards-press.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+Fixes issue where notification data was not updating in react strict mode

--- a/packages/react-core/src/modules/feed/hooks/useNotifications.ts
+++ b/packages/react-core/src/modules/feed/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import Knock, { Feed, FeedClientOptions } from "@knocklabs/client";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef  } from "react";
 
 function useNotifications(
   knock: Knock,
@@ -13,12 +13,13 @@ function useNotifications(
       feedClientRef.current.dispose();
     }
 
-    const feedClient = knock.feeds.initialize(feedChannelId, options);
+    feedClientRef.current = knock.feeds.initialize(feedChannelId, options);
+    feedClientRef.current.listenForUpdates();
+    feedClientRef.current.store.subscribe((t) =>
+      feedClientRef?.current?.store.setState(t),
+    );
 
-    feedClient.listenForUpdates();
-    feedClientRef.current = feedClient;
-
-    return feedClient;
+    return feedClientRef.current;
   }, [
     knock,
     feedChannelId,


### PR DESCRIPTION
In react strict mode, updates from `useNotifications` was not persisted downstream, so the UI seemed unresponsive as it wasn't getting updates. There is likely an underlying issue that we need to investigate further, but using zustand's [transient updates](https://github.com/pmndrs/zustand?tab=readme-ov-file#transient-updates-for-often-occurring-state-changes) pattern seems to work for both react strict mode and a production build. 