### PR TITLE
chore: render body in ootb components as inner html

### DIFF
--- a/packages/react/src/modules/in-app-messages/components/Banner/Banner.tsx
+++ b/packages/react/src/modules/in-app-messages/components/Banner/Banner.tsx
@@ -70,9 +70,11 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
   ...props
 }) => {
   return (
-    <div className={clsx("knock-iam-banner__body", className)} {...props}>
-      {body}
-    </div>
+    <div
+      className={clsx("knock-iam-banner__body", className)}
+      dangerouslySetInnerHTML={{ __html: body }}
+      {...props}
+    />
   );
 };
 Body.displayName = "BannerView.Body";

--- a/packages/react/src/modules/in-app-messages/components/Banner/styles.css
+++ b/packages/react/src/modules/in-app-messages/components/Banner/styles.css
@@ -24,6 +24,12 @@
   font-weight: var(--knock-weight-regular);
   line-height: var(--knock-leading-3);
 }
+.knock-iam-banner__body > :first-child {
+  margin-top: 0;
+}
+.knock-iam-banner__body > :last-child {
+  margin-bottom: 0;
+}
 .knock-iam-banner__actions {
   display: flex;
   align-items: center;

--- a/packages/react/src/modules/in-app-messages/components/Card/Card.tsx
+++ b/packages/react/src/modules/in-app-messages/components/Card/Card.tsx
@@ -93,9 +93,11 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
   ...props
 }) => {
   return (
-    <div className={clsx("knock-iam-card__body", className)} {...props}>
-      {body}
-    </div>
+    <div
+      className={clsx("knock-iam-card__body", className)}
+      dangerouslySetInnerHTML={{ __html: body }}
+      {...props}
+    />
   );
 };
 Body.displayName = "CardView.Body";

--- a/packages/react/src/modules/in-app-messages/components/Card/styles.css
+++ b/packages/react/src/modules/in-app-messages/components/Card/styles.css
@@ -40,6 +40,12 @@
   font-weight: var(--knock-weight-regular);
   line-height: var(--knock-leading-3);
 }
+.knock-iam-card__body > :first-child {
+  margin-top: 0;
+}
+.knock-iam-card__body > :last-child {
+  margin-bottom: 0;
+}
 .knock-iam-card__actions {
   display: flex;
   align-items: center;

--- a/packages/react/src/modules/in-app-messages/components/Modal/Modal.tsx
+++ b/packages/react/src/modules/in-app-messages/components/Modal/Modal.tsx
@@ -120,10 +120,9 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
   return (
     <Dialog.Description
       className={clsx("knock-iam-modal__body", className)}
+      dangerouslySetInnerHTML={{ __html: body }}
       {...props}
-    >
-      {body}
-    </Dialog.Description>
+    />
   );
 };
 Body.displayName = "ModalView.Body";

--- a/packages/react/src/modules/in-app-messages/components/Modal/styles.css
+++ b/packages/react/src/modules/in-app-messages/components/Modal/styles.css
@@ -41,6 +41,12 @@
   line-height: var(--knock-leading-3);
   margin: 0;
 }
+.knock-iam-modal__body > :first-child {
+  margin-top: 0;
+}
+.knock-iam-modal__body > :last-child {
+  margin-bottom: 0;
+}
 .knock-iam-modal__actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### What changed?
Following the update that converted the body fields of OOTB message types to markdown (https://github.com/knocklabs/control/pull/4362), this PR now renders the rendered body/html content as an inner html in the components. This should handle the rendered content whether it was a text or markdown field.

### Tasks
[KNO-7559](https://linear.app/knock/issue/KNO-7559/[sdk]-change-ootb-message-type-body-fields-to-markdown)

### Screenshots or Loom

![CleanShot 2025-01-08 at 10 36 55@2x](https://github.com/user-attachments/assets/b9e0f98e-ab84-400c-8daa-601973a1e6cf)
