### PR TITLE
mike-kno-7971-knockexpopushnotificationprovider-autoregister-prop-isnt

### DIFF
--- a/examples/ms-teams-connect-example/package.json
+++ b/examples/ms-teams-connect-example/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.5",
+    "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22",
     "@types/react": "^18.3.6",
     "@types/react-dom": "^18.2.15",

--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@knocklabs/eslint-config": "workspace:^",
     "@knocklabs/typescript-config": "workspace:^",
-    "@next/eslint-plugin-next": "^15.1.6",
+    "@next/eslint-plugin-next": "^15.2.0",
     "@types/eslint": "^8.44.7",
     "@types/node": "^22",
     "@types/react": "^18.3.6",

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -26,7 +26,7 @@
     "@types/react-test-renderer": "^19.0.0",
     "babel-jest": "^29.6.3",
     "eslint": "^8.56.0",
-    "prettier": "^3.4.2",
+    "prettier": "^3.5.3",
     "react-test-renderer": "19.0.0",
     "typescript": "^5.7.3"
   },

--- a/examples/slack-connect-example/package.json
+++ b/examples/slack-connect-example/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.5",
+    "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22",
     "@types/react": "^18.3.6",
     "@types/react-dom": "^18.2.15",

--- a/examples/slack-kit-example/app/examine-channel-data/page.tsx
+++ b/examples/slack-kit-example/app/examine-channel-data/page.tsx
@@ -23,7 +23,8 @@ export default async function Page() {
         <code className="text-[#E95744]">access_token</code> and Slack channel
         connections as channel data on the{" "}
         <code className="text-[#E95744]">{tenant}</code> tenant and{" "}
-        <code className="text-[#E95744]">{objectId}</code> object recipient.{" "}
+        <code className="text-[#E95744]">{objectId}</code> object
+        recipient.{" "}
       </p>
       <p className="mb-4">
         We&apos;ve fetched this channel data for you from the resources you

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@knocklabs/prettier-config": "workspace:^",
     "@knocklabs/typescript-config": "workspace:^",
     "@manypkg/cli": "^0.22.0",
-    "prettier": "^3.4.2",
+    "prettier": "^3.5.3",
     "turbo": "^2.3.3"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,7 +61,7 @@
     "crypto": "^1.0.1",
     "eslint": "^8.56.0",
     "jsonwebtoken": "^9.0.2",
-    "prettier": "^3.4.2",
+    "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "rollup": "^4.34.8",
     "typescript": "^5.7.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -72,7 +72,7 @@
     "@babel/runtime": "^7.26.0",
     "@knocklabs/types": "workspace:^",
     "@types/phoenix": "^1.6.6",
-    "axios": "^1.7.9",
+    "axios": "^1.8.1",
     "axios-retry": "^4.5.0",
     "eventemitter2": "^6.4.5",
     "jwt-decode": "^4.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-transform-runtime": "^7.25.4",
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
-    "@types/jsonwebtoken": "^9.0.5",
+    "@types/jsonwebtoken": "^9.0.9",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "@typescript-eslint/parser": "^8.24.0",
     "cross-env": "^7.0.3",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/parser": "^8.24.0",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^8.56.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "expo": ">=52.0.35",
     "expo-constants": ">=17.0.4",

--- a/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
+++ b/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
@@ -237,6 +237,7 @@ const InternalKnockExpoPushNotificationProvider: React.FC<
     notificationReceivedHandler,
     notificationTappedHandler,
     customNotificationHandler,
+    autoRegister,
     expoPushToken,
     knockExpoChannelId,
     knockClient,

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -17,6 +17,6 @@
   ],
   "dependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "prettier": "^3.4.2"
+    "prettier": "^3.5.3"
   }
 }

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -62,7 +62,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "babel-plugin-react-require": "^4.0.3",
     "eslint": "^8.56.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "jsdom": "^25.0.1",
     "react": "^18.2.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -58,7 +58,7 @@
     "@typescript-eslint/parser": "^8.24.0",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^8.56.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "react": "^18.2.0",
     "react-native": "^0.73.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,7 +74,7 @@
     "babel-plugin-react-require": "^4.0.3",
     "eslint": "^8.56.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "jsdom": "^25.0.1",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5996,7 +5996,7 @@ __metadata:
     jsonwebtoken: "npm:^9.0.2"
     jwt-decode: "npm:^4.0.0"
     phoenix: "npm:1.7.19"
-    prettier: "npm:^3.4.2"
+    prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.34.8"
     typescript: "npm:^5.7.3"
@@ -6086,7 +6086,7 @@ __metadata:
     "@knocklabs/prettier-config": "workspace:^"
     "@knocklabs/typescript-config": "workspace:^"
     "@manypkg/cli": "npm:^0.22.0"
