### PR TITLE
feat(KNO-7785): use SWR in useConnectedSlackChannels hook

### DIFF
--- a/.changeset/dirty-parents-add.md
+++ b/.changeset/dirty-parents-add.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react": patch
+---
+
+Use SWR to update connected channels in `SlackChannelCombobox`
+
+`SlackChannelCombobox` now uses [SWR](https://swr.vercel.app/) to retrieve and update connected Slack channels. There should be no change in the behavior of this component.

--- a/.changeset/polite-dodos-itch.md
+++ b/.changeset/polite-dodos-itch.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react-core": patch
+---
+
+Use SWR in `useConnectedSlackChannels` hook
+
+`useConnectedSlackChannels` now uses [SWR](https://swr.vercel.app/) under the hood. The returned array of connections (`data`) will now update optimistically when `updateConnectedChannels` is called.

--- a/packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts
+++ b/packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts
@@ -10,7 +10,7 @@ type UseConnectedSlackChannelsProps = {
   slackChannelsRecipientObject: RecipientObject;
 };
 
-type UseConnectedSlackChannelOutput = {
+type UseConnectedSlackChannelsOutput = {
   data: SlackChannelConnection[] | null;
   updateConnectedChannels: (
     connectedChannels: SlackChannelConnection[],
@@ -22,7 +22,7 @@ type UseConnectedSlackChannelOutput = {
 
 function useConnectedSlackChannels({
   slackChannelsRecipientObject: { objectId, collection },
-}: UseConnectedSlackChannelsProps): UseConnectedSlackChannelOutput {
+}: UseConnectedSlackChannelsProps): UseConnectedSlackChannelsOutput {
   const { t } = useTranslations();
   const knock = useKnockClient();
   const { connectionStatus, knockSlackChannelId } = useKnockSlackClient();

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
@@ -87,10 +87,6 @@ export const SlackChannelCombobox: FunctionComponent<
     updating: connectedChannelsUpdating,
   } = useConnectedSlackChannels({ slackChannelsRecipientObject });
 
-  const [currentConnectedChannels, setCurrentConnectedChannels] = useState<
-    SlackChannelConnection[] | null
-  >(null);
-
   useEffect(() => {
     if (comboboxListOpen) {
       // Timeout to allow for the state to update and the component to re-render
@@ -101,7 +97,9 @@ export const SlackChannelCombobox: FunctionComponent<
     }
   }, [comboboxListOpen]);
 
-  useEffect(() => {
+  const currentConnectedChannels = useMemo<
+    SlackChannelConnection[] | null
+  >(() => {
     // Used to make sure we're only showing currently available channels to select from.
     // There are cases where a channel is "connected" in Knock, but it wouldn't be
     // posting to it if the channel is private and the Slackbot doesn't belong to it,
@@ -110,12 +108,11 @@ export const SlackChannelCombobox: FunctionComponent<
       slackChannels.map((channel) => [channel.id, channel]),
     );
 
-    const channels =
+    return (
       connectedChannels?.filter((connectedChannel) => {
         return slackChannelsMap.has(connectedChannel.channel_id || "");
-      }) || [];
-
-    setCurrentConnectedChannels(channels);
+      }) || []
+    );
   }, [connectedChannels, slackChannels]);
 
   const inErrorState = useMemo(
@@ -220,7 +217,6 @@ export const SlackChannelCombobox: FunctionComponent<
         (connectedChannel) => connectedChannel.channel_id !== channelId,
       );
 
-      setCurrentConnectedChannels(channelsToSendToKnock);
       updateConnectedChannels(channelsToSendToKnock);
     } else {
       const channelsToSendToKnock = [
@@ -228,7 +224,6 @@ export const SlackChannelCombobox: FunctionComponent<
         { channel_id: channelId } as SlackChannelConnection,
       ];
 
-      setCurrentConnectedChannels(channelsToSendToKnock);
       updateConnectedChannels(channelsToSendToKnock);
     }
   };

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
@@ -97,9 +97,7 @@ export const SlackChannelCombobox: FunctionComponent<
     }
   }, [comboboxListOpen]);
 
-  const currentConnectedChannels = useMemo<
-    SlackChannelConnection[] | null
-  >(() => {
+  const currentConnectedChannels = useMemo<SlackChannelConnection[]>(() => {
     // Used to make sure we're only showing currently available channels to select from.
     // There are cases where a channel is "connected" in Knock, but it wouldn't be
     // posting to it if the channel is private and the Slackbot doesn't belong to it,


### PR DESCRIPTION
This PR updates the `useConnectedSlackChannels` hook so that it uses [SWR](https://swr.vercel.app/) under the hood. This allows us to optimistically update the returned array of connections when `updateConnectedChannels` is called.

We can also update `SlackChannelCombobox` to eliminate a `useState` hook that in effect implemented optimistic updates of the UI whenever `updateConnectedChannels` was called. There should be no change in the behavior of this component.

## Videos

### Success

https://github.com/user-attachments/assets/f6b5c5e8-c9dc-48b8-8610-96bc1f453b46

### Error

https://github.com/user-attachments/assets/333573b8-14a1-412e-b746-82a6d63287cc