### PR TITLE
fix: allow falsey userIds for auth and gracefully handle

### DIFF
--- a/.changeset/healthy-ladybugs-drum.md
+++ b/.changeset/healthy-ladybugs-drum.md
@@ -1,0 +1,6 @@
+---
+"nextjs-example": patch
+"@knocklabs/client": patch
+---
+
+fix: ensure feed can render with empty/missing userId values

--- a/examples/nextjs-example/next-env.d.ts
+++ b/examples/nextjs-example/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/examples/nextjs-example/pages/api/identify.ts
+++ b/examples/nextjs-example/pages/api/identify.ts
@@ -26,14 +26,19 @@ export default async function handler(
       name: name || faker.person.fullName(),
     });
 
-    const userToken = await Knock.signUserToken(userId, {
-      expiresInSeconds: process.env.KNOCK_TOKEN_EXPIRES_IN_SECONDS
-        ? Number(process.env.KNOCK_TOKEN_EXPIRES_IN_SECONDS)
-        : 3600,
-    });
+    let userToken = undefined;
+
+    if (process.env.KNOCK_SIGNING_KEY) {
+      userToken = await Knock.signUserToken(userId, {
+        expiresInSeconds: process.env.KNOCK_TOKEN_EXPIRES_IN_SECONDS
+          ? Number(process.env.KNOCK_TOKEN_EXPIRES_IN_SECONDS)
+          : 3600,
+      });
+    }
 
     return res.status(200).json({ error: null, user: knockUser, userToken });
   } catch (error) {
+    console.error(error);
     return res.status(500).json({
       error: (error as Error).message || (error as Error).toString(),
       user: null,

--- a/examples/nextjs-example/pages/api/notify.ts
+++ b/examples/nextjs-example/pages/api/notify.ts
@@ -21,7 +21,7 @@ export default async function handler(
   const { message, showToast, userId, tenant, templateType } = req.body;
 
   try {
-    await knockClient.notify(KNOCK_WORKFLOW, {
+    const response = await knockClient.workflows.trigger(KNOCK_WORKFLOW, {
       recipients: [userId],
       actor: userId,
       tenant,
@@ -32,7 +32,7 @@ export default async function handler(
       },
     });
 
-    return res.status(200).json({ error: null });
+    return res.status(200).json({ error: null, response });
   } catch (error) {
     return res.status(500).json({
       error: (error as Error).message || (error as Error).toString(),

--- a/examples/nextjs-example/pages/index.tsx
+++ b/examples/nextjs-example/pages/index.tsx
@@ -1,13 +1,4 @@
-import {
-  Box,
-  Flex,
-  Heading,
-  Icon,
-  Link,
-  Select,
-  Spinner,
-  Text,
-} from "@chakra-ui/react";
+import { Box, Flex, Heading, Icon, Link, Select, Text } from "@chakra-ui/react";
 import {
   KnockFeedProvider,
   KnockProvider,
@@ -32,7 +23,7 @@ const TenantLabels = {
 };
 
 export default function Home() {
-  const { userId, isLoading, userToken } = useIdentify();
+  const { userId, userToken } = useIdentify();
   const [tenant, setTenant] = useState(Tenants.TeamA);
 
   const tokenRefreshHandler = useCallback(async () => {
@@ -42,19 +33,6 @@ export default function Home() {
 
     return json.userToken;
   }, [userId]);
-
-  if (isLoading) {
-    return (
-      <Flex
-        alignItems="center"
-        justifyContent="center"
-        width="100vw"
-        height="100vh"
-      >
-        <Spinner />
-      </Flex>
-    );
-  }
 
   return (
     <KnockProvider

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -48,16 +48,6 @@ class Knock {
   }
 
   client() {
-    if (!this.userId) {
-      console.warn(
-        `[Knock] You must call authenticate(userId, userToken) first before trying to make a request.
-        Typically you'll see this message when you're creating a feed instance before having called
-        authenticate with a user Id and token. That means we won't know who to issue the request
-        to Knock on behalf of.
-        `,
-      );
-    }
-
     // Initiate a new API client if we don't have one yet
     if (!this.apiClient) {
       this.apiClient = this.createApiClient();


### PR DESCRIPTION
Currently, we require that a `userId` must be set in order to initialize Knock. This means that our customers have to wrap their `KnockProvider` in conditional logic if the user they're authenticating is not available at render.

We previously made the entire client library resilient to userId and userToken changes; gracefully reconnecting and reinitializing when that happens.

This PR changes the behavior of the Feed instance so that when unauthenticated no feed calls or socket connections are initialized. This makes it so that `undefined` can be passed the `userId` and feed clients can be initialized without any fetches, and therefore errors, occurring on the client.

I also took a moment here to fix the logic with badge counts where bulk archiving items could lead to negative badge counts/metadata being set. An obvious bug!