### PR TITLE
fix(KNO-8072): set revalidateFirstPage option of useSWRInfinite to false

### DIFF
--- a/.changeset/dull-carrots-juggle.md
+++ b/.changeset/dull-carrots-juggle.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react-core": patch
+---
+
+Fix unnecessary refetches of first page by `useSlackChannels` and `useMsTeamsTeams` hooks
+
+Previously, both the `useSlackChannels` and `useMsTeamsTeams` hooks would unnecessarily refetch the first page of data whenever multiple pages of data were loaded. This has been fixed.

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -10,7 +10,7 @@ const MAX_COUNT = 1000;
 
 const QUERY_KEY = "MS_TEAMS_TEAMS";
 
-type UseMsTeamsTeamsProps = {
+type UseMsTeamsTeamsOptions = {
   queryOptions?: MsTeamsTeamQueryOptions;
 };
 
@@ -42,7 +42,7 @@ function getQueryKey(
 
 function useMsTeamsTeams({
   queryOptions = {},
-}: UseMsTeamsTeamsProps): UseMsTeamsTeamsOutput {
+}: UseMsTeamsTeamsOptions): UseMsTeamsTeamsOutput {
   const knock = useKnockClient();
   const { knockMsTeamsChannelId, tenantId, connectionStatus } =
     useKnockMsTeamsClient();

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts
@@ -63,6 +63,7 @@ function useMsTeamsTeams({
     useSWRInfinite<GetMsTeamsTeamsResponse>(getQueryKey, fetchTeams, {
       initialSize: 0,
       revalidateOnFocus: false,
+      revalidateFirstPage: false,
     });
 
   const lastPage = data?.at(-1);

--- a/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
+++ b/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
@@ -6,12 +6,12 @@ import useSWRInfinite from "swr/infinite";
 import { useKnockClient } from "../../core";
 
 const MAX_COUNT = 1000;
-const LIMIT_PER_PAGE = 4;
+const LIMIT_PER_PAGE = 200;
 const CHANNEL_TYPES = "private_channel,public_channel";
 
 const QUERY_KEY = "SLACK_CHANNELS";
 
-type UseSlackChannelsProps = {
+type UseSlackChannelsOptions = {
   queryOptions?: SlackChannelQueryOptions;
 };
 
@@ -43,7 +43,7 @@ function getQueryKey(
 
 function useSlackChannels({
   queryOptions,
-}: UseSlackChannelsProps): UseSlackChannelOutput {
+}: UseSlackChannelsOptions): UseSlackChannelOutput {
   const knock = useKnockClient();
   const { knockSlackChannelId, tenantId, connectionStatus } =
     useKnockSlackClient();

--- a/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
+++ b/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
@@ -64,6 +64,7 @@ function useSlackChannels({
   const { data, error, isLoading, isValidating, setSize, mutate } =
     useSWRInfinite<GetSlackChannelsResponse>(getQueryKey, fetchChannels, {
       initialSize: 0,
+      revalidateFirstPage: false,
     });
 
   const lastPage = data?.at(-1);


### PR DESCRIPTION
This PR fixes an issue with the two hooks in our React SDK that use `useSWRInfinite` internally, `useMsTeamsTeams` and `useSlackChannels`.

Both of these hooks call `setSize` within a `useEffect` so that they continuously load pages of data until the max number of teams (or channels) has been loaded, or there are no more pages available:

https://github.com/knocklabs/javascript/blob/7d68b259200bf828198bc2002bd255812d41ce12/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts#L90-L92

Calling `setSize` to fetch the next page seems to trigger SWR’s revalidation behavior. Because [`useSWRInfinite`’s `revalidateFirstPage` option](https://swr.vercel.app/docs/pagination#parameters) is `true` by default, this means the first page is refetched every time we call `setSize`.

To fix this, we can simply set `revalidateFirstPage` to `false`.

## Videos

Tested locally with a page size of 4:

### Before

Notice there are five requests to load Slack channels, three of which load the first page:

https://github.com/user-attachments/assets/bfe68832-2930-4f20-b518-9d61001cece2

### After

https://github.com/user-attachments/assets/2132e5c2-9f1c-4c6b-a356-665749e2638c