-    prettier: "npm:^3.4.2"
+    prettier: "npm:^3.5.3"
     turbo: "npm:^2.3.3"
   languageName: unknown
   linkType: soft
@@ -6105,7 +6105,7 @@ __metadata:
   resolution: "@knocklabs/prettier-config@workspace:packages/prettier-config"
   dependencies:
     "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    prettier: "npm:^3.4.2"
+    prettier: "npm:^3.5.3"
   languageName: unknown
   linkType: soft
 
@@ -6157,7 +6157,7 @@ __metadata:
     "@types/react-test-renderer": "npm:^19.0.0"
     babel-jest: "npm:^29.6.3"
     eslint: "npm:^8.56.0"
-    prettier: "npm:^3.4.2"
+    prettier: "npm:^3.5.3"
     react: "npm:^18.2.0"
     react-native: "npm:^0.73.4"
     react-native-config: "npm:^1.5.5"
@@ -22915,12 +22915,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.4.2":
-  version: 3.4.2
-  resolution: "prettier@npm:3.4.2"
+"prettier@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "prettier@npm:3.5.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
+  checksum: 10c0/3880cb90b9dc0635819ab52ff571518c35bd7f15a6e80a2054c05dbc8a3aa6e74f135519e91197de63705bcb38388ded7e7230e2178432a1468005406238b877
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6051,7 +6051,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.24.0"
     "@vitejs/plugin-react": "npm:^4.3.4"
     eslint: "npm:^8.56.0"
-    eslint-plugin-react-hooks: "npm:^5.0.0"
+    eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.14"
     expo: "npm:>=52.0.35"
     expo-constants: "npm:>=17.0.4"
@@ -6122,7 +6122,7 @@ __metadata:
     babel-plugin-react-require: "npm:^4.0.3"
     date-fns: "npm:^4.0.0"
     eslint: "npm:^8.56.0"
-    eslint-plugin-react-hooks: "npm:^5.0.0"
+    eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.14"
     jsdom: "npm:^25.0.1"
     react: "npm:^18.2.0"
@@ -6179,7 +6179,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.24.0"
     "@vitejs/plugin-react": "npm:^4.3.4"
     eslint: "npm:^8.56.0"
-    eslint-plugin-react-hooks: "npm:^5.0.0"
+    eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.14"
     react: "npm:^18.2.0"
     react-native: "npm:^0.73.4"
@@ -6219,7 +6219,7 @@ __metadata:
     babel-plugin-react-require: "npm:^4.0.3"
     eslint: "npm:^8.56.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
-    eslint-plugin-react-hooks: "npm:^5.0.0"
+    eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.4.14"
     jsdom: "npm:^25.0.1"
     lodash.debounce: "npm:^4.0.8"
@@ -15166,12 +15166,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "eslint-plugin-react-hooks@npm:5.0.0"
+"eslint-plugin-react-hooks@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "eslint-plugin-react-hooks@npm:5.2.0"
   peerDependencies:
     eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10c0/bcb74b421f32e4203a7100405b57aab85526be4461e5a1da01bc537969a30012d2ee209a2c2a6cac543833a27188ce1e6ad71e4628d0bb4a2e5365cad86c5002
+  checksum: 10c0/1c8d50fa5984c6dea32470651807d2922cc3934cf3425e78f84a24c2dfd972e7f019bee84aefb27e0cf2c13fea0ac1d4473267727408feeb1c56333ca1489385
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5987,7 +5987,7 @@ __metadata:
     "@types/phoenix": "npm:^1.6.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.19.1"
     "@typescript-eslint/parser": "npm:^8.24.0"
-    axios: "npm:^1.7.9"
+    axios: "npm:^1.8.1"
     axios-retry: "npm:^4.5.0"
     cross-env: "npm:^7.0.3"
     crypto: "npm:^1.0.1"
@@ -11710,14 +11710,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.7.9":
-  version: 1.7.9
-  resolution: "axios@npm:1.7.9"
+"axios@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "axios@npm:1.8.1"
   dependencies:
     follow-redirects: "npm:^1.15.6"
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/b7a41e24b59fee5f0f26c1fc844b45b17442832eb3a0fb42dd4f1430eb4abc571fe168e67913e8a1d91c993232bd1d1ab03e20e4d1fee8c6147649b576fc1b0b
+  checksum: 10c0/b2e1d5a61264502deee4b50f0a6df0aa3b174c546ccf68c0dff714a2b8863232e0bd8cb5b84f853303e97f242a98260f9bb9beabeafe451ad5af538e9eb7ac22
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6459,12 +6459,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/eslint-plugin-next@npm:^15.1.6":
-  version: 15.1.6
-  resolution: "@next/eslint-plugin-next@npm:15.1.6"
+"@next/eslint-plugin-next@npm:^15.2.0":
+  version: 15.2.0
+  resolution: "@next/eslint-plugin-next@npm:15.2.0"
   dependencies:
     fast-glob: "npm:3.3.1"
