### PR TITLE
fix(KNO-7854): fix page layout shifting when combobox opens

### DIFF
--- a/.changeset/serious-carrots-itch.md
+++ b/.changeset/serious-carrots-itch.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react": patch
+---
+
+Make `SlackChannelCombobox` and `MsTeamsChannelCombobox` non-modal
+
+This fixes a bug whereby the page layout could shift when the combobox dropdown menu opens and the `<body>` element has non-zero padding.

--- a/.changeset/sweet-dancers-behave.md
+++ b/.changeset/sweet-dancers-behave.md
@@ -1,0 +1,6 @@
+---
+"ms-teams-connect-example": patch
+"slack-connect-example": patch
+---
+
+Add padding to `<body>` element of example app

--- a/examples/ms-teams-connect-example/pages/_app.tsx
+++ b/examples/ms-teams-connect-example/pages/_app.tsx
@@ -2,6 +2,8 @@ import "@knocklabs/react/dist/index.css";
 import { NextSeo } from "next-seo";
 import { AppProps } from "next/app";
 
+import "./styles.css";
+
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>

--- a/examples/ms-teams-connect-example/pages/styles.css
+++ b/examples/ms-teams-connect-example/pages/styles.css
@@ -1,0 +1,3 @@
+body {
+  padding: 12px;
+}

--- a/examples/slack-connect-example/pages/_app.tsx
+++ b/examples/slack-connect-example/pages/_app.tsx
@@ -2,6 +2,8 @@ import "@knocklabs/react/dist/index.css";
 import { NextSeo } from "next-seo";
 import { AppProps } from "next/app";
 
+import "./styles.css";
+
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>

--- a/examples/slack-connect-example/pages/styles.css
+++ b/examples/slack-connect-example/pages/styles.css
@@ -1,0 +1,3 @@
+body {
+  padding: 12px;
+}

--- a/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsChannelInTeamCombobox.tsx
+++ b/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsChannelInTeamCombobox.tsx
@@ -107,6 +107,10 @@ export const MsTeamsChannelInTeamCombobox: FunctionComponent<
           }
           closeOnSelect={false}
           layout="wrap"
+          modal={
+            // Modal comboboxes cause page layout to shift when body has padding. See KNO-7854.
+            false
+          }
         >
           <Combobox.Trigger />
           <Combobox.Content>

--- a/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsTeamCombobox.tsx
+++ b/packages/react/src/modules/ms-teams/components/MsTeamsChannelCombobox/MsTeamsTeamCombobox.tsx
@@ -53,6 +53,10 @@ export const MsTeamsTeamCombobox: FunctionComponent<
         }}
         placeholder="Select team"
         disabled={inErrorState || inLoadingState || sortedTeams.length === 0}
+        modal={
+          // Modal comboboxes cause page layout to shift when body has padding. See KNO-7854.
+          false
+        }
       >
         <Combobox.Trigger />
         <Combobox.Content>

--- a/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
+++ b/packages/react/src/modules/slack/components/SlackChannelCombobox/SlackChannelCombobox.tsx
@@ -184,6 +184,10 @@ export const SlackChannelCombobox: FunctionComponent<
         errored={inErrorState}
         closeOnSelect={false}
         layout="wrap"
+        modal={
+          // Modal comboboxes cause page layout to shift when body has padding. See KNO-7854.
+          false
+        }
       >
         <Combobox.Trigger />
         <Combobox.Content>


### PR DESCRIPTION
This PR fixes a bug whereby the page layout could shift whenever a combobox opens and the `<body>` element has non-zero padding.

When the combobox opens, a style `body[data-scroll-locked]` is applied by `react-remove-scroll-bar` (which is a dependency of `react-remove-scroll`, used by Radix):

<img width="438" alt="Screenshot 2025-02-13 at 2 57 49 PM" src="https://github.com/user-attachments/assets/5950179d-093b-44ae-9dad-7834da02e99f" />

By default, `react-remove-scroll-bar` uses [a “gap mode” of `"margin"`](https://github.com/theKashey/react-remove-scroll-bar/blob/29e9fcd1eecf7d3b77a767941c4a57fe461fc1e4/src/utils.ts#L29). This means it uses [the margin attributes rather than padding](https://github.com/theKashey/react-remove-scroll-bar/blob/29e9fcd1eecf7d3b77a767941c4a57fe461fc1e4/src/utils.ts#L22-L24) when computing this `body[data-scroll-locked]` style.

There’s a lot of discussion in the Radix repo about page layouts shifting due to `react-remove-scroll`:

- radix-ui/primitives#1100
- radix-ui/primitives#1586
- radix-ui/primitives#1925

Unfortunately, it doesn’t seem `react-remove-scroll` or Radix have a fix for this. The bug even occurs on the [Dropdown Menu page of the Radix docs](https://www.radix-ui.com/primitives/docs/components/dropdown-menu), if you use DevTools to apply padding to the `<body>` element.

I tried updating `@radix-ui/react-menu` in Telegraph, since the most recent Radix releases update their `react-remove-scroll` dependency, but the bug still occurs. 😞 

Making the comboboxes non-modal fixes the bug, as suggested by [this comment in the Radix repo](https://github.com/radix-ui/primitives/discussions/1100#discussioncomment-7826853). Unless we feel strongly that these comboboxes should be modal, I’m fine with this fix.

I also added some padding to the `<body>` elements in `slack-connect-example-app` and `ms-teams-connect-example-app`, so that the shifting will be apparent if the `modal={false}` prop is accidentally removed at some point.

## Videos

### Before

https://github.com/user-attachments/assets/0b9d6945-43d1-4fed-8ca2-31ad47e618cb

### After

https://github.com/user-attachments/assets/ca87f626-e30e-41de-b064-8b274c115560
