### PR TITLE
NotificationFeed: Refetch items after archiving

### DIFF
--- a/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
+++ b/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
@@ -64,7 +64,9 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
       if (action === TopHeaderAction.MARK_ALL_AS_READ) {
         feedClient.markAllAsRead();
       } else {
-        feedClient.markAllReadAsArchived();
+        feedClient.markAllReadAsArchived().then(() => {
+          feedClient.fetch({ status });
+        });
       }
     },
     [feedClient],


### PR DESCRIPTION
This ensures that when the user clicks archive,
the items in the feed are visibly archived.

Without this, the items are archived but the view remains stale.

