### PR TITLE
chore(KNO-7863): group Telegraph dependencies in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       - "knocklabs/product"
     versioning-strategy: increase
     open-pull-requests-limit: 5
+    groups:
+      telegraph-packages:
+        patterns:
+          - "@telegraph/*"
     ignore:
       - dependency-name: "@radix-ui/react-popover"
       - dependency-name: "@radix-ui/react-visually-hidden"


### PR DESCRIPTION
[Just as we do in the control repo](https://github.com/knocklabs/control/blob/71266d417e6821c7b84c99afc1eea514bbd574a6/.github/dependabot.yml#L24-L27), we should update Telegraph dependencies in a single PR.