### PR TITLE
fix: ensure that options are stable between re-renders for useAuthenticatedKnockClient

### DIFF
--- a/.changeset/four-actors-itch.md
+++ b/.changeset/four-actors-itch.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+fix: ensure options are memoized in useAuthenticatedKnockClient

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -41,8 +41,6 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
   i18n,
 }) => {
   // We memoize the options here so that we don't create a new object on every re-render
-  // TODO: we probably need to put this optimization into the `useAuthenticatedKnockClient`
-  // hook itself to fix this
   const authenticateOptions = React.useMemo(
     () => ({
       host,

--- a/packages/react-core/test/core/useAuthenticatedKnockClient.test.ts
+++ b/packages/react-core/test/core/useAuthenticatedKnockClient.test.ts
@@ -1,0 +1,126 @@
+import Knock from "@knocklabs/client";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useAuthenticatedKnockClient } from "../../src";
+import { AuthenticatedKnockClientOptions } from "../../src/modules/core/hooks/useAuthenticatedKnockClient";
+
+const defaultProps: {
+  apiKey: string;
+  userId: string;
+  userToken?: string;
+  options?: AuthenticatedKnockClientOptions;
+} = {
+  apiKey: "pk_1234",
+  userId: "user_123",
+  userToken: undefined,
+  options: undefined,
+};
+
+describe("useAuthenticatedKnockClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should create a new knock client instance", () => {
+    const { result } = renderHook(
+      ({ apiKey, userId, userToken, options }) =>
+        useAuthenticatedKnockClient(apiKey, userId, userToken, options),
+      { initialProps: defaultProps },
+    );
+
+    expect(result.current).toBeInstanceOf(Knock);
+    expect(result.current.userId).toEqual("user_123");
+  });
+
+  it("should not create a new instance when the userId is stable during re-renders", () => {
+    const { result, rerender } = renderHook(
+      ({ apiKey, userId, userToken, options }) =>
+        useAuthenticatedKnockClient(apiKey, userId, userToken, options),
+      { initialProps: defaultProps },
+    );
+
+    const authenticateSpy = vi.spyOn(result.current, "authenticate");
+
+    expect(result.current).toBeInstanceOf(Knock);
+    expect(result.current.userId).toEqual("user_123");
+
+    rerender(defaultProps);
+
+    expect(authenticateSpy).not.toBeCalled();
+  });
+
+  it("should reauthenticate when the userId or userToken changes", () => {
+    const { result, rerender } = renderHook(
+      ({ apiKey, userId, userToken, options }) =>
+        useAuthenticatedKnockClient(apiKey, userId, userToken, options),
+      { initialProps: defaultProps },
+    );
+
+    expect(result.current).toBeInstanceOf(Knock);
+    expect(result.current.userId).toEqual("user_123");
+
+    const authenticateSpy = vi.spyOn(result.current, "authenticate");
+
+    // Change the user id
+    rerender({ ...defaultProps, userId: "user_2345" });
+
+    expect(result.current.userId).toEqual("user_2345");
+    expect(authenticateSpy).toBeCalled();
+
+    // Change the user token
+    rerender({ ...defaultProps, userToken: "token_1234" });
+
+    expect(result.current.userToken).toEqual("token_1234");
+    expect(authenticateSpy).toBeCalled();
+  });
+
+  it("should create a new instance when the api key changes", () => {
+    const { result, rerender } = renderHook(
+      ({ apiKey, userId, userToken, options }) =>
+        useAuthenticatedKnockClient(apiKey, userId, userToken, options),
+      { initialProps: defaultProps },
+    );
+
+    expect(result.current).toBeInstanceOf(Knock);
+
+    const teardownSpy = vi.spyOn(result.current, "teardown");
+
+    rerender({ ...defaultProps, apiKey: "pk_23456" });
+
+    expect(teardownSpy).toHaveBeenCalledOnce();
+  });
+
+  it("should create a new instance when the options change", () => {
+    const { result, rerender } = renderHook(
+      ({ apiKey, userId, userToken, options }) =>
+        useAuthenticatedKnockClient(
+          apiKey,
+          userId,
+          userToken,
+          options as AuthenticatedKnockClientOptions,
+        ),
+      {
+        initialProps: {
+          ...defaultProps,
+          options: { logLevel: "debug" } as AuthenticatedKnockClientOptions,
+        },
+      },
+    );
+
+    expect(result.current).toBeInstanceOf(Knock);
+    expect(result.current.logLevel).toEqual("debug");
+
+    const teardownSpy = vi.spyOn(result.current, "teardown");
+
+    // Change options and we should teardown and re-render
+    rerender({
+      ...defaultProps,
+      options: { host: "https://whatever.com", logLevel: "debug" },
+    });
+
+    expect(teardownSpy).toHaveBeenCalledOnce();
+
+    expect(result.current).toBeInstanceOf(Knock);
+  });
+});


### PR DESCRIPTION
- Uses a shallow comparison and a memo for `options` passed into the `useAuthenticatedKnockClient` hook to ensure the options are stable between re-renders
- Adds a test for the hook (!)