### PR TITLE
feat(KNO-8294): add containerStyle prop to React Native NotificationFeed component

### DIFF
--- a/.changeset/silver-roses-relate.md
+++ b/.changeset/silver-roses-relate.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-native": patch
+---
+
+Add `containerStyle` prop to the `NotificationFeed` component

--- a/examples/expo-example/src/NotificationFeedContainer.tsx
+++ b/examples/expo-example/src/NotificationFeedContainer.tsx
@@ -32,7 +32,6 @@ const NotificationFeedContainer: React.FC<NotificationFeedContainerProps> = ({
       <NotificationFeed
         onCellActionButtonTap={onCellActionButtonTap}
         onRowTap={onRowTap}
-        containerStyle={styles.notificationFeed}
       />
     </View>
   );
@@ -64,8 +63,5 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "bold",
     color: "#000000",
-  },
-  notificationFeed: {
-    backgroundColor: "#ff99ff",
   },
 });

--- a/examples/expo-example/src/NotificationFeedContainer.tsx
+++ b/examples/expo-example/src/NotificationFeedContainer.tsx
@@ -32,6 +32,7 @@ const NotificationFeedContainer: React.FC<NotificationFeedContainerProps> = ({
       <NotificationFeed
         onCellActionButtonTap={onCellActionButtonTap}
         onRowTap={onRowTap}
+        style={styles.notificationFeed}
       />
     </View>
   );
@@ -63,5 +64,8 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "bold",
     color: "#000000",
+  },
+  notificationFeed: {
+    backgroundColor: "#ff99ff",
   },
 });

--- a/examples/expo-example/src/NotificationFeedContainer.tsx
+++ b/examples/expo-example/src/NotificationFeedContainer.tsx
@@ -32,7 +32,7 @@ const NotificationFeedContainer: React.FC<NotificationFeedContainerProps> = ({
       <NotificationFeed
         onCellActionButtonTap={onCellActionButtonTap}
         onRowTap={onRowTap}
-        style={styles.notificationFeed}
+        containerStyle={styles.notificationFeed}
       />
     </View>
   );

--- a/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
+++ b/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
@@ -1,6 +1,6 @@
-import { FeedItem } from "@knocklabs/client";
 import {
   ActionButton,
+  FeedItem,
   NetworkStatus,
   isRequestInFlight,
 } from "@knocklabs/client";
@@ -9,14 +9,15 @@ import {
   useFeedSettings,
   useKnockFeed,
 } from "@knocklabs/react-core";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   FlatList,
   RefreshControl,
+  StyleProp,
   StyleSheet,
   View,
+  ViewStyle,
 } from "react-native";
 
 import { PoweredByKnockIcon } from "../../../../assets/PoweredByKnockIcon";
@@ -43,6 +44,7 @@ export interface NotificationFeedProps {
     item: FeedItem;
   }) => void;
   onRowTap?: (item: FeedItem) => void;
+  style?: StyleProp<ViewStyle>;
 }
 
 export const NotificationFeed: React.FC<NotificationFeedProps> = ({
@@ -51,6 +53,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   emptyFeedStyle = undefined,
   onCellActionButtonTap = () => {},
   onRowTap = () => {},
+  style = undefined,
 }) => {
   const { feedClient, useFeedStore } = useKnockFeed();
   const { settings } = useFeedSettings(feedClient);
@@ -121,6 +124,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
       style={[
         styles.container,
         { backgroundColor: useTheme().colors.surface1 },
+        style,
       ]}
     >
       <View>

--- a/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
+++ b/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
@@ -36,6 +36,7 @@ import NotificationFeedHeader, {
 } from "./NotificationFeedHeader";
 
 export interface NotificationFeedProps {
+  containerStyle?: StyleProp<ViewStyle>;
   notificationRowStyle?: NotificationFeedCellStyle; // Customize style of the NotificationRows
   headerConfig?: NotificationFeedHeaderConfig; // Customize the top filters and buttons
   emptyFeedStyle?: EmptyNotificationFeedStyle;
@@ -44,16 +45,15 @@ export interface NotificationFeedProps {
     item: FeedItem;
   }) => void;
   onRowTap?: (item: FeedItem) => void;
-  style?: StyleProp<ViewStyle>;
 }
 
 export const NotificationFeed: React.FC<NotificationFeedProps> = ({
+  containerStyle = undefined,
   notificationRowStyle = undefined,
   headerConfig = undefined,
   emptyFeedStyle = undefined,
   onCellActionButtonTap = () => {},
   onRowTap = () => {},
-  style = undefined,
 }) => {
   const { feedClient, useFeedStore } = useKnockFeed();
   const { settings } = useFeedSettings(feedClient);
@@ -124,7 +124,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
       style={[
         styles.container,
         { backgroundColor: useTheme().colors.surface1 },
-        style,
+        containerStyle,
       ]}
     >
       <View>


### PR DESCRIPTION
This will allow styling the outermost `<View>` rendered by the `<NotificationFeed>` component.

## Screenshots

<img src="https://github.com/user-attachments/assets/6fb3eb0c-0b55-4936-95ef-856acd9cf70c" width="250">

<img src="https://github.com/user-attachments/assets/a4530dff-0791-4b3f-a07f-e2cbbcaae453" width="250">

