### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "knocklabs/product"
+    versioning-strategy: increase
+    open-pull-requests-limit: 5


### PR DESCRIPTION
### Description 
- Adds dependabot config to repo. Bases config off of telegraph so that it works correctly in a monorepo.

### Tasks
[KNO-6439](https://linear.app/knock/issue/KNO-6439/[sdk]-add-dependabot-to-javascript-repo)