### PR TITLE
fix: ensure userId can be null or undefined on init now

### DIFF
--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -20,7 +20,7 @@ const DEFAULT_HOST = "https://api.knock.app";
 class Knock {
   public host: string;
   private apiClient: ApiClient | null = null;
-  public userId: string | undefined;
+  public userId: string | undefined | null;
   public userToken?: string;
   public logLevel?: LogLevel;
   private tokenExpirationTimer: ReturnType<typeof setTimeout> | null = null;
@@ -63,8 +63,8 @@ class Knock {
     the userToken must be specified.
   */
   authenticate(
-    userId: string,
-    userToken?: string,
+    userId: Knock["userId"],
+    userToken?: Knock["userToken"],
     options?: AuthenticateOptions,
   ) {
     let reinitializeApi = false;

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -18,14 +18,12 @@ export interface KnockProviderProps {
   apiKey: string;
   host?: string;
   // Authentication props
-  userId: string;
-  userToken?: string;
+  userId: Knock["userId"];
+  userToken?: Knock["userToken"];
   onUserTokenExpiring?: AuthenticateOptions["onUserTokenExpiring"];
   timeBeforeExpirationInMs?: AuthenticateOptions["timeBeforeExpirationInMs"];
-
   // i18n translations
   i18n?: I18nContent;
-
   logLevel?: LogLevel;
 }
 

--- a/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
+++ b/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
@@ -5,8 +5,8 @@ import { useStableOptions } from "../../core";
 
 function authenticateWithOptions(
   knock: Knock,
-  userId: string,
-  userToken?: string,
+  userId: Knock["userId"],
+  userToken?: Knock["userToken"],
   options: AuthenticateOptions = {},
 ) {
   knock.authenticate(userId, userToken, {
@@ -20,8 +20,8 @@ export type AuthenticatedKnockClientOptions = KnockOptions &
 
 function useAuthenticatedKnockClient(
   apiKey: string,
-  userId: string,
-  userToken?: string,
+  userId: Knock["userId"],
+  userToken?: Knock["userToken"],
   options: AuthenticatedKnockClientOptions = {},
 ) {
   const knockRef = React.useRef<Knock | undefined>();


### PR DESCRIPTION
I missed this in my last round of changes, but we need to ensure the types here can accept `string or undefined or null` for the `userId`.