### PR TITLE
fix(KNO-7971): fixes autoregister dependency in KnockExpoPushNotificationProvider useEffect

### DIFF
--- a/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
+++ b/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
@@ -237,6 +237,7 @@ const InternalKnockExpoPushNotificationProvider: React.FC<
     notificationReceivedHandler,
     notificationTappedHandler,
     customNotificationHandler,
+    autoRegister,
     expoPushToken,
     knockExpoChannelId,
     knockClient,


### PR DESCRIPTION
# fix(KNO-7971): fixes autoregister dependency in KnockExpoPushNotificationProvider useEffect

## Description

The `useEffect` that controls the registering does not include `autoRegister` as a dependency, preventing the registration from firing when `autoRegister` changed. 

Merging into the React 19 branch to get it out with the next release.

Addresses #430 

## Issues
[Linear KNO-7971](https://linear.app/knock/issue/KNO-7971/knockexpopushnotificationprovider-autoregister-prop-isnt-reactive-not)