### PR TITLE
fix: make message client stable

### DIFF
--- a/examples/in-app-message-example/src/App.tsx
+++ b/examples/in-app-message-example/src/App.tsx
@@ -66,6 +66,7 @@ function App() {
       apiKey={import.meta.env.VITE_KNOCK_API_KEY!}
       userId={import.meta.env.VITE_KNOCK_USER_ID!}
       host={import.meta.env.VITE_KNOCK_HOST}
+      logLevel="debug"
     >
       <KnockInAppChannelProvider
         channelId={import.meta.env.VITE_KNOCK_CHANNEL_ID}
@@ -105,22 +106,7 @@ function App() {
           <hr />
           <Messages />
 
-          <Modal.View.Default
-            colorMode={colorMode}
-            content={{
-              title: "Modal title",
-              body: "Contextual copy about what is being shown in the Modal. Use modals for announcements, timely updates, and messages with important calls to action.",
-              dismissible: true,
-              primary_button: {
-                text: "Primary",
-                action: "",
-              },
-              secondary_button: {
-                text: "Secondary",
-                action: "",
-              },
-            }}
-          />
+          <Modal.Default />
         </>
       </KnockInAppChannelProvider>
     </KnockProvider>

--- a/packages/client/src/clients/in-app-messages/channel-client.ts
+++ b/packages/client/src/clients/in-app-messages/channel-client.ts
@@ -22,6 +22,8 @@ export class InAppChannelClient {
     readonly defaultOptions: InAppMessagesClientOptions = {},
   ) {
     this.store = createStore();
+
+    this.knock.log(`[IAM] Initialized a client on channel ${channelId}`);
   }
 
   // ----------------------------------------------

--- a/packages/client/src/clients/in-app-messages/message-client.ts
+++ b/packages/client/src/clients/in-app-messages/message-client.ts
@@ -32,6 +32,8 @@ export class InAppMessagesClient {
     };
     this.knock = channelClient.knock;
     this.queryKey = this.buildQueryKey(this.defaultOptions);
+
+    this.knock.log(`[IAM] Initialized a client for message ${messageType}`);
   }
 
   // ----------------------------------------------

--- a/packages/react-core/src/modules/in-app-message/hooks/useInAppMessages.ts
+++ b/packages/react-core/src/modules/in-app-message/hooks/useInAppMessages.ts
@@ -8,6 +8,7 @@ import { GenericData } from "@knocklabs/types";
 import { useStore } from "@tanstack/react-store";
 import { useEffect, useMemo } from "react";
 
+import { useStableOptions } from "../../core";
 import { useInAppChannel } from "../context";
 
 export interface UseInAppMessagesOptions extends InAppMessagesClientOptions {}
@@ -31,10 +32,15 @@ export const useInAppMessages = <
 ): UseInAppMessagesResponse<TContent, TData> => {
   const { inAppChannelClient } = useInAppChannel();
 
+  const stableOptions = useStableOptions(options);
+
   const inAppMessagesClient = useMemo(() => {
-    // TODO: This is not stable
-    return new InAppMessagesClient(inAppChannelClient, messageType, options);
-  }, [inAppChannelClient, messageType, options]);
+    return new InAppMessagesClient(
+      inAppChannelClient,
+      messageType,
+      stableOptions,
+    );
+  }, [inAppChannelClient, messageType, stableOptions]);
 
   const { messages, networkStatus, loading } = useStore(
     inAppChannelClient.store,


### PR DESCRIPTION
- Makes options stable which makes the message client created by `useInAppMessage(s)` stable
- Adds logs to message and channel client to debug client creation

Example shows 1 channel client created with 3 message clients created which is expected for:
- Default banner
- Custom banner
- Default modal
- None for card as the demo uses the view card component
![CleanShot 2024-10-08 at 13 22 36](https://github.com/user-attachments/assets/24e4707a-2027-4c82-9d9f-6ac1415fc3af)
