### PR TITLE
fix: fail if not authenticated on core user methods

### DIFF
--- a/.changeset/red-drinks-brake.md
+++ b/.changeset/red-drinks-brake.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: raise when calling user methods before auth

--- a/packages/client/src/clients/preferences/index.ts
+++ b/packages/client/src/clients/preferences/index.ts
@@ -33,6 +33,8 @@ class Preferences {
    * @deprecated Use `user.getAllPreferences()` instead
    */
   async getAll() {
+    this.instance.failIfNotAuthenticated();
+
     const result = await this.instance.client().makeRequest({
       method: "GET",
       url: `/v1/users/${this.instance.userId}/preferences`,
@@ -45,6 +47,8 @@ class Preferences {
    * @deprecated Use `user.getPreferences()` instead
    */
   async get(options: PreferenceOptions = {}) {
+    this.instance.failIfNotAuthenticated();
+
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -62,6 +66,8 @@ class Preferences {
     preferenceSet: SetPreferencesProperties,
     options: PreferenceOptions = {},
   ) {
+    this.instance.failIfNotAuthenticated();
+
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -80,6 +86,7 @@ class Preferences {
     channelTypePreferences: ChannelTypePreferences,
     options: PreferenceOptions = {},
   ) {
+    this.instance.failIfNotAuthenticated();
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -99,6 +106,7 @@ class Preferences {
     setting: boolean,
     options: PreferenceOptions = {},
   ) {
+    this.instance.failIfNotAuthenticated();
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -117,6 +125,7 @@ class Preferences {
     workflowPreferences: WorkflowPreferences,
     options: PreferenceOptions = {},
   ) {
+    this.instance.failIfNotAuthenticated();
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -136,6 +145,8 @@ class Preferences {
     setting: WorkflowPreferenceSetting,
     options: PreferenceOptions = {},
   ) {
+    this.instance.failIfNotAuthenticated();
+
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
     const params = buildUpdateParam(setting);
 
@@ -155,6 +166,8 @@ class Preferences {
     categoryPreferences: WorkflowPreferences,
     options: PreferenceOptions = {},
   ) {
+    this.instance.failIfNotAuthenticated();
+
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -174,6 +187,8 @@ class Preferences {
     setting: WorkflowPreferenceSetting,
     options: PreferenceOptions = {},
   ) {
+    this.instance.failIfNotAuthenticated();
+
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
     const params = buildUpdateParam(setting);
 

--- a/packages/client/src/clients/users/index.ts
+++ b/packages/client/src/clients/users/index.ts
@@ -22,6 +22,8 @@ class UserClient {
   }
 
   async get() {
+    this.instance.failIfNotAuthenticated();
+
     const result = await this.instance.client().makeRequest({
       method: "GET",
       url: `/v1/users/${this.instance.userId}`,
@@ -31,6 +33,8 @@ class UserClient {
   }
 
   async identify(props: GenericData = {}) {
+    this.instance.failIfNotAuthenticated();
+
     const result = await this.instance.client().makeRequest({
       method: "PUT",
       url: `/v1/users/${this.instance.userId}`,
@@ -41,6 +45,8 @@ class UserClient {
   }
 
   async getAllPreferences() {
+    this.instance.failIfNotAuthenticated();
+
     const result = await this.instance.client().makeRequest({
       method: "GET",
       url: `/v1/users/${this.instance.userId}/preferences`,
@@ -52,6 +58,7 @@ class UserClient {
   async getPreferences(
     options: GetPreferencesOptions = {},
   ): Promise<PreferenceSet> {
+    this.instance.failIfNotAuthenticated();
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -67,6 +74,7 @@ class UserClient {
     preferenceSet: SetPreferencesProperties,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
+    this.instance.failIfNotAuthenticated();
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
     const result = await this.instance.client().makeRequest({
@@ -79,6 +87,8 @@ class UserClient {
   }
 
   async getChannelData<T = GenericData>(params: GetChannelDataInput) {
+    this.instance.failIfNotAuthenticated();
+
     const result = await this.instance.client().makeRequest({
       method: "GET",
       url: `/v1/users/${this.instance.userId}/channel_data/${params.channelId}`,
@@ -91,6 +101,8 @@ class UserClient {
     channelId,
     channelData,
   }: SetChannelDataInput) {
+    this.instance.failIfNotAuthenticated();
+
     const result = await this.instance.client().makeRequest({
       method: "PUT",
       url: `/v1/users/${this.instance.userId}/channel_data/${channelId}`,

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -106,6 +106,12 @@ class Knock {
     return;
   }
 
+  failIfNotAuthenticated() {
+    if (!this.isAuthenticated()) {
+      throw new Error("Not authenticated. Please call `authenticate` first.");
+    }
+  }
+
   /*
     Returns whether or this Knock instance is authenticated. Passing `true` will check the presence
     of the userToken as well.


### PR DESCRIPTION
### TL;DR
Added authentication checks across user and preference-related operations to prevent access when uninitialized (e.g. userId is null or undefined).

### What changed?
- Added a new `failIfNotAuthenticated` method to validate authentication status
- Implemented authentication checks before executing user-related operations
- Added validation before performing preference-related actions
- Each API endpoint now verifies authentication status before proceeding

