### PR TITLE
feat(KNO-7622): add TeamsKit hooks for teams and channels

### DIFF
--- a/.changeset/shy-impalas-wave.md
+++ b/.changeset/shy-impalas-wave.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+---
+
+add TeamsKit hooks for teams and channels

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -2,7 +2,9 @@ export type MsTeamsChannelConnection = {
   ms_teams_tenant_id?: string;
   ms_teams_channel_id?: string;
   ms_teams_user_id?: null;
-  incoming_webhook?: string;
+  incoming_webhook?: {
+    url: string;
+  };
 };
 
 export type GetMsTeamsTeamsInput = {

--- a/packages/client/src/clients/ms-teams/interfaces.ts
+++ b/packages/client/src/clients/ms-teams/interfaces.ts
@@ -1,3 +1,10 @@
+export type MsTeamsChannelConnection = {
+  ms_teams_tenant_id?: string;
+  ms_teams_channel_id?: string;
+  ms_teams_user_id?: null;
+  incoming_webhook?: string;
+};
+
 export type GetMsTeamsTeamsInput = {
   tenant: string;
   knockChannelId: string;

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -3,3 +3,4 @@ export * from "./modules/feed";
 export * from "./modules/ms-teams";
 export * from "./modules/slack";
 export * from "./modules/i18n";
+export * from "./interfaces";

--- a/packages/react-core/src/interfaces.ts
+++ b/packages/react-core/src/interfaces.ts
@@ -1,0 +1,4 @@
+export type RecipientObject = {
+  objectId: string;
+  collection: string;
+};

--- a/packages/react-core/src/modules/i18n/languages/en.ts
+++ b/packages/react-core/src/modules/i18n/languages/en.ts
@@ -12,6 +12,7 @@ const en: I18nContent = {
     unread: "Unread",
     read: "Read",
     unseen: "Unseen",
+    msTeamsChannelSetError: "Error setting channel.",
     msTeamsConnect: "Connect to Microsoft Teams",
     msTeamsConnected: "Connected",
     msTeamsConnecting: "Connecting to Microsoft Teams…",

--- a/packages/react-core/src/modules/i18n/languages/index.ts
+++ b/packages/react-core/src/modules/i18n/languages/index.ts
@@ -13,6 +13,7 @@ export interface Translations {
   readonly unread: string;
   readonly read: string;
   readonly unseen: string;
+  readonly msTeamsChannelSetError: string;
   readonly msTeamsConnect: string;
   readonly msTeamsConnected: string;
   readonly msTeamsConnecting: string;

--- a/packages/react-core/src/modules/ms-teams/hooks/index.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useMsTeamsConnectionStatus } from "./useMsTeamsConnectionStatus";
 export { default as useMsTeamsAuth } from "./useMsTeamsAuth";
 export { default as useMsTeamsTeams } from "./useMsTeamsTeams";
+export { default as useMsTeamsChannels } from "./useMsTeamsChannels";

--- a/packages/react-core/src/modules/ms-teams/hooks/index.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useMsTeamsConnectionStatus } from "./useMsTeamsConnectionSta
 export { default as useMsTeamsAuth } from "./useMsTeamsAuth";
 export { default as useMsTeamsTeams } from "./useMsTeamsTeams";
 export { default as useMsTeamsChannels } from "./useMsTeamsChannels";
+export { default as useConnectedMsTeamsChannels } from "./useConnectedMsTeamsChannels";

--- a/packages/react-core/src/modules/ms-teams/hooks/index.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useMsTeamsConnectionStatus } from "./useMsTeamsConnectionStatus";
 export { default as useMsTeamsAuth } from "./useMsTeamsAuth";
+export { default as useMsTeamsTeams } from "./useMsTeamsTeams";

--- a/packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts
@@ -14,7 +14,7 @@ type UseConnectedMsTeamsChannelsOutput = {
   data: MsTeamsChannelConnection[] | null;
   updateConnectedChannels: (
     connectedChannels: MsTeamsChannelConnection[],
-  ) => void;
+  ) => Promise<void>;
   loading: boolean;
   error: string | null;
   updating: boolean;

--- a/packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts
@@ -35,8 +35,8 @@ function useConnectedMsTeamsChannels({
 
   const fetchAndSetConnectedChannels = useCallback(() => {
     setIsLoading(true);
-    const getConnectedChannels = async () =>
-      await knock.objects.getChannelData({
+    const getConnectedChannels = () =>
+      knock.objects.getChannelData({
         collection,
         objectId,
         channelId: knockMsTeamsChannelId,

--- a/packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts
@@ -1,0 +1,106 @@
+import { useKnockMsTeamsClient } from "..";
+import { MsTeamsChannelConnection } from "@knocklabs/client";
+import { useCallback, useEffect, useState } from "react";
+
+import { RecipientObject } from "../../..";
+import { useKnockClient } from "../../core";
+import { useTranslations } from "../../i18n";
+
+type UseConnectedMsTeamsChannelsProps = {
+  msTeamsChannelsRecipientObject: RecipientObject;
+};
+
+type UseConnectedMsTeamsChannelsOutput = {
+  data: MsTeamsChannelConnection[] | null;
+  updateConnectedChannels: (
+    connectedChannels: MsTeamsChannelConnection[],
+  ) => void;
+  loading: boolean;
+  error: string | null;
+  updating: boolean;
+};
+
+function useConnectedMsTeamsChannels({
+  msTeamsChannelsRecipientObject: { objectId, collection },
+}: UseConnectedMsTeamsChannelsProps): UseConnectedMsTeamsChannelsOutput {
+  const { t } = useTranslations();
+  const knock = useKnockClient();
+  const { connectionStatus, knockMsTeamsChannelId } = useKnockMsTeamsClient();
+  const [connectedChannels, setConnectedChannels] = useState<
+    null | MsTeamsChannelConnection[]
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const fetchAndSetConnectedChannels = useCallback(() => {
+    setIsLoading(true);
+    const getConnectedChannels = async () =>
+      await knock.objects.getChannelData({
+        collection,
+        objectId,
+        channelId: knockMsTeamsChannelId,
+      });
+
+    getConnectedChannels()
+      .then((res) => {
+        if (res?.data?.connections) {
+          setConnectedChannels(res?.data?.connections);
+        } else {
+          setConnectedChannels([]);
+        }
+        setError(null);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        setConnectedChannels([]);
+        setError(null);
+        setIsLoading(false);
+      });
+  }, [collection, knock.objects, knockMsTeamsChannelId, objectId]);
+
+  useEffect(() => {
+    if (
+      connectionStatus === "connected" &&
+      !connectedChannels &&
+      !error &&
+      !isLoading
+    ) {
+      fetchAndSetConnectedChannels();
+    }
+  }, [
+    connectedChannels,
+    fetchAndSetConnectedChannels,
+    isLoading,
+    error,
+    connectionStatus,
+  ]);
+
+  const updateConnectedChannels = async (
+    channelsToSendToKnock: MsTeamsChannelConnection[],
+  ) => {
+    setIsUpdating(true);
+    try {
+      await knock.objects.setChannelData({
+        objectId,
+        collection,
+        channelId: knockMsTeamsChannelId,
+        data: { connections: channelsToSendToKnock },
+      });
+      fetchAndSetConnectedChannels();
+    } catch (_error) {
+      setError(t("msTeamsChannelSetError") || "");
+    }
+    setIsUpdating(false);
+  };
+
+  return {
+    data: connectedChannels,
+    updateConnectedChannels,
+    updating: isUpdating,
+    loading: isLoading,
+    error,
+  };
+}
+
+export default useConnectedMsTeamsChannels;

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
@@ -1,0 +1,7 @@
+import { useKnockClient } from "../../core";
+
+function useMsTeamsChannels() {
+  const knock = useKnockClient();
+}
+
+export default useMsTeamsChannels;

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
@@ -25,8 +25,8 @@ function useMsTeamsChannels({
   const knock = useKnockClient();
   const { knockMsTeamsChannelId, tenantId } = useKnockMsTeamsClient();
 
-  const fetchChannels = () => {
-    return knock.msTeams.getChannels({
+  const fetchChannels = () =>
+    knock.msTeams.getChannels({
       knockChannelId: knockMsTeamsChannelId,
       tenant: tenantId,
       teamId,
@@ -35,7 +35,6 @@ function useMsTeamsChannels({
         $select: queryOptions?.select,
       },
     });
-  };
 
   const { data, isLoading, isValidating, mutate } =
     useSWR<GetMsTeamsChannelsResponse>([QUERY_KEY, teamId], fetchChannels, {});

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
@@ -3,12 +3,13 @@ import useSWR from "swr";
 
 import { useKnockClient } from "../../core";
 import { useKnockMsTeamsClient } from "../context";
+import { MsTeamsChannelQueryOptions } from "../interfaces";
 
 const QUERY_KEY = "MS_TEAMS_CHANNELS";
 
 type UseMsTeamsChannelsProps = {
   teamId: string;
-  queryOptions?: {};
+  queryOptions?: MsTeamsChannelQueryOptions;
 };
 
 type UseMsTeamsChannelsOutput = {
@@ -19,6 +20,7 @@ type UseMsTeamsChannelsOutput = {
 
 function useMsTeamsChannels({
   teamId,
+  queryOptions,
 }: UseMsTeamsChannelsProps): UseMsTeamsChannelsOutput {
   const knock = useKnockClient();
   const { knockMsTeamsChannelId, tenantId } = useKnockMsTeamsClient();
@@ -28,6 +30,7 @@ function useMsTeamsChannels({
       knockChannelId: knockMsTeamsChannelId,
       tenant: tenantId,
       teamId,
+      queryOptions,
     });
   };
 

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
@@ -30,7 +30,10 @@ function useMsTeamsChannels({
       knockChannelId: knockMsTeamsChannelId,
       tenant: tenantId,
       teamId,
-      queryOptions,
+      queryOptions: {
+        $filter: queryOptions?.filter,
+        $select: queryOptions?.select,
+      },
     });
   };
 

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
@@ -38,7 +38,7 @@ function useMsTeamsChannels({
   };
 
   const { data, isLoading, isValidating, mutate } =
-    useSWR<GetMsTeamsChannelsResponse>([QUERY_KEY], fetchChannels, {});
+    useSWR<GetMsTeamsChannelsResponse>([QUERY_KEY, teamId], fetchChannels, {});
 
   return {
     data: data?.ms_teams_channels ?? [],

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts
@@ -1,7 +1,44 @@
-import { useKnockClient } from "../../core";
+import { GetMsTeamsChannelsResponse, MsTeamsChannel } from "@knocklabs/client";
+import useSWR from "swr";
 
-function useMsTeamsChannels() {
+import { useKnockClient } from "../../core";
+import { useKnockMsTeamsClient } from "../context";
+
+const QUERY_KEY = "MS_TEAMS_CHANNELS";
+
+type UseMsTeamsChannelsProps = {
+  teamId: string;
+  queryOptions?: {};
+};
+
+type UseMsTeamsChannelsOutput = {
+  data: MsTeamsChannel[];
+  isLoading: boolean;
+  refetch: () => void;
+};
+
+function useMsTeamsChannels({
+  teamId,
+}: UseMsTeamsChannelsProps): UseMsTeamsChannelsOutput {
   const knock = useKnockClient();
+  const { knockMsTeamsChannelId, tenantId } = useKnockMsTeamsClient();
+
+  const fetchChannels = () => {
+    return knock.msTeams.getChannels({
+      knockChannelId: knockMsTeamsChannelId,
+      tenant: tenantId,
+      teamId,
+    });
+  };
+
+  const { data, isLoading, isValidating, mutate } =
+    useSWR<GetMsTeamsChannelsResponse>([QUERY_KEY], fetchChannels, {});
+
+  return {
+    data: data?.ms_teams_channels ?? [],
+    isLoading: isLoading || isValidating,
+    refetch: () => mutate(),
+  };
 }
 
 export default useMsTeamsChannels;

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -47,8 +47,8 @@ function useMsTeamsTeams({
   const { knockMsTeamsChannelId, tenantId, connectionStatus } =
     useKnockMsTeamsClient();
 
-  const fetchTeams = (queryKey: QueryKey) => {
-    return knock.msTeams.getTeams({
+  const fetchTeams = (queryKey: QueryKey) =>
+    knock.msTeams.getTeams({
       knockChannelId: knockMsTeamsChannelId,
       tenant: tenantId,
       queryOptions: {
@@ -58,7 +58,6 @@ function useMsTeamsTeams({
         $select: queryOptions?.select,
       },
     });
-  };
 
   const { data, error, isLoading, isValidating, setSize, mutate } =
     useSWRInfinite<GetMsTeamsTeamsResponse>(getQueryKey, fetchTeams, {
@@ -88,7 +87,7 @@ function useMsTeamsTeams({
       teams.length < maxCount
     ) {
       // Fetch a page at a time until we have nothing else left to fetch
-      // or we've already hit the max amount of channels to fetch
+      // or we've already hit the max amount of teams to fetch
       setSize((size) => size + 1);
     }
   }, [

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -1,8 +1,115 @@
-import { useKnockClient } from "../../core";
+import { GetMsTeamsTeamsResponse, MsTeamsTeam } from "@knocklabs/client";
+import { useEffect, useMemo } from "react";
+import useSWRInfinite from "swr/infinite";
 
-function useMsTeamsTeams() {
+import { useKnockClient } from "../../core";
+import { useKnockMsTeamsClient } from "../context";
+
+const MAX_COUNT = 1000;
+
+const QUERY_KEY = "MS_TEAMS_TEAMS";
+
+type UseMsTeamsTeamsProps = {
+  queryOptions?: { maxCount?: number };
+};
+
+type UseMsTeamsTeamsOutput = {
+  data: MsTeamsTeam[];
+  isLoading: boolean;
+  refetch: () => void;
+};
+
+type QueryKey = [key: string, skiptoken: string] | null;
+
+function getQueryKey(
+  pageIndex: number,
+  previousPageData: GetMsTeamsTeamsResponse,
+): QueryKey {
+  // First page so just pass empty
+  if (pageIndex === 0) {
+    return [QUERY_KEY, ""];
+  }
+
+  // If there's no more data then return an empty next skiptoken
+  if (previousPageData && ["", null].includes(previousPageData.skip_token)) {
+    return null;
+  }
+
+  // Next skiptoken exists so pass it
+  return [QUERY_KEY, previousPageData.skip_token ?? ""];
+}
+
+function useMsTeamsTeams({
+  queryOptions,
+}: UseMsTeamsTeamsProps): UseMsTeamsTeamsOutput {
   const knock = useKnockClient();
-  return null;
+  const { knockMsTeamsChannelId, tenantId, connectionStatus } =
+    useKnockMsTeamsClient();
+
+  const fetchTeams = (queryKey: QueryKey) => {
+    return knock.msTeams.getTeams({
+      knockChannelId: knockMsTeamsChannelId,
+      tenant: tenantId,
+      queryOptions: {
+        // TODO More default query options?
+        $skiptoken: queryKey?.[1],
+      },
+    });
+  };
+
+  const { data, error, isLoading, isValidating, size, setSize, mutate } =
+    useSWRInfinite<GetMsTeamsTeamsResponse>(getQueryKey, fetchTeams, {
+      initialSize: 0,
+    });
+
+  const currentPage = data?.length || 0;
+
+  const hasNextPage =
+    currentPage === 0 ||
+    (data &&
+      data[currentPage]?.skip_token &&
+      data[currentPage]?.skip_token !== "");
+
+  const teams = useMemo(
+    () =>
+      (data ?? [])
+        .flatMap((page) => page?.ms_teams_teams)
+        .filter((team) => !!team),
+    [data],
+  );
+
+  const maxCount = queryOptions?.maxCount || MAX_COUNT;
+
+  useEffect(() => {
+    if (
+      connectionStatus === "connected" &&
+      !error &&
+      hasNextPage &&
+      !isLoading &&
+      !isValidating &&
+      teams.length < maxCount
+    ) {
+      // Fetch a page at a time until we have nothing else left to fetch
+      // or we've already hit the max amount of channels to fetch
+      setSize(size + 1);
+    }
+  }, [
+    teams.length,
+    setSize,
+    size,
+    hasNextPage,
+    isLoading,
+    isValidating,
+    maxCount,
+    error,
+    connectionStatus,
+  ]);
+
+  return {
+    data: teams,
+    isLoading: isLoading || isValidating,
+    refetch: () => mutate(),
+  };
 }
 
 export default useMsTeamsTeams;

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -52,8 +52,10 @@ function useMsTeamsTeams({
       knockChannelId: knockMsTeamsChannelId,
       tenant: tenantId,
       queryOptions: {
-        ...queryOptions,
         $skiptoken: queryKey?.[1],
+        $top: queryOptions?.limitPerPage,
+        $filter: queryOptions?.filter,
+        $select: queryOptions?.select,
       },
     });
   };

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -60,18 +60,13 @@ function useMsTeamsTeams({
     });
   };
 
-  const { data, error, isLoading, isValidating, size, setSize, mutate } =
+  const { data, error, isLoading, isValidating, setSize, mutate } =
     useSWRInfinite<GetMsTeamsTeamsResponse>(getQueryKey, fetchTeams, {
       initialSize: 0,
     });
 
-  const currentPage = data?.length || 0;
-
-  const hasNextPage =
-    currentPage === 0 ||
-    (data &&
-      data[currentPage]?.skip_token &&
-      data[currentPage]?.skip_token !== "");
+  const lastPage = data?.at(-1);
+  const hasNextPage = lastPage === undefined || !!lastPage.skip_token;
 
   const teams = useMemo(
     () =>
@@ -94,12 +89,11 @@ function useMsTeamsTeams({
     ) {
       // Fetch a page at a time until we have nothing else left to fetch
       // or we've already hit the max amount of channels to fetch
-      setSize(size + 1);
+      setSize((size) => size + 1);
     }
   }, [
     teams.length,
     setSize,
-    size,
     hasNextPage,
     isLoading,
     isValidating,

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -4,13 +4,14 @@ import useSWRInfinite from "swr/infinite";
 
 import { useKnockClient } from "../../core";
 import { useKnockMsTeamsClient } from "../context";
+import { MsTeamsTeamQueryOptions } from "../interfaces";
 
 const MAX_COUNT = 1000;
 
 const QUERY_KEY = "MS_TEAMS_TEAMS";
 
 type UseMsTeamsTeamsProps = {
-  queryOptions?: { maxCount?: number };
+  queryOptions?: MsTeamsTeamQueryOptions;
 };
 
 type UseMsTeamsTeamsOutput = {
@@ -51,7 +52,7 @@ function useMsTeamsTeams({
       knockChannelId: knockMsTeamsChannelId,
       tenant: tenantId,
       queryOptions: {
-        // TODO More default query options?
+        ...queryOptions,
         $skiptoken: queryKey?.[1],
       },
     });

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -1,0 +1,8 @@
+import { useKnockClient } from "../../core";
+
+function useMsTeamsTeams() {
+  const knock = useKnockClient();
+  return null;
+}
+
+export default useMsTeamsTeams;

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -41,7 +41,7 @@ function getQueryKey(
 }
 
 function useMsTeamsTeams({
-  queryOptions,
+  queryOptions = {},
 }: UseMsTeamsTeamsProps): UseMsTeamsTeamsOutput {
   const knock = useKnockClient();
   const { knockMsTeamsChannelId, tenantId, connectionStatus } =

--- a/packages/react-core/src/modules/ms-teams/index.ts
+++ b/packages/react-core/src/modules/ms-teams/index.ts
@@ -1,2 +1,3 @@
 export * from "./context";
 export * from "./hooks";
+export * from "./interfaces";

--- a/packages/react-core/src/modules/ms-teams/interfaces.ts
+++ b/packages/react-core/src/modules/ms-teams/interfaces.ts
@@ -1,8 +1,8 @@
 export type MsTeamsTeamQueryOptions = {
-  $filter?: string;
-  $select?: string;
-  $top?: number;
-  $skiptoken?: string;
+  maxCount?: number;
+  limitPerPage?: number;
+  filter?: string;
+  select?: string;
 };
 
 export type MsTeamsChannelQueryOptions = {

--- a/packages/react-core/src/modules/ms-teams/interfaces.ts
+++ b/packages/react-core/src/modules/ms-teams/interfaces.ts
@@ -1,3 +1,10 @@
+export type MsTeamsTeamQueryOptions = {
+  $filter?: string;
+  $select?: string;
+  $top?: number;
+  $skiptoken?: string;
+};
+
 export type MsTeamsChannelQueryOptions = {
   $filter?: string;
   $select?: string;

--- a/packages/react-core/src/modules/ms-teams/interfaces.ts
+++ b/packages/react-core/src/modules/ms-teams/interfaces.ts
@@ -1,0 +1,4 @@
+export type MsTeamsChannelQueryOptions = {
+  $filter?: string;
+  $select?: string;
+};

--- a/packages/react-core/src/modules/ms-teams/interfaces.ts
+++ b/packages/react-core/src/modules/ms-teams/interfaces.ts
@@ -6,6 +6,6 @@ export type MsTeamsTeamQueryOptions = {
 };
 
 export type MsTeamsChannelQueryOptions = {
-  $filter?: string;
-  $select?: string;
+  filter?: string;
+  select?: string;
 };

--- a/packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts
+++ b/packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts
@@ -1,12 +1,13 @@
-import { ContainerObject, useKnockSlackClient } from "..";
+import { useKnockSlackClient } from "..";
 import { SlackChannelConnection } from "@knocklabs/client";
 import { useCallback, useEffect, useState } from "react";
 
+import { RecipientObject } from "../../..";
 import { useKnockClient } from "../../core";
 import { useTranslations } from "../../i18n";
 
 type UseConnectedSlackChannelsProps = {
-  slackChannelsRecipientObject: ContainerObject;
+  slackChannelsRecipientObject: RecipientObject;
 };
 
 type UseConnectedSlackChannelOutput = {

--- a/packages/react-core/src/modules/slack/interfaces.ts
+++ b/packages/react-core/src/modules/slack/interfaces.ts
@@ -1,3 +1,7 @@
+import type { RecipientObject } from "../../interfaces";
+
+export type ContainerObject = RecipientObject;
+
 export type SlackChannelQueryOptions = {
   maxCount?: number;
   limitPerPage?: number;

--- a/packages/react-core/src/modules/slack/interfaces.ts
+++ b/packages/react-core/src/modules/slack/interfaces.ts
@@ -1,8 +1,3 @@
-export type ContainerObject = {
-  objectId: string;
-  collection: string;
-};
-
 export type SlackChannelQueryOptions = {
   maxCount?: number;
   limitPerPage?: number;

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
@@ -1,6 +1,6 @@
 import { SlackChannelConnection } from "@knocklabs/client";
 import {
-  ContainerObject,
+  RecipientObject,
   SlackChannelQueryOptions,
   useConnectedSlackChannels,
   useKnockSlackClient,
@@ -35,7 +35,7 @@ export type SlackChannelComboboxInputMessages = {
 };
 
 export interface SlackChannelComboboxProps {
-  slackChannelsRecipientObject: ContainerObject;
+  slackChannelsRecipientObject: RecipientObject;
   queryOptions?: SlackChannelQueryOptions;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   inputContainerProps?: React.HTMLAttributes<HTMLDivElement>;


### PR DESCRIPTION
This PR adds three new hooks for use in TeamsKit:
- `useMsTeamsTeams`, which loads a list of teams for a tenant.
- `useMsTeamsChannels`, which loads a list of channels within a given team.
- `useConnectedMsTeamsChannels`, which returns the connections channel data for a recipient object, and allows updating the channel data.

These hooks are based on the existing SlackKit hooks `useSlackChannels` and `useConnectedSlackChannels`.

## Video

Here’s a quick Loom demonstrating these hooks:

https://www.loom.com/share/cd6ead2a92654dbca7ac3e3e6550505e?sid=d7fb9469-1828-4862-a62a-d022c29c5a2f