### PR TITLE
feat(KNO-8430): make bell icon stroke width configurable

### DIFF
--- a/.changeset/fancy-radios-beg.md
+++ b/.changeset/fancy-radios-beg.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-native": patch
+"@knocklabs/expo": patch
+---
+
+Allow styling stroke width of the bell icon

--- a/packages/react-native/src/assets/BellIcon.tsx
+++ b/packages/react-native/src/assets/BellIcon.tsx
@@ -20,7 +20,6 @@ const BellIcon: React.FC<BellIconProps> = ({
   strokeWidth = 1.5,
 }) => {
   const theme = useTheme();
-  const finalStrokeColor = strokeColor ?? theme.colors.gray12;
 
   return (
     <Svg
@@ -29,17 +28,16 @@ const BellIcon: React.FC<BellIconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       style={style}
+      stroke={strokeColor ?? theme.colors.gray12}
     >
       <Path
         d="M20.0474 16.4728C18.8436 14.9996 17.9938 14.2496 17.9938 10.1879C17.9938 6.46832 16.0944 5.14317 14.5311 4.49957C14.3235 4.41426 14.128 4.21832 14.0647 4.00504C13.7905 3.07176 13.0217 2.24957 11.9999 2.24957C10.978 2.24957 10.2088 3.07223 9.93736 4.00598C9.87408 4.2216 9.67861 4.41426 9.47096 4.49957C7.9058 5.1441 6.0083 6.46457 6.0083 10.1879C6.00596 14.2496 5.15611 14.9996 3.95237 16.4728C3.45362 17.0832 3.89049 17.9996 4.76283 17.9996H19.2416C20.1092 17.9996 20.5433 17.0803 20.0474 16.4728Z"
-        stroke={finalStrokeColor}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <Path
         d="M14.9999 17.9988V18.7488C14.9999 19.5445 14.6838 20.3075 14.1212 20.8701C13.5586 21.4327 12.7955 21.7488 11.9999 21.7488C11.2042 21.7488 10.4412 21.4327 9.87856 20.8701C9.31595 20.3075 8.99988 19.5445 8.99988 18.7488V17.9988"
-        stroke={finalStrokeColor}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/packages/react-native/src/assets/BellIcon.tsx
+++ b/packages/react-native/src/assets/BellIcon.tsx
@@ -9,6 +9,7 @@ type BellIconProps = {
   height?: number;
   style?: ViewStyle;
   strokeColor?: string;
+  strokeWidth?: number;
 };
 
 const BellIcon: React.FC<BellIconProps> = ({
@@ -16,8 +17,10 @@ const BellIcon: React.FC<BellIconProps> = ({
   height = 24,
   style,
   strokeColor,
+  strokeWidth = 1.5,
 }) => {
   const theme = useTheme();
+  const finalStrokeColor = strokeColor ?? theme.colors.gray12;
 
   return (
     <Svg
@@ -25,18 +28,19 @@ const BellIcon: React.FC<BellIconProps> = ({
       height={height}
       viewBox="0 0 24 24"
       fill="none"
-      stroke={strokeColor ?? theme.colors.gray12}
       style={style}
     >
       <Path
         d="M20.0474 16.4728C18.8436 14.9996 17.9938 14.2496 17.9938 10.1879C17.9938 6.46832 16.0944 5.14317 14.5311 4.49957C14.3235 4.41426 14.128 4.21832 14.0647 4.00504C13.7905 3.07176 13.0217 2.24957 11.9999 2.24957C10.978 2.24957 10.2088 3.07223 9.93736 4.00598C9.87408 4.2216 9.67861 4.41426 9.47096 4.49957C7.9058 5.1441 6.0083 6.46457 6.0083 10.1879C6.00596 14.2496 5.15611 14.9996 3.95237 16.4728C3.45362 17.0832 3.89049 17.9996 4.76283 17.9996H19.2416C20.1092 17.9996 20.5433 17.0803 20.0474 16.4728Z"
-        strokeWidth="1.5"
+        stroke={finalStrokeColor}
+        strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <Path
         d="M14.9999 17.9988V18.7488C14.9999 19.5445 14.6838 20.3075 14.1212 20.8701C13.5586 21.4327 12.7955 21.7488 11.9999 21.7488C11.2042 21.7488 10.4412 21.4327 9.87856 20.8701C9.31595 20.3075 8.99988 19.5445 8.99988 18.7488V17.9988"
-        strokeWidth="1.5"
+        stroke={finalStrokeColor}
+        strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/packages/react-native/src/modules/feed/components/NotificationIconButton/NotificationIconButton.tsx
+++ b/packages/react-native/src/modules/feed/components/NotificationIconButton/NotificationIconButton.tsx
@@ -21,6 +21,7 @@ export interface NotificationIconButtonStyle {
   textStyle?: TextStyle;
   bellIconStyle?: ViewStyle;
   bellIconColor?: string;
+  bellIconStrokeWidth?: number;
   badgeStyle?: ViewStyle;
 }
 
@@ -40,6 +41,7 @@ export const NotificationIconButton: React.FC<NotificationIconButtonProps> = ({
         <BellIcon
           style={styleOverride.bellIconStyle}
           strokeColor={styleOverride.bellIconColor}
+          strokeWidth={styleOverride.bellIconStrokeWidth}
         />
         <View style={styles.badgeContainer}>
           <UnseenBadge


### PR DESCRIPTION
This PR adds another style override to the `BellIcon` component so that you can set its stroke width