### PR TITLE
feat(8086): add support for date range filters in the feed

### DIFF
--- a/.changeset/better-bugs-sneeze.md
+++ b/.changeset/better-bugs-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/client": minor
+"client-example": patch
+---
+
+add support for filtering by date in the feed client

--- a/examples/client-example/vite.config.js
+++ b/examples/client-example/vite.config.js
@@ -11,9 +11,6 @@ export default defineConfig({
       include: [/node_modules/],
     },
   },
-  optimizeDeps: {
-    include: ['@knocklabs/client'],
-  },
   resolve: {
     extensions: ['.js', '.jsx', '.json'],
   },

--- a/examples/nextjs-example/next-env.d.ts
+++ b/examples/nextjs-example/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/slack-connect-example/next-env.d.ts
+++ b/examples/slack-connect-example/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/client/src/clients/feed/interfaces.ts
+++ b/packages/client/src/clients/feed/interfaces.ts
@@ -30,6 +30,15 @@ export interface FeedClientOptions {
   // Optionally set the delay amount in milliseconds when automatically disconnecting sockets from inactive tabs (defaults to `2000`)
   // Requires `auto_manage_socket_connection` to be `true`
   auto_manage_socket_connection_delay?: number;
+  // Optionally scope notifications to a given date range
+  inserted_at_date_range?: {
+    // Optionally set the start date with a string in ISO 8601 format
+    start?: string;
+    // Optionally set the end date with a string in ISO 8601 format
+    end?: string;
+    // Optionally set whether to be inclusive of the start and end dates
+    inclusive?: boolean;
+  };
 }
 
 export type FetchFeedOptions = {


### PR DESCRIPTION
This adds support for filtering messages by a given date range.

It also removes `optimizeDeps` from the client example app which caused the dependency to be cached.