### PR TITLE
fix: check type of zustand create and fallback to .default

### DIFF
--- a/.changeset/kind-yaks-compete.md
+++ b/.changeset/kind-yaks-compete.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: check type of zustand default import and fix cjs build

--- a/packages/client/src/clients/feed/store.ts
+++ b/packages/client/src/clients/feed/store.ts
@@ -1,11 +1,17 @@
 import { GenericData } from "@knocklabs/types";
-import create from "zustand/vanilla";
+import zustand from "zustand/vanilla";
 
 import { NetworkStatus } from "../../networkStatus";
 
 import { FeedItem } from "./interfaces";
 import { FeedStoreState } from "./types";
 import { deduplicateItems, sortItems } from "./utils";
+
+// Get the correct Zustand function. Caused by some issues in v3 exports
+// https://github.com/pmndrs/zustand/issues/334
+const create: typeof zustand =
+  // @ts-expect-error workaround for issue above
+  typeof zustand === "function" ? zustand : zustand.default;
 
 function processItems(items: FeedItem[]) {
   const deduped = deduplicateItems(items);


### PR DESCRIPTION
As of version 0.8.21, the CJS feed client breaks which can be reproduced by a new Ember JS project with the error
```
TypeError: i is not a function
  at Module.p [as default] (store.js:1:654)
  at new v (feed.js:1:1035)
  at f.initialize (index.js:1:550)
```

This can be resolved by accessing `require("zustand/vanilla").default` in the CJS build. This seems to be caused by an issue with Zustand v3 not having the correct exports for sub packages (e.g. it breaks for `zustand/vanilla`). Checking the type of the default zustand export seems to fix this issue.

Tested locally against an Ember project and against our Nextjs and Client examples to make sure this doesn't cause any regressions. 