### PR TITLE
fix: if axios is not imported as the default, then account for it

### DIFF
--- a/.changeset/red-spiders-promise.md
+++ b/.changeset/red-spiders-promise.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: ensure axios is always imported correctly

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -30,8 +30,15 @@ class ApiClient {
     this.apiKey = options.apiKey;
     this.userToken = options.userToken || null;
 
-    // Create a retryable axios client
-    this.axiosClient = axios.create({
+    // Create a retryable axios client, but account for issues where the axios export is not
+    // the default in certain bundlers (Webpack).
+    //
+    // NOTE: This is a temporary fix that exists because of this issue:
+    // https://github.com/axios/axios/issues/6591
+    const axiosInstance = // @ts-expect-error Fixing the issue described above
+      (axios.default ? axios.default : axios) as AxiosStatic;
+
+    this.axiosClient = axiosInstance.create({
       baseURL: this.host,
       headers: {
         Accept: "application/json",


### PR DESCRIPTION
### TL;DR

Ensure axios is always imported correctly in the client package.

### What changed?

Modified the `ApiClient` class in `packages/client/src/api.ts` to handle cases where the axios export is not the default in certain bundlers (e.g., Webpack). This change addresses an issue reported in the axios repository.

### How to test?

1. Build the client package using different bundlers, especially Webpack.
2. Verify that the axios instance is created correctly without any import-related errors.
3. Ensure that API calls using the client still function as expected.

### Why make this change?

This change resolves a potential issue where the axios library might not be imported correctly in certain bundling scenarios. By accounting for both default and non-default exports, we ensure consistent behavior across different build environments, improving the reliability and compatibility of the Knock client package.