### PR TITLE
fix(kno-7176): unsubscribe onTokenRefresh listener in React Native sample app

### DIFF
--- a/.changeset/curly-pets-guess.md
+++ b/.changeset/curly-pets-guess.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-native-example": patch
+---
+
+Unsubscribe token refresh listener in FCM push notification example

--- a/examples/react-native-example/FCMPushNotificationHandler.tsx
+++ b/examples/react-native-example/FCMPushNotificationHandler.tsx
@@ -61,10 +61,12 @@ function useFCMPushToken(): string | null {
       })
       .catch(console.error);
 
-    messaging().onTokenRefresh((token) => {
+    const unsubscribe = messaging().onTokenRefresh((token) => {
       console.log(`Push token refreshed: ${token}`);
       setToken(token);
     });
+
+    return unsubscribe;
   }, []);
 
   return token;


### PR DESCRIPTION
Small fix. Turns out [`onTokenRefresh`](https://github.com/invertase/react-native-firebase/blob/9c940857a3759f85fad2f8d995b83f7c08058d6b/packages/messaging/lib/index.d.ts#L790) returns an unsubscribe function.