### PR TITLE
feat(KNO-7619): add getTeams and getChannels to MsTeamsClient

### DIFF
--- a/.changeset/tall-rocks-help.md
+++ b/.changeset/tall-rocks-help.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+add getTeams and getChannels to MsTeamsClient

--- a/packages/client/src/clients/ms-teams/index.ts
+++ b/packages/client/src/clients/ms-teams/index.ts
@@ -3,6 +3,8 @@ import { AuthCheckInput, RevokeAccessTokenInput } from "../../interfaces";
 import Knock from "../../knock";
 import { TENANT_OBJECT_COLLECTION } from "../objects/constants";
 
+import { GetMsTeamsTeamsInput, GetMsTeamsTeamsResponse } from "./interfaces";
+
 class MsTeamsClient {
   private instance: Knock;
 
@@ -20,6 +22,33 @@ class MsTeamsClient {
           collection: TENANT_OBJECT_COLLECTION,
         },
         channel_id: knockChannelId,
+      },
+    });
+
+    return this.handleResponse(result);
+  }
+
+  async getTeams(
+    input: GetMsTeamsTeamsInput,
+  ): Promise<GetMsTeamsTeamsResponse> {
+    const { knockChannelId, tenantId } = input;
+    const queryOptions = input.queryOptions || {};
+
+    const result = await this.instance.client().makeRequest({
+      method: "GET",
+      url: `/v1/providers/ms-teams/${knockChannelId}/teams`,
+      params: {
+        ms_teams_tenant_object: {
+          object_id: tenantId,
+          collection: TENANT_OBJECT_COLLECTION,
+        },
+        query_options: {
+          $filter: queryOptions.$filter,
+          $select: queryOptions.$select,
+          $top: queryOptions.$top,
+          $skiptoken: queryOptions.$skiptoken,
+          $count: queryOptions.$count,
+        },
       },
     });
 

--- a/packages/client/src/clients/ms-teams/index.ts
+++ b/packages/client/src/clients/ms-teams/index.ts
@@ -36,7 +36,7 @@ class MsTeamsClient {
   async getTeams(
     input: GetMsTeamsTeamsInput,
   ): Promise<GetMsTeamsTeamsResponse> {
-    const { knockChannelId, tenantId } = input;
+    const { knockChannelId, tenant: tenantId } = input;
     const queryOptions = input.queryOptions || {};
 
     const result = await this.instance.client().makeRequest({
@@ -62,7 +62,7 @@ class MsTeamsClient {
   async getChannels(
     input: GetMsTeamsChannelsInput,
   ): Promise<GetMsTeamsChannelsResponse> {
-    const { knockChannelId, tenantId } = input;
+    const { knockChannelId, tenant: tenantId } = input;
     const queryOptions = input.queryOptions || {};
 
     const result = await this.instance.client().makeRequest({

--- a/packages/client/src/clients/ms-teams/index.ts
+++ b/packages/client/src/clients/ms-teams/index.ts
@@ -3,7 +3,12 @@ import { AuthCheckInput, RevokeAccessTokenInput } from "../../interfaces";
 import Knock from "../../knock";
 import { TENANT_OBJECT_COLLECTION } from "../objects/constants";
 
-import { GetMsTeamsTeamsInput, GetMsTeamsTeamsResponse } from "./interfaces";
+import {
+  GetMsTeamsChannelsInput,
+  GetMsTeamsChannelsResponse,
+  GetMsTeamsTeamsInput,
+  GetMsTeamsTeamsResponse,
+} from "./interfaces";
 
 class MsTeamsClient {
   private instance: Knock;
@@ -47,6 +52,30 @@ class MsTeamsClient {
           $select: queryOptions.$select,
           $top: queryOptions.$top,
           $skiptoken: queryOptions.$skiptoken,
+        },
+      },
+    });
+
+    return this.handleResponse(result);
+  }
+
+  async getChannels(
+    input: GetMsTeamsChannelsInput,
+  ): Promise<GetMsTeamsChannelsResponse> {
+    const { knockChannelId, tenantId } = input;
+    const queryOptions = input.queryOptions || {};
+
+    const result = await this.instance.client().makeRequest({
+      method: "GET",
+      url: `/v1/providers/ms-teams/${knockChannelId}/channels`,
+      params: {
+        ms_teams_tenant_object: {
+          object_id: tenantId,
+          collection: TENANT_OBJECT_COLLECTION,
+        },
+        query_options: {
+          $filter: queryOptions.$filter,
+          $select: queryOptions.$select,
         },
       },
     });

--- a/packages/client/src/clients/ms-teams/index.ts
+++ b/packages/client/src/clients/ms-teams/index.ts
@@ -47,7 +47,6 @@ class MsTeamsClient {
           $select: queryOptions.$select,
           $top: queryOptions.$top,
           $skiptoken: queryOptions.$skiptoken,
-          $count: queryOptions.$count,
         },
       },
     });

--- a/packages/client/src/clients/ms-teams/index.ts
+++ b/packages/client/src/clients/ms-teams/index.ts
@@ -62,7 +62,7 @@ class MsTeamsClient {
   async getChannels(
     input: GetMsTeamsChannelsInput,
   ): Promise<GetMsTeamsChannelsResponse> {
-    const { knockChannelId, tenant: tenantId } = input;
+    const { knockChannelId, teamId, tenant: tenantId } = input;
     const queryOptions = input.queryOptions || {};
 
     const result = await this.instance.client().makeRequest({
@@ -73,6 +73,7 @@ class MsTeamsClient {
           object_id: tenantId,
           collection: TENANT_OBJECT_COLLECTION,
         },
+        team_id: teamId,
         query_options: {
           $filter: queryOptions.$filter,
           $select: queryOptions.$select,

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -21,7 +21,7 @@ export type GetMsTeamsChannelsInput = {
 
 export type GetMsTeamsTeamsResponse = {
   ms_teams_teams: MsTeamsTeam[];
-  next_link: string | null;
+  skip_token: string | null;
 };
 
 export type GetMsTeamsChannelsResponse = {

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -15,6 +15,21 @@ export type GetMsTeamsTeamsResponse = {
   next_link: string | null;
 };
 
+export type GetMsTeamsChannelsResponse = {
+  ms_teams_channels: MsTeamsChannel[];
+};
+
 export type MsTeamsTeam = {
-  id: string;
+  id?: string;
+  displayName?: string;
+  description?: string;
+};
+
+export type MsTeamsChannel = {
+  id?: string;
+  displayName?: string;
+  description?: string;
+  membershipType?: string;
+  isArchived?: boolean;
+  createdDateTime?: string;
 };

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -4,9 +4,8 @@ export type GetMsTeamsTeamsInput = {
   queryOptions?: {
     $filter?: string;
     $select?: string;
-    $top?: string;
+    $top?: number;
     $skiptoken?: string;
-    $count?: string;
   };
 };
 

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -1,0 +1,20 @@
+export type GetMsTeamsTeamsInput = {
+  tenantId: string;
+  knockChannelId: string;
+  queryOptions?: {
+    $filter?: string;
+    $select?: string;
+    $top?: string;
+    $skiptoken?: string;
+    $count?: string;
+  };
+};
+
+export type GetMsTeamsTeamsResponse = {
+  ms_teams_teams: MsTeamsTeam[];
+  next_link: string | null;
+};
+
+export type MsTeamsTeam = {
+  id: string;
+};

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -1,5 +1,5 @@
 export type GetMsTeamsTeamsInput = {
-  tenantId: string;
+  tenant: string;
   knockChannelId: string;
   queryOptions?: {
     $filter?: string;
@@ -10,7 +10,7 @@ export type GetMsTeamsTeamsInput = {
 };
 
 export type GetMsTeamsChannelsInput = {
-  tenantId: string;
+  tenant: string;
   knockChannelId: string;
   teamId: string;
   queryOptions?: {

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -10,6 +10,16 @@ export type GetMsTeamsTeamsInput = {
   };
 };
 
+export type GetMsTeamsChannelsInput = {
+  tenantId: string;
+  knockChannelId: string;
+  teamId: string;
+  queryOptions?: {
+    $filter?: string;
+    $select?: string;
+  };
+};
+
 export type GetMsTeamsTeamsResponse = {
   ms_teams_teams: MsTeamsTeam[];
   next_link: string | null;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,6 +10,7 @@ export * from "./clients/preferences/interfaces";
 export * from "./clients/slack";
 export * from "./clients/slack/interfaces";
 export * from "./clients/ms-teams";
+export * from "./clients/ms-teams/interfaces";
 export * from "./clients/users";
 export * from "./clients/users/interfaces";
 export * from "./clients/messages";


### PR DESCRIPTION
This PR updates `MsTeamsClient` with two new functions, `getTeams` and `getChannels`, for use with TeamsKit. These functions make network requests to upcoming API endpoints.