### PR TITLE
chore(KNO-8352): update SlackKit example app scopes

### DIFF
--- a/.changeset/bright-moose-listen.md
+++ b/.changeset/bright-moose-listen.md
@@ -1,0 +1,5 @@
+---
+"slack-connect-example": patch
+---
+
+Add scopes required for [email-based user ID resolution](https://docs.knock.app/integrations/chat/slack/sending-a-direct-message#enabling-email-based-user-id-resolution)

--- a/examples/slack-connect-example/pages/index.tsx
+++ b/examples/slack-connect-example/pages/index.tsx
@@ -114,6 +114,7 @@ export default function Home() {
                     slackClientId={process.env.NEXT_PUBLIC_SLACK_CLIENT_ID!}
                     redirectUrl={redirectUrl}
                     onAuthenticationComplete={onAuthComplete}
+                    additionalScopes={["users:read", "users:read.email"]}
                   />
                 </div>
               </div>
@@ -135,6 +136,7 @@ export default function Home() {
                     <SlackAuthButton
                       slackClientId={process.env.NEXT_PUBLIC_SLACK_CLIENT_ID!}
                       redirectUrl={redirectUrl}
+                      additionalScopes={["users:read", "users:read.email"]}
                     />
                   }
                 />


### PR DESCRIPTION
This PR updates the SlackKit example app so that rendered `<SlackAuthButton>` components request the scopes required for use with [email-based user ID resolution](https://docs.knock.app/integrations/chat/slack/sending-a-direct-message#enabling-email-based-user-id-resolution).