### PR TITLE
fix: refetch in-app messages when query options change 

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -52,6 +52,7 @@
     "@knocklabs/client": "workspace:^",
     "@tanstack/react-store": "^0.5.5",
     "date-fns": "^4.0.0",
+    "fast-deep-equal": "^3.1.3",
     "swr": "^2.2.5",
     "zustand": "^3.7.2"
   },

--- a/packages/react-core/src/modules/core/hooks/useStableOptions.ts
+++ b/packages/react-core/src/modules/core/hooks/useStableOptions.ts
@@ -1,5 +1,5 @@
+import fastDeepEqual from "fast-deep-equal";
 import { useMemo, useRef } from "react";
-import shallow from "zustand/shallow";
 
 export default function useStableOptions<T>(options: T): T {
   const optionsRef = useRef<T>();
@@ -7,7 +7,7 @@ export default function useStableOptions<T>(options: T): T {
   return useMemo(() => {
     const currentOptions = optionsRef.current;
 
-    if (currentOptions && shallow(options, currentOptions)) {
+    if (currentOptions && fastDeepEqual(options, currentOptions)) {
       return currentOptions;
     }
 

--- a/packages/react-core/src/modules/in-app-messages/hooks/useInAppMessages.ts
+++ b/packages/react-core/src/modules/in-app-messages/hooks/useInAppMessages.ts
@@ -54,9 +54,7 @@ export const useInAppMessages = <
     return () => {
       inAppMessagesClient.unsubscribe();
     };
-    // Run only once at mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [inAppMessagesClient]);
 
   return { messages, networkStatus, loading, inAppMessagesClient };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4363,6 +4363,7 @@ __metadata:
     eslint: "npm:^8.56.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     eslint-plugin-react-refresh: "npm:^0.4.4"
+    fast-deep-equal: "npm:^3.1.3"
     jsdom: "npm:^24.0.0"
     react: "npm:^18.2.0"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
Fixes this issue: https://knocklabs.slack.com/archives/C079G6X3DD4/p1731085160770939

* Need to re-run the effect upon getting new options, so adding inAppMessagesClient to the useEffect deps array in the in-app message client
* Uses `fast-deep-equal` instead of `zustand/shallow` since the latter does not handle array values, and some of our query params can be arrays.

