### PR TITLE
fix: include all message and feed item fields on types

### DIFF
--- a/.changeset/three-ears-learn.md
+++ b/.changeset/three-ears-learn.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: include missing timestamp fields on FeedItem and Message

--- a/packages/client/src/clients/feed/interfaces.ts
+++ b/packages/client/src/clients/feed/interfaces.ts
@@ -80,6 +80,9 @@ export interface FeedItem<T = GenericData> {
   updated_at: string;
   read_at: string | null;
   seen_at: string | null;
+  clicked_at: string | null;
+  interacted_at: string | null;
+  link_clicked_at: string | null;
   archived_at: string | null;
   total_activities: number;
   total_actors: number;

--- a/packages/client/src/clients/messages/interfaces.ts
+++ b/packages/client/src/clients/messages/interfaces.ts
@@ -32,6 +32,9 @@ export interface Message<T = GenericData> {
   read_at: string | null;
   seen_at: string | null;
   archived_at: string | null;
+  clicked_at: string | null;
+  interacted_at: string | null;
+  link_clicked_at: string | null;
   tenant: string | null;
   status: MessageDeliveryStatus;
   engagement_statuses: MessageEngagementStatus[];


### PR DESCRIPTION
1### TL;DR
Added new timestamp fields for tracking user engagement with feed items and messages.

### What changed?
Added three new timestamp fields to both `FeedItem` and `Message` interfaces:
- `clicked_at`: Tracks when the item/message was clicked
- `interacted_at`: Tracks when any interaction occurred
- `link_clicked_at`: Tracks when embedded links were clicked

### How to test?
1. Verify that feed items and messages include the new timestamp fields in their responses
2. Confirm that these fields are properly populated when:
   - Clicking on an item/message
   - Interacting with content
   - Clicking embedded links
3. Validate that null values are returned when no interactions have occurred

### Why make this change?
To provide more granular tracking of user engagement with content, enabling better analytics and user behavior insights. This data can be used to improve content relevance and measure engagement effectiveness.