### PR TITLE
fix(kno-8221): date range option can be passed to initialize feed

### DIFF
--- a/.changeset/good-baths-search.md
+++ b/.changeset/good-baths-search.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+Allows the feed to accept date range options upon initialization.

--- a/examples/client-example/src/App.jsx
+++ b/examples/client-example/src/App.jsx
@@ -15,11 +15,6 @@ const useNotificationFeed = (knockClient, feedId) => {
     const notificationFeed = knockClient.feeds.initialize(feedId, {
       auto_manage_socket_connection: true,
       auto_manage_socket_connection_delay: 500,
-      inserted_at_date_range: {
-        start: "2025-03-28T14:00:10.432Z",
-        end: "2025-03-28T16:53:10.432Z",
-        inclusive: true,
-      },
     });
 
     notificationFeed.fetch();

--- a/examples/client-example/src/App.jsx
+++ b/examples/client-example/src/App.jsx
@@ -15,6 +15,11 @@ const useNotificationFeed = (knockClient, feedId) => {
     const notificationFeed = knockClient.feeds.initialize(feedId, {
       auto_manage_socket_connection: true,
       auto_manage_socket_connection_delay: 500,
+      inserted_at_date_range: {
+        start: "2025-03-28T14:00:10.432Z",
+        end: "2025-03-28T16:53:10.432Z",
+        inclusive: true,
+      },
     });
 
     notificationFeed.fetch();

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -60,7 +60,10 @@ class Feed {
     this.userFeedId = this.buildUserFeedId();
     this.store = createStore();
     this.broadcaster = new EventEmitter({ wildcard: true, delimiter: "." });
-    this.defaultOptions = { ...feedClientDefaults, ...mergeDateRangeParams(options) };
+    this.defaultOptions = {
+      ...feedClientDefaults,
+      ...mergeDateRangeParams(options),
+    };
     this.knock.log(`[Feed] Initialized a feed on channel ${feedId}`);
 
     // Attempt to setup a realtime connection (does not join)
@@ -496,7 +499,7 @@ class Feed {
       __fetchSource: undefined,
       __experimentalCrossBrowserUpdates: undefined,
       auto_manage_socket_connection: undefined,
-      auto_manage_socket_connection_delay: undefined
+      auto_manage_socket_connection_delay: undefined,
     };
 
     const result = await this.knock.client().makeRequest({

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -28,7 +28,7 @@ import {
   FeedRealTimeCallback,
   FeedStoreState,
 } from "./types";
-import { formatOptionsForApi } from "./utils";
+import { mergeDateRangeParams } from "./utils";
 
 // Default options to apply
 const feedClientDefaults: Pick<FeedClientOptions, "archived"> = {
@@ -60,7 +60,7 @@ class Feed {
     this.userFeedId = this.buildUserFeedId();
     this.store = createStore();
     this.broadcaster = new EventEmitter({ wildcard: true, delimiter: "." });
-    this.defaultOptions = { ...feedClientDefaults, ...formatOptionsForApi(options) };
+    this.defaultOptions = { ...feedClientDefaults, ...mergeDateRangeParams(options) };
     this.knock.log(`[Feed] Initialized a feed on channel ${feedId}`);
 
     // Attempt to setup a realtime connection (does not join)
@@ -470,7 +470,6 @@ class Feed {
 
   /* Fetches the feed content, appending it to the store */
   async fetch(options: FetchFeedOptions = {}) {
-    const formattedOptions = formatOptionsForApi(options);
     const { networkStatus, ...state } = this.store.getState();
 
     // If the user is not authenticated, then do nothing
@@ -491,7 +490,7 @@ class Feed {
     // Always include the default params, if they have been set
     const queryParams = {
       ...this.defaultOptions,
-      ...formattedOptions,
+      ...mergeDateRangeParams(options),
       // Unset options that should not be sent to the API
       __loadingType: undefined,
       __fetchSource: undefined,

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -28,6 +28,7 @@ import {
   FeedRealTimeCallback,
   FeedStoreState,
 } from "./types";
+import { formatOptionsForApi } from "./utils";
 
 // Default options to apply
 const feedClientDefaults: Pick<FeedClientOptions, "archived"> = {
@@ -59,8 +60,7 @@ class Feed {
     this.userFeedId = this.buildUserFeedId();
     this.store = createStore();
     this.broadcaster = new EventEmitter({ wildcard: true, delimiter: "." });
-    this.defaultOptions = { ...feedClientDefaults, ...options };
-
+    this.defaultOptions = { ...feedClientDefaults, ...formatOptionsForApi(options) };
     this.knock.log(`[Feed] Initialized a feed on channel ${feedId}`);
 
     // Attempt to setup a realtime connection (does not join)
@@ -470,6 +470,7 @@ class Feed {
 
   /* Fetches the feed content, appending it to the store */
   async fetch(options: FetchFeedOptions = {}) {
+    const formattedOptions = formatOptionsForApi(options);
     const { networkStatus, ...state } = this.store.getState();
 
     // If the user is not authenticated, then do nothing
@@ -490,49 +491,19 @@ class Feed {
     // Always include the default params, if they have been set
     const queryParams = {
       ...this.defaultOptions,
-      ...options,
+      ...formattedOptions,
       // Unset options that should not be sent to the API
       __loadingType: undefined,
       __fetchSource: undefined,
       __experimentalCrossBrowserUpdates: undefined,
       auto_manage_socket_connection: undefined,
-      auto_manage_socket_connection_delay: undefined,
-      inserted_at_date_range: undefined,
+      auto_manage_socket_connection_delay: undefined
     };
-
-    // If the user has set a date range, transform it to the backend's expected format
-    const dateRange = options.inserted_at_date_range;
-    let finalQueryParams = { ...queryParams };
-
-    if (dateRange) {
-      // Create a properly typed object for our date filter parameters
-      const dateRangeParams: Record<string, string> = {};
-
-      // Determine which operators to use based on the inclusive flag
-      const isInclusive = dateRange.inclusive ?? false;
-
-      // For start date: use gte if inclusive, gt if not
-      if (dateRange.start) {
-        const startOperator = isInclusive
-          ? "inserted_at.gte"
-          : "inserted_at.gt";
-        dateRangeParams[startOperator] = dateRange.start;
-      }
-
-      // For end date: use lte if inclusive, lt if not
-      if (dateRange.end) {
-        const endOperator = isInclusive ? "inserted_at.lte" : "inserted_at.lt";
-        dateRangeParams[endOperator] = dateRange.end;
-      }
-
-      // Create a new object combining queryParams and dateRangeParams
-      finalQueryParams = { ...queryParams, ...dateRangeParams };
-    }
 
     const result = await this.knock.client().makeRequest({
       method: "GET",
       url: `/v1/users/${this.knock.userId}/feeds/${this.feedId}`,
-      params: finalQueryParams,
+      params: queryParams,
     });
 
     if (result.statusCode === "error" || !result.body) {

--- a/packages/client/src/clients/feed/utils.ts
+++ b/packages/client/src/clients/feed/utils.ts
@@ -36,9 +36,7 @@ export function mergeDateRangeParams(options: FeedClientOptions) {
 
   // For start date: use gte if inclusive, gt if not
   if (inserted_at_date_range.start) {
-    const startOperator = isInclusive
-      ? "inserted_at.gte"
-      : "inserted_at.gt";
+    const startOperator = isInclusive ? "inserted_at.gte" : "inserted_at.gt";
     dateRangeParams[startOperator] = inserted_at_date_range.start;
   }
 
@@ -48,5 +46,5 @@ export function mergeDateRangeParams(options: FeedClientOptions) {
     dateRangeParams[endOperator] = inserted_at_date_range.end;
   }
 
-  return { ...rest, ...dateRangeParams }
+  return { ...rest, ...dateRangeParams };
 }

--- a/packages/client/src/clients/feed/utils.ts
+++ b/packages/client/src/clients/feed/utils.ts
@@ -1,4 +1,4 @@
-import { FeedItem } from "./interfaces";
+import { FeedClientOptions, FeedItem } from "./interfaces";
 
 export function deduplicateItems(items: FeedItem[]): FeedItem[] {
   const seen: Record<string, boolean> = {};
@@ -20,4 +20,40 @@ export function sortItems(items: FeedItem[]) {
       new Date(b.inserted_at).getTime() - new Date(a.inserted_at).getTime()
     );
   });
+}
+
+function formatInsertedAtDateRange(insertedAtDateRange?: { start?: string, end?: string, inclusive?: boolean }) {
+  if (!insertedAtDateRange) {
+    return {};
+  }
+
+  // Create a properly typed object for our date filter parameters
+  const dateRangeParams: Record<string, string> = {};
+
+  // Determine which operators to use based on the inclusive flag
+  const isInclusive = insertedAtDateRange.inclusive ?? false;
+
+  // For start date: use gte if inclusive, gt if not
+  if (insertedAtDateRange.start) {
+    const startOperator = isInclusive
+      ? "inserted_at.gte"
+      : "inserted_at.gt";
+    dateRangeParams[startOperator] = insertedAtDateRange.start;
+  }
+
+  // For end date: use lte if inclusive, lt if not
+  if (insertedAtDateRange.end) {
+    const endOperator = isInclusive ? "inserted_at.lte" : "inserted_at.lt";
+    dateRangeParams[endOperator] = insertedAtDateRange.end;
+  }
+
+  return dateRangeParams;
+}
+
+export function formatOptionsForApi(options: FeedClientOptions) {
+  const { inserted_at_date_range, ...rest } = options;
+
+  const dateRangeParams = formatInsertedAtDateRange(inserted_at_date_range);
+
+  return { ...rest, ...dateRangeParams };
 }

--- a/packages/client/src/clients/feed/utils.ts
+++ b/packages/client/src/clients/feed/utils.ts
@@ -26,7 +26,7 @@ export function mergeDateRangeParams(options: FeedClientOptions) {
   const { inserted_at_date_range, ...rest } = options;
 
   if (!inserted_at_date_range) {
-    return {};
+    return rest;
   }
 
   const dateRangeParams: Record<string, string> = {};

--- a/packages/client/src/clients/feed/utils.ts
+++ b/packages/client/src/clients/feed/utils.ts
@@ -22,38 +22,31 @@ export function sortItems(items: FeedItem[]) {
   });
 }
 
-function formatInsertedAtDateRange(insertedAtDateRange?: { start?: string, end?: string, inclusive?: boolean }) {
-  if (!insertedAtDateRange) {
+export function mergeDateRangeParams(options: FeedClientOptions) {
+  const { inserted_at_date_range, ...rest } = options;
+
+  if (!inserted_at_date_range) {
     return {};
   }
 
-  // Create a properly typed object for our date filter parameters
   const dateRangeParams: Record<string, string> = {};
 
   // Determine which operators to use based on the inclusive flag
-  const isInclusive = insertedAtDateRange.inclusive ?? false;
+  const isInclusive = inserted_at_date_range.inclusive ?? false;
 
   // For start date: use gte if inclusive, gt if not
-  if (insertedAtDateRange.start) {
+  if (inserted_at_date_range.start) {
     const startOperator = isInclusive
       ? "inserted_at.gte"
       : "inserted_at.gt";
-    dateRangeParams[startOperator] = insertedAtDateRange.start;
+    dateRangeParams[startOperator] = inserted_at_date_range.start;
   }
 
   // For end date: use lte if inclusive, lt if not
-  if (insertedAtDateRange.end) {
+  if (inserted_at_date_range.end) {
     const endOperator = isInclusive ? "inserted_at.lte" : "inserted_at.lt";
-    dateRangeParams[endOperator] = insertedAtDateRange.end;
+    dateRangeParams[endOperator] = inserted_at_date_range.end;
   }
 
-  return dateRangeParams;
-}
-
-export function formatOptionsForApi(options: FeedClientOptions) {
-  const { inserted_at_date_range, ...rest } = options;
-
-  const dateRangeParams = formatInsertedAtDateRange(inserted_at_date_range);
-
-  return { ...rest, ...dateRangeParams };
+  return { ...rest, ...dateRangeParams }
 }

--- a/packages/client/test/feed.test.ts
+++ b/packages/client/test/feed.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 
 import Knock from "../src/knock";
+import ApiClient from "../src/api";
 
 describe("it can create a feed client", () => {
   test("it sets configuration values", () => {
@@ -55,6 +56,124 @@ describe("it can auto manage socket connections", () => {
     expect(addEventListenerSpy).toHaveBeenCalledWith(
       "visibilitychange",
       expect.any(Function),
+    );
+  });
+});
+
+describe("it can handle date range parameters", () => {
+  let makeRequestSpy: MockInstance;
+
+  beforeEach(() => {
+    makeRequestSpy = vi.spyOn(ApiClient.prototype, "makeRequest");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("it properly formats date range parameters for API requests", async () => {
+    const knock = new Knock("pk_test_12345");
+    knock.authenticate("userId");
+
+    const feedClient = knock.feeds.initialize("feedId", {
+      inserted_at_date_range: {
+        start: "2024-01-01T00:00:00Z",
+        end: "2024-02-01T00:00:00Z",
+        inclusive: true,
+      },
+    });
+
+    // Trigger a fetch to see the actual request parameters
+    await feedClient.fetch();
+
+    expect(makeRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          "inserted_at.gte": "2024-01-01T00:00:00Z",
+          "inserted_at.lte": "2024-02-01T00:00:00Z",
+        }),
+      }),
+    );
+  });
+
+  test("it handles non-inclusive date ranges", async () => {
+    const knock = new Knock("pk_test_12345");
+    knock.authenticate("userId");
+
+    const feedClient = knock.feeds.initialize("feedId", {
+      inserted_at_date_range: {
+        start: "2024-01-01T00:00:00Z",
+        end: "2024-02-01T00:00:00Z",
+        inclusive: false,
+      },
+    });
+
+    await feedClient.fetch();
+
+    expect(makeRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          "inserted_at.gt": "2024-01-01T00:00:00Z",
+          "inserted_at.lt": "2024-02-01T00:00:00Z",
+        }),
+      }),
+    );
+  });
+
+  test("it handles partial date ranges", async () => {
+    const knock = new Knock("pk_test_12345");
+    knock.authenticate("userId");
+
+    // Start date only
+    const feedClientStart = knock.feeds.initialize("feedId", {
+      inserted_at_date_range: {
+        start: "2024-01-01T00:00:00Z",
+        inclusive: true,
+      },
+    });
+    await feedClientStart.fetch();
+    expect(makeRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          "inserted_at.gte": "2024-01-01T00:00:00Z",
+        }),
+      }),
+    );
+
+    // End date only
+    const feedClientEnd = knock.feeds.initialize("feedId", {
+      inserted_at_date_range: {
+        end: "2024-02-01T00:00:00Z",
+        inclusive: true,
+      },
+    });
+    await feedClientEnd.fetch();
+    expect(makeRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          "inserted_at.lte": "2024-02-01T00:00:00Z",
+        }),
+      }),
+    );
+  });
+
+  test("it preserves other options when no date range is provided", async () => {
+    const knock = new Knock("pk_test_12345");
+    knock.authenticate("userId");
+
+    const feedClient = knock.feeds.initialize("feedId", {
+      auto_manage_socket_connection: true,
+      archived: "include",
+    });
+
+    await feedClient.fetch();
+
+    expect(makeRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          archived: "include",
+        }),
+      }),
     );
   });
 });


### PR DESCRIPTION
Previously, we weren't respecting the date range option upon feed initialization. This moves the transformation helper into utils so that we can use it when the feed is initialized and when it fetches.

We're doing this transformation because while the date range helper uses `inserted_at_date_range` with start and end times, the Switchboard api expects `inserted_at.gt` etc.