### PR TITLE
fix(KNO-7439): engagement_status in BulkUpdateMessagesInChannelProperties type

### DIFF
--- a/.changeset/poor-colts-work.md
+++ b/.changeset/poor-colts-work.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: engagement_status in BulkUpdateMessagesInChannelProperties type

--- a/packages/client/src/clients/messages/interfaces.ts
+++ b/packages/client/src/clients/messages/interfaces.ts
@@ -47,7 +47,15 @@ export type BulkUpdateMessagesInChannelProperties = {
   status: "seen" | "read" | "archive";
   options: {
     user_ids?: string[];
-    engagement_status?: "seen" | "read" | "unseen" | "unread";
+    engagement_status?:
+      | "seen"
+      | "read"
+      | "archived"
+      | "unseen"
+      | "unread"
+      | "unarchived"
+      | "interacted"
+      | "link_clicked";
     archived?: "exclude" | "include" | "only";
     has_tenant?: boolean;
     tenants?: string[];


### PR DESCRIPTION
This PR updates the `BulkUpdateMessagesInChannelProperties` type to include the missing `"archived"`, `"unarchived"`, `"interacted"`, and `"link_clicked"` values for `engagement_status`.