### PR TITLE
fix: RN push provider flag

### DIFF
--- a/.changeset/twelve-dogs-hide.md
+++ b/.changeset/twelve-dogs-hide.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-native": patch
+---
+
+Adding a prop to our KnockExpoPushNotificationProvider to allow users to opt out of our auto registration


### PR DESCRIPTION
Adding a prop to our KnockExpoPushNotificationProvider to allow users to opt out of our auto registration