### PR TITLE
chore(KNO-7803): lint React SDK using eslint-plugin-jsx-a11y

### DIFF
--- a/.changeset/blue-tigers-hunt.md
+++ b/.changeset/blue-tigers-hunt.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+Fix a11y issues caught by eslint-plugin-jsx-a11y

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   extends: [
     "@knocklabs/eslint-config/library.js",
     "plugin:react-hooks/recommended",
-    "plugin:jsx-a11y/recommended",
+    "plugin:jsx-a11y/strict",
   ],
   parserOptions: {
     projects: ["tsconfig.json", "tsconfig.node.json"],

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   extends: [
     "@knocklabs/eslint-config/library.js",
     "plugin:react-hooks/recommended",
+    "plugin:jsx-a11y/recommended",
   ],
   parserOptions: {
     projects: ["tsconfig.json", "tsconfig.node.json"],

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -9,4 +9,9 @@ module.exports = {
   parserOptions: {
     projects: ["tsconfig.json", "tsconfig.node.json"],
   },
+  settings: {
+    "jsx-a11y": {
+      polymorphicPropName: "as",
+    },
+  },
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.0",
+    "@types/eslint-plugin-jsx-a11y": "^6",
     "@types/lodash.debounce": "^4.0.9",
     "@types/react": "^18.3.6",
     "@types/react-dom": "^18.2.15",
@@ -74,6 +75,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "babel-plugin-react-require": "^4.0.3",
     "eslint": "^8.56.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "jsdom": "^25.0.1",

--- a/packages/react/src/modules/feed/components/NotificationCell/Avatar.tsx
+++ b/packages/react/src/modules/feed/components/NotificationCell/Avatar.tsx
@@ -20,7 +20,7 @@ export const Avatar: React.FC<AvatarProps> = ({ name, src }) => {
   return (
     <div className="rnf-avatar">
       {src ? (
-        <img src={src} alt={`Image of ${name}`} className="rnf-avatar__image" />
+        <img src={src} alt={name} className="rnf-avatar__image" />
       ) : (
         <span className="rnf-avatar__initials">{getInitials(name)}</span>
       )}

--- a/packages/react/src/modules/feed/components/NotificationCell/NotificationCell.tsx
+++ b/packages/react/src/modules/feed/components/NotificationCell/NotificationCell.tsx
@@ -108,11 +108,13 @@ export const NotificationCell = React.forwardRef<
     const actor = item.actors[0];
 
     return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         ref={ref}
         className={`rnf-notification-cell rnf-notification-cell--${colorMode}`}
         onClick={onContainerClickHandler}
         onKeyDown={onKeyDown}
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
       >
         <div className="rnf-notification-cell__inner">

--- a/packages/react/src/modules/feed/components/NotificationIconButton/NotificationIconButton.tsx
+++ b/packages/react/src/modules/feed/components/NotificationIconButton/NotificationIconButton.tsx
@@ -21,7 +21,6 @@ export const NotificationIconButton = React.forwardRef<
   return (
     <button
       className={`rnf-notification-icon-button rnf-notification-icon-button--${colorMode}`}
-      role="button"
       aria-label="Open notification feed"
       ref={ref}
       onClick={onClick}

--- a/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsChannelCombobox.tsx
+++ b/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsChannelCombobox.tsx
@@ -46,7 +46,7 @@ const MsTeamsChannelCombobox: FunctionComponent<Props> = ({
 
   return (
     <Stack className="tgph rtk-combobox__grid" gap="3">
-      <Text color="gray" size="2" as="div">
+      <Text color="gray" size="2" as="a">
         Team
       </Text>
       <MsTeamsTeamCombobox

--- a/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsChannelCombobox.tsx
+++ b/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsChannelCombobox.tsx
@@ -46,7 +46,7 @@ const MsTeamsChannelCombobox: FunctionComponent<Props> = ({
 
   return (
     <Stack className="tgph rtk-combobox__grid" gap="3">
-      <Text color="gray" size="2" as="a">
+      <Text color="gray" size="2" as="div">
         Team
       </Text>
       <MsTeamsTeamCombobox

--- a/yarn.lock
+++ b/yarn.lock
@@ -6068,6 +6068,7 @@ __metadata:
     "@telegraph/layout": "npm:^0.1.3"
     "@telegraph/typography": "npm:^0.1.3"
     "@testing-library/react": "npm:^14.2.0"
+    "@types/eslint-plugin-jsx-a11y": "npm:^6"
     "@types/lodash.debounce": "npm:^4.0.9"
     "@types/react": "npm:^18.3.6"
     "@types/react-dom": "npm:^18.2.15"
@@ -6076,6 +6077,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.4"
     babel-plugin-react-require: "npm:^4.0.3"
     eslint: "npm:^8.56.0"
+    eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react-hooks: "npm:^5.0.0"
     eslint-plugin-react-refresh: "npm:^0.4.14"
     jsdom: "npm:^25.0.1"
@@ -9542,6 +9544,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint-plugin-jsx-a11y@npm:^6":
+  version: 6.10.0
+  resolution: "@types/eslint-plugin-jsx-a11y@npm:6.10.0"
+  dependencies:
+    "@types/eslint": "npm:*"
+  checksum: 10c0/ec494e0ea56a0a10140316a74463eb8a6ac5ed02d7408ef91444f7c0c9bc875866a9d0be7a761f1631ea543c2413b1db947bf7cb1df9d936171e5d82f71c6772
+  languageName: node
+  linkType: hard
+
+"@types/eslint@npm:*":
+  version: 9.6.1
+  resolution: "@types/eslint@npm:9.6.1"
+  dependencies:
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
+  checksum: 10c0/69ba24fee600d1e4c5abe0df086c1a4d798abf13792d8cfab912d76817fe1a894359a1518557d21237fbaf6eda93c5ab9309143dee4c59ef54336d1b3570420e
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:^7.29.0 || ^8.4.1, @types/eslint@npm:^8.44.7":
   version: 8.56.12
   resolution: "@types/eslint@npm:8.56.12"
@@ -11446,7 +11467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.0.0":
+"aria-query@npm:^5.0.0, aria-query@npm:^5.3.2":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
   checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
@@ -15070,6 +15091,31 @@ __metadata:
     jest:
       optional: true
   checksum: 10c0/b8b09f7d8ba3d84a8779a6e95702a6e4dce45ab034e4edf5ddb631e77cd38dcdf791dfd9228e0a0d1d80d1eb2d278deb62ad2ec39f10fb8fd43cec07304e0c38
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jsx-a11y@npm:^6.10.2":
+  version: 6.10.2
+  resolution: "eslint-plugin-jsx-a11y@npm:6.10.2"
+  dependencies:
+    aria-query: "npm:^5.3.2"
+    array-includes: "npm:^3.1.8"
+    array.prototype.flatmap: "npm:^1.3.2"
+    ast-types-flow: "npm:^0.0.8"
+    axe-core: "npm:^4.10.0"
+    axobject-query: "npm:^4.1.0"
+    damerau-levenshtein: "npm:^1.0.8"
+    emoji-regex: "npm:^9.2.2"
+    hasown: "npm:^2.0.2"
+    jsx-ast-utils: "npm:^3.3.5"
+    language-tags: "npm:^1.0.9"
+    minimatch: "npm:^3.1.2"
+    object.fromentries: "npm:^2.0.8"
+    safe-regex-test: "npm:^1.0.3"
+    string.prototype.includes: "npm:^2.0.1"
+  peerDependencies:
+    eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+  checksum: 10c0/d93354e03b0cf66f018d5c50964e074dffe4ddf1f9b535fa020d19c4ae45f89c1a16e9391ca61ac3b19f7042c751ac0d361a056a65cbd1de24718a53ff8daa6e
   languageName: node
   linkType: hard
 
@@ -25523,6 +25569,17 @@ __metadata:
     define-properties: "npm:^1.1.3"
     es-abstract: "npm:^1.17.5"
   checksum: 10c0/32dff118c9e9dcc87e240b05462fa8ee7248d9e335c0015c1442fe18152261508a2146d9bb87ddae56abab69148a83c61dfaea33f53853812a6a2db737689ed2
+  languageName: node
+  linkType: hard
+
+"string.prototype.includes@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "string.prototype.includes@npm:2.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+  checksum: 10c0/25ce9c9b49128352a2618fbe8758b46f945817a58a4420f4799419e40a8d28f116e176c7590d767d5327a61e75c8f32c86171063f48e389b9fdd325f1bd04ee5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:
- Installs [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) and updates our ESLint config to extend eslint-plugin-jsx-a11y’s strict configuration.
- Fixes the few existing violations caught by eslint-plugin-jsx-a11y.