### PR TITLE
fix: update preference set types

### DIFF
--- a/.changeset/rude-camels-care.md
+++ b/.changeset/rude-camels-care.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/client": patch
+"@knocklabs/types": patch
+---
+
+fix: update preference set types

--- a/packages/client/src/clients/preferences/interfaces.ts
+++ b/packages/client/src/clients/preferences/interfaces.ts
@@ -1,12 +1,17 @@
-import { ChannelType } from "@knocklabs/types";
+import { ChannelType, Condition } from "@knocklabs/types";
+
+export type ConditionalPreferenceSettings = {
+  conditions: Condition[];
+};
 
 export type ChannelTypePreferences = {
-  [_K in ChannelType]?: boolean;
+  [_K in ChannelType]?: boolean | ConditionalPreferenceSettings;
 };
 
 export type WorkflowPreferenceSetting =
   | boolean
-  | { channel_types: ChannelTypePreferences };
+  | { channel_types: ChannelTypePreferences }
+  | ConditionalPreferenceSettings;
 
 export type WorkflowPreferences = Partial<
   Record<string, WorkflowPreferenceSetting>
@@ -20,9 +25,9 @@ export interface SetPreferencesProperties {
 
 export interface PreferenceSet {
   id: string;
-  categories: WorkflowPreferences;
-  workflows: WorkflowPreferences;
-  channel_types: ChannelTypePreferences;
+  categories: WorkflowPreferences | null;
+  workflows: WorkflowPreferences | null;
+  channel_types: ChannelTypePreferences | null;
 }
 
 export interface PreferenceOptions {

--- a/packages/types/src/common.d.ts
+++ b/packages/types/src/common.d.ts
@@ -18,3 +18,9 @@ export type ChannelType =
   | "push"
   | "chat"
   | "http";
+
+export interface Condition {
+  argument: string;
+  variable: string;
+  operator: string;
+}


### PR DESCRIPTION
Marks categories, workflows, and channel_types as nullable which matches the behavior of the API.

Also adds `Condition` and `ConditionalPreferenceSettings` to match the types from the Node SDK.