### PR TITLE
fix: remove event stop propogation from outside click hook

### DIFF
--- a/.changeset/rich-foxes-tease.md
+++ b/.changeset/rich-foxes-tease.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+remove stop propogation from useComponentVisible hook to prevent page reloads with react-router-dom

--- a/packages/react/src/modules/core/hooks/useComponentVisible.ts
+++ b/packages/react/src/modules/core/hooks/useComponentVisible.ts
@@ -27,7 +27,6 @@ export default function useComponentVisible(
       options.closeOnClickOutside &&
       !contains(ref.current, event.target as HTMLElement)
     ) {
-      event.stopPropagation();
       onClose(event);
     }
   };


### PR DESCRIPTION
### Description
A customer was experiencing an issue where when the notification feed popover was open, clicking a link outside of the popover would cause the page to hard refresh when using `react-router-dom`. Removing `event.stopPropogation()` from the `useComponentVisible` hook fixed this issue. 

### Tasks
[KNO-6065](https://linear.app/knock/issue/KNO-6065/[js-sdk]-investigate-event-propagation-issue-with-react-popover)