-  checksum: 10c0/753babd13e197304eb7a224c08a9a286aee10e316dcf86c49fe655fe9ea16659969bdbe4502429723cdf318e47fba4188ca101a5fc0d91dcad13404e773013a9
+  checksum: 10c0/baffd78b58e410796cb0ac52d1af8d374a07fefc5b5ed6b1adc698a2828f88dec569ccc744298e64a2ddfbc9c4071a3924acf1a26141ca92a2d41ba4bd66d04a
   languageName: node
   linkType: hard
 
@@ -21024,7 +21024,7 @@ __metadata:
     "@knocklabs/node": "npm:^0.6.15"
     "@knocklabs/react": "workspace:^"
     "@knocklabs/typescript-config": "workspace:^"
-    "@next/eslint-plugin-next": "npm:^15.1.6"
+    "@next/eslint-plugin-next": "npm:^15.2.0"
     "@types/eslint": "npm:^8.44.7"
     "@types/node": "npm:^22"
     "@types/react": "npm:^18.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5983,7 +5983,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.0"
     "@knocklabs/types": "workspace:^"
-    "@types/jsonwebtoken": "npm:^9.0.5"
+    "@types/jsonwebtoken": "npm:^9.0.9"
     "@types/phoenix": "npm:^1.6.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.19.1"
     "@typescript-eslint/parser": "npm:^8.24.0"
@@ -9670,12 +9670,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsonwebtoken@npm:^9.0.5":
-  version: 9.0.7
-  resolution: "@types/jsonwebtoken@npm:9.0.7"
+"@types/jsonwebtoken@npm:^9.0.9":
+  version: 9.0.9
+  resolution: "@types/jsonwebtoken@npm:9.0.9"
   dependencies:
+    "@types/ms": "npm:*"
     "@types/node": "npm:*"
-  checksum: 10c0/e1cd0e48fcae21b1d4378887a23453bd7212b480a131b11bcda2cdeb0687d03c9646ee5ba592e04cfaf76f7cc80f179950e627cdb3ebc90a5923bce49a35631a
+  checksum: 10c0/d754a7b65fc021b298fc94e8d7a7d71f35dedf24296ac89286f80290abc5dbb0c7830a21440ee9ecbb340efc1b0a21f5609ea298a35b874cae5ad29a65440741
   languageName: node
   linkType: hard
 
@@ -9708,6 +9709,13 @@ __metadata:
   version: 1.3.5
   resolution: "@types/mime@npm:1.3.5"
   checksum: 10c0/c2ee31cd9b993804df33a694d5aa3fa536511a49f2e06eeab0b484fef59b4483777dbb9e42a4198a0809ffbf698081fdbca1e5c2218b82b91603dfab10a10fbc
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 2.1.0
+  resolution: "@types/ms@npm:2.1.0"
+  checksum: 10c0/5ce692ffe1549e1b827d99ef8ff71187457e0eb44adbae38fdf7b9a74bae8d20642ee963c14516db1d35fa2652e65f47680fdf679dcbde52bbfadd021f497225
   languageName: node
   linkType: hard
 
@@ -20821,7 +20829,7 @@ __metadata:
   resolution: "ms-teams-connect-example@workspace:examples/ms-teams-connect-example"
   dependencies:
     "@knocklabs/react": "npm:*"
-    "@types/jsonwebtoken": "npm:^9.0.5"
+    "@types/jsonwebtoken": "npm:^9.0.9"
     "@types/node": "npm:^22"
     "@types/react": "npm:^18.3.6"
     "@types/react-dom": "npm:^18.2.15"
@@ -25154,7 +25162,7 @@ __metadata:
   resolution: "slack-connect-example@workspace:examples/slack-connect-example"
   dependencies:
     "@knocklabs/react": "npm:*"
-    "@types/jsonwebtoken": "npm:^9.0.5"
+    "@types/jsonwebtoken": "npm:^9.0.9"
     "@types/node": "npm:^22"
     "@types/react": "npm:^18.3.6"
     "@types/react-dom": "npm:^18.2.15"


### PR DESCRIPTION
### TL;DR
Added `autoRegister` parameter to the internal Knock Expo push notification provider component.

### What changed?
Added support for the `autoRegister` prop in the `InternalKnockExpoPushNotificationProvider` component's parameter list, allowing for more control over the push notification registration process.

### How to test?
1. Import `KnockExpoPushNotificationProvider`
2. Set the `autoRegister` prop to `false` to prevent automatic registration
3. Verify that push notification registration behavior aligns with the `autoRegister` setting

### Why make this change?
To provide developers with more flexibility in controlling when and how push notification registration occurs, particularly in scenarios where automatic registration may not be desired.