### PR TITLE
fix: bundle client package using "compat" interop

### DIFF
--- a/.changeset/fair-masks-whisper.md
+++ b/.changeset/fair-masks-whisper.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: bundle client package using "compat" interop

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -30,15 +30,8 @@ class ApiClient {
     this.apiKey = options.apiKey;
     this.userToken = options.userToken || null;
 
-    // Create a retryable axios client, but account for issues where the axios export is not
-    // the default in certain bundlers (Webpack).
-    //
-    // NOTE: This is a temporary fix that exists because of this issue:
-    // https://github.com/axios/axios/issues/6591
-    const axiosInstance = // @ts-expect-error Fixing the issue described above
-      (axios.default ? axios.default : axios) as AxiosStatic;
-
-    this.axiosClient = axiosInstance.create({
+    // Create a retryable axios client
+    this.axiosClient = axios.create({
       baseURL: this.host,
       headers: {
         Accept: "application/json",

--- a/packages/client/vite.config.mts
+++ b/packages/client/vite.config.mts
@@ -28,6 +28,7 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
         output: {
+          interop: "compat",
           entryFileNames: () => {
             return `[name].${CJS ? "js" : "mjs"}`;
           },


### PR DESCRIPTION
#261 fixed an issue whereby Axios was imported incorrectly in the CJS bundle of our `client` package. We just learned that the same issue applies to `axios-retry`. [axios-retry’s README](https://github.com/softonic/axios-retry/blob/4c38b77bce745f6d077a55c5ac02aafe9be72dc1/README.md?plain=1#L16-L17) even indicates that CJS builds should import it using `require('axios-retry').default` rather than `require('axios-retry')`.

Rather than apply the same workaround to `axios-retry`, I’m pretty certain we can instead leverage [Rollup’s `output.interop` option](https://rollupjs.org/configuration-options/#output-interop) and set it to `"compat"`. This will make it so that Rollup automatically checks for a `default` property on imported modules. We already use the `"compat"` interop mode in our `expo`, `react`, `react-core`, and `react-native` packages, so I think it should be safe to use in `client`.

My plan is to cut a pre-release and have the customer test out this build.

## Bundled output of `api.ts`

### Before

#### CJS

```js
"use strict";
var a = Object.defineProperty;
var n = (s, e, t) =>
  e in s
    ? a(s, e, { enumerable: !0, configurable: !0, writable: !0, value: t })
    : (s[e] = t);
var r = (s, e, t) => n(s, typeof e != "symbol" ? e + "" : e, t);
Object.defineProperties(exports, {
  __esModule: { value: !0 },
  [Symbol.toStringTag]: { value: "Module" },
});
const i = require("axios"),
  o = require("axios-retry"),
  u = require("phoenix");
class c {
  constructor(e) {
    r(this, "host");
    r(this, "apiKey");
    r(this, "userToken");
    r(this, "axiosClient");
    r(this, "socket");
    (this.host = e.host),
      (this.apiKey = e.apiKey),
      (this.userToken = e.userToken || null);
    const t = i.default ? i.default : i;
    (this.axiosClient = t.create({
      baseURL: this.host,
      headers: {
        Accept: "application/json",
        "Content-Type": "application/json",
        Authorization: `Bearer ${this.apiKey}`,
        "X-Knock-User-Token": this.userToken,
      },
    })),
      typeof window < "u" &&
        (this.socket = new u.Socket(
          `${this.host.replace("http", "ws")}/ws/v1`,
          { params: { user_token: this.userToken, api_key: this.apiKey } },
        )),
      o(this.axiosClient, {
        retries: 3,
        retryCondition: this.canRetryRequest,
        retryDelay: o.exponentialDelay,
      });
  }
  async makeRequest(e) {
    try {
      const t = await this.axiosClient(e);
      return {
        statusCode: t.status < 300 ? "ok" : "error",
        body: t.data,
        error: void 0,
        status: t.status,
      };
    } catch (t) {
      return (
        console.error(t),
        { statusCode: "error", status: 500, body: void 0, error: t }
      );
    }
  }
  canRetryRequest(e) {
    return o.isNetworkError(e)
      ? !0
      : e.response
        ? (e.response.status >= 500 && e.response.status <= 599) ||
          e.response.status === 429
        : !1;
  }
}
exports.default = c;
//# sourceMappingURL=api.js.map
```

#### ESM

```js
var a = Object.defineProperty;
var n = (s, e, t) => e in s ? a(s, e, { enumerable: !0, configurable: !0, writable: !0, value: t }) : s[e] = t;
var r = (s, e, t) => n(s, typeof e != "symbol" ? e + "" : e, t);
import o from "axios";
import i from "axios-retry";
import { Socket as u } from "phoenix";
class y {
  constructor(e) {
    r(this, "host");
    r(this, "apiKey");
    r(this, "userToken");
    r(this, "axiosClient");
    r(this, "socket");
    this.host = e.host, this.apiKey = e.apiKey, this.userToken = e.userToken || null;
    const t = (
      // @ts-expect-error Fixing the issue described above
      o.default ? o.default : o
    );
    this.axiosClient = t.create({
      baseURL: this.host,
      headers: {
        Accept: "application/json",
        "Content-Type": "application/json",
        Authorization: `Bearer ${this.apiKey}`,
        "X-Knock-User-Token": this.userToken
      }
    }), typeof window < "u" && (this.socket = new u(`${this.host.replace("http", "ws")}/ws/v1`, {
      params: {
        user_token: this.userToken,
        api_key: this.apiKey
      }
    })), i(this.axiosClient, {
      retries: 3,
      retryCondition: this.canRetryRequest,
      retryDelay: i.exponentialDelay
    });
  }
  async makeRequest(e) {
    try {
      const t = await this.axiosClient(e);
      return {
        statusCode: t.status < 300 ? "ok" : "error",
        body: t.data,
        error: void 0,
        status: t.status
      };
    } catch (t) {
      return console.error(t), {
        statusCode: "error",
        status: 500,
        body: void 0,
        error: t
      };
    }
  }
  canRetryRequest(e) {
    return i.isNetworkError(e) ? !0 : e.response ? e.response.status >= 500 && e.response.status <= 599 || e.response.status === 429 : !1;
  }
}
export {
  y as default
};
//# sourceMappingURL=api.mjs.map
```

### After

#### CJS

```js
"use strict";
var i = Object.defineProperty;
var n = (t, e, s) =>
  e in t
    ? i(t, e, { enumerable: !0, configurable: !0, writable: !0, value: s })
    : (t[e] = s);
var r = (t, e, s) => n(t, typeof e != "symbol" ? e + "" : e, s);
Object.defineProperties(exports, {
  __esModule: { value: !0 },
  [Symbol.toStringTag]: { value: "Module" },
});
const u = require("axios"),
  l = require("axios-retry"),
  c = require("phoenix"),
  a = (t) => (t && typeof t == "object" && "default" in t ? t : { default: t }),
  p = a(u),
  o = a(l);
class d {
  constructor(e) {
    r(this, "host");
    r(this, "apiKey");
    r(this, "userToken");
    r(this, "axiosClient");
    r(this, "socket");
    (this.host = e.host),
      (this.apiKey = e.apiKey),
      (this.userToken = e.userToken || null),
      (this.axiosClient = p.default.create({
        baseURL: this.host,
        headers: {
          Accept: "application/json",
          "Content-Type": "application/json",
          Authorization: `Bearer ${this.apiKey}`,
          "X-Knock-User-Token": this.userToken,
        },
      })),
      typeof window < "u" &&
        (this.socket = new c.Socket(
          `${this.host.replace("http", "ws")}/ws/v1`,
          { params: { user_token: this.userToken, api_key: this.apiKey } },
        )),
      o.default(this.axiosClient, {
        retries: 3,
        retryCondition: this.canRetryRequest,
        retryDelay: o.default.exponentialDelay,
      });
  }
  async makeRequest(e) {
    try {
      const s = await this.axiosClient(e);
      return {
        statusCode: s.status < 300 ? "ok" : "error",
        body: s.data,
        error: void 0,
        status: s.status,
      };
    } catch (s) {
      return (
        console.error(s),
        { statusCode: "error", status: 500, body: void 0, error: s }
      );
    }
  }
  canRetryRequest(e) {
    return o.default.isNetworkError(e)
      ? !0
      : e.response
        ? (e.response.status >= 500 && e.response.status <= 599) ||
          e.response.status === 429
        : !1;
  }
}
exports.default = d;
//# sourceMappingURL=api.js.map
```

#### ESM

```js
var i = Object.defineProperty;
var a = (s, e, t) => e in s ? i(s, e, { enumerable: !0, configurable: !0, writable: !0, value: t }) : s[e] = t;
var r = (s, e, t) => a(s, typeof e != "symbol" ? e + "" : e, t);
import n from "axios";
import o from "axios-retry";
import { Socket as u } from "phoenix";
class y {
  constructor(e) {
    r(this, "host");
    r(this, "apiKey");
    r(this, "userToken");
    r(this, "axiosClient");
    r(this, "socket");
    this.host = e.host, this.apiKey = e.apiKey, this.userToken = e.userToken || null, this.axiosClient = n.create({
      baseURL: this.host,
      headers: {
        Accept: "application/json",
        "Content-Type": "application/json",
        Authorization: `Bearer ${this.apiKey}`,
        "X-Knock-User-Token": this.userToken
      }
    }), typeof window < "u" && (this.socket = new u(`${this.host.replace("http", "ws")}/ws/v1`, {
      params: {
        user_token: this.userToken,
        api_key: this.apiKey
      }
    })), o(this.axiosClient, {
      retries: 3,
      retryCondition: this.canRetryRequest,
      retryDelay: o.exponentialDelay
    });
  }
  async makeRequest(e) {
    try {
      const t = await this.axiosClient(e);
      return {
        statusCode: t.status < 300 ? "ok" : "error",
        body: t.data,
        error: void 0,
        status: t.status
      };
    } catch (t) {
      return console.error(t), {
        statusCode: "error",
        status: 500,
        body: void 0,
        error: t
      };
    }
  }
  canRetryRequest(e) {
    return o.isNetworkError(e) ? !0 : e.response ? e.response.status >= 500 && e.response.status <= 599 || e.response.status === 429 : !1;
  }
}
export {
  y as default
};
//# sourceMappingURL=api.mjs.map
```
