### PR TITLE
fix(KNO-7520): bundle client package using "compat" interop

### DIFF
--- a/.changeset/fair-masks-whisper.md
+++ b/.changeset/fair-masks-whisper.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: bundle client package using "compat" interop

--- a/.changeset/fair-masks-whisper.md
+++ b/.changeset/fair-masks-whisper.md
@@ -1,5 +1,0 @@
----
-"@knocklabs/client": patch
----
-
-fix: bundle client package using "compat" interop

--- a/.changeset/tall-scissors-reflect.md
+++ b/.changeset/tall-scissors-reflect.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: bundle client package using "compat" interop

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -30,15 +30,8 @@ class ApiClient {
     this.apiKey = options.apiKey;
     this.userToken = options.userToken || null;
 
-    // Create a retryable axios client, but account for issues where the axios export is not
-    // the default in certain bundlers (Webpack).
-    //
-    // NOTE: This is a temporary fix that exists because of this issue:
-    // https://github.com/axios/axios/issues/6591
-    const axiosInstance = // @ts-expect-error Fixing the issue described above
-      (axios.default ? axios.default : axios) as AxiosStatic;
-
-    this.axiosClient = axiosInstance.create({
+    // Create a retryable axios client
+    this.axiosClient = axios.create({
       baseURL: this.host,
       headers: {
         Accept: "application/json",

--- a/packages/client/vite.config.mts
+++ b/packages/client/vite.config.mts
@@ -28,6 +28,7 @@ export default defineConfig(({ mode }) => {
       },
       rollupOptions: {
         output: {
+          interop: "compat",
           entryFileNames: () => {
             return `[name].${CJS ? "js" : "mjs"}`;
           },


### PR DESCRIPTION
This PR cherry-picks commit bc99374, which updates the Client SDK with the same changes applied to the `main` branch by #315.