### PR TITLE
fix: render issues in next 14 with react 18 strict mode

### DIFF
--- a/.changeset/empty-taxis-nail.md
+++ b/.changeset/empty-taxis-nail.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: don't destroy the store, ever

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -112,7 +112,6 @@ class Feed {
     this.teardown();
     this.broadcaster.removeAllListeners();
     this.knock.feeds.removeInstance(this);
-    this.store.destroy();
   }
 
   /*


### PR DESCRIPTION
Destroying the store unbinds listeners, which breaks our workaround for handling double renders in React strict mode. There's definitely something deeper going on here, but I cannot for the life of me figure it out.