### PR TITLE
feat: add prerelease action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,70 @@
+name: Prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      preid:
+        description: "The prerelease identifier (e.g., alpha, beta, rc)"
+        required: true
+        default: "rc"
+      branch:
+        description: "The branch to create the prerelease from"
+        required: true
+        default: "next"
+
+concurrency:
+  group: prerelease-${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  prerelease:
+    name: Prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+          node-version-file: "package.json"
+          cache: "yarn"
+
+      - name: Install Dependencies
+        run: yarn --immutable
+
+      - name: Setup .yarnrc
+        run: |
+          yarn config set npmRegistryServer "https://registry.npmjs.org"
+          yarn config set npmAlwaysAuth true
+          yarn config set npmAuthToken $NPM_TOKEN
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Prerelease Version
+        run: yarn changeset pre enter ${{ github.event.inputs.preid }}
+
+      - name: Version Packages
+        run: yarn changeset version
+
+      - name: Build Packages
+        run: yarn build:packages
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          commit: "chore(repo): prerelease"
+          title: "chore(repo): prerelease ${{ github.event.inputs.preid }}"
+          publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Exit Prerelease Mode
+        run: yarn changeset pre exit


### PR DESCRIPTION
Adds a prerelease action which runs the changeset action in prerelease mode. Defaults to running against the `next` branch and appending `rc` to the versions

Changesets prerelease docs: https://github.com/changesets/changesets/blob/main/docs/prereleases.md