### PR TITLE
fix: convert trigger_data to string for in-app-messages api

### DIFF
--- a/packages/client/src/clients/in-app-messages/message-client.ts
+++ b/packages/client/src/clients/in-app-messages/message-client.ts
@@ -57,7 +57,11 @@ export class InAppMessagesClient {
       }
     | undefined
   > {
-    const params = this.defaultOptions;
+    const params = {
+      ...this.defaultOptions,
+      // Convert trigger_data to a string, which the API expects
+      trigger_data: JSON.stringify(this.defaultOptions.trigger_data),
+    };
 
     this.queryKey = this.buildQueryKey(params);
 

--- a/packages/client/src/clients/in-app-messages/types.ts
+++ b/packages/client/src/clients/in-app-messages/types.ts
@@ -73,7 +73,5 @@ export interface InAppMessagesClientOptions {
   // Optionally scope to a given archived status (defaults to `exclude`)
   archived?: "include" | "exclude" | "only";
   // Optionally scope all notifications that contain this argument as part of their trigger payload
-  // TODO(KNO-7140): This currently does not work because the API expects this
-  // to be a json string.
   trigger_data?: GenericData;
 }

--- a/packages/client/src/clients/users/interfaces.ts
+++ b/packages/client/src/clients/users/interfaces.ts
@@ -14,5 +14,7 @@ export interface GetChannelDataInput {
 export interface GetInAppMessagesInput {
   channelId: string;
   messageType: string;
-  params: InAppMessagesClientOptions;
+  params: Omit<InAppMessagesClientOptions, "trigger_data"> & {
+    trigger_data: string;
+  };
 }


### PR DESCRIPTION
The API allows filtering by trigger_data, but expects it to be a string. An object is easier to work with and matches the feeds API, so we're going to just convert the object to a string before calling the API. 