### PR TITLE
fix: wrap long, unbroken text in notification cell

### DIFF
--- a/.changeset/perfect-chairs-impress.md
+++ b/.changeset/perfect-chairs-impress.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+fix: wrap long, unbroken text in notification cell

--- a/packages/react/src/modules/feed/components/NotificationCell/styles.css
+++ b/packages/react/src/modules/feed/components/NotificationCell/styles.css
@@ -97,7 +97,7 @@
   font-size: var(--rnf-notification-cell-content-font-size);
   line-height: var(--rnf-notification-cell-content-line-height);
   margin-bottom: var(--rnf-spacing-1);
-  word-break: normal;
+  word-break: break-word;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
Long, unbroken text (like links) caused the notification cell to overflow horizontally. This PR updates the word-break to `break-word` to fix that.
![Screenshot 2024-07-11 at 12 55 45 PM](https://github.com/knocklabs/javascript/assets/12838032/29ce64af-a889-48de-a37b-43b3885a30ca)
