### PR TITLE
fix: useNotifications memory leak

### DIFF
--- a/.changeset/great-fans-post.md
+++ b/.changeset/great-fans-post.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+fixes memory leak when unmounting the useNotifications hook

--- a/packages/react-core/src/modules/feed/hooks/useNotifications.ts
+++ b/packages/react-core/src/modules/feed/hooks/useNotifications.ts
@@ -19,22 +19,22 @@ function useNotifications(
   feedChannelId: string,
   options: FeedClientOptions = {},
 ) {
-  const feedClientRef = useRef<Feed>(
-    initializeFeedClient(knock, feedChannelId, options),
-  );
   const stableOptions = useStableOptions(options);
+  const feedClientRef = useRef<Feed>();
 
-  useEffect(() => {
+  if (!feedClientRef.current) {
     feedClientRef.current = initializeFeedClient(
       knock,
       feedChannelId,
       stableOptions,
     );
+  }
 
+  useEffect(() => {
     return () => {
-      feedClientRef.current.dispose();
+      feedClientRef.current?.dispose();
     };
-  }, [knock, feedChannelId, stableOptions]);
+  }, []);
 
   return feedClientRef.current;
 }

--- a/packages/react-core/src/modules/feed/hooks/useNotifications.ts
+++ b/packages/react-core/src/modules/feed/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import Knock, { Feed, FeedClientOptions } from "@knocklabs/client";
-import { useMemo, useRef } from "react";
+import { useEffect, useState } from "react";
 
 import { useStableOptions } from "../../core";
 
@@ -8,29 +8,23 @@ function useNotifications(
   feedChannelId: string,
   options: FeedClientOptions = {},
 ) {
-  const feedClientRef = useRef<Feed>();
+  const [feedClient, setFeedClient] = useState<Feed>();
   const stableOptions = useStableOptions(options);
 
-  return useMemo(() => {
-    if (feedClientRef.current) {
-      feedClientRef.current.dispose();
-    }
+  useEffect(() => {
+    const newFeedClient = knock.feeds.initialize(feedChannelId, stableOptions);
 
-    feedClientRef.current = knock.feeds.initialize(
-      feedChannelId,
-      stableOptions,
-    );
+    newFeedClient.store.subscribe((t) => newFeedClient.store.setState(t));
 
-    // In development, we need to introduce this extra set state to force a render
-    // for Zustand as otherwise the state doesn't get reflected correctly
-    feedClientRef.current.store.subscribe((t) =>
-      feedClientRef?.current?.store.setState(t),
-    );
+    newFeedClient.listenForUpdates();
+    setFeedClient(newFeedClient);
 
-    feedClientRef.current.listenForUpdates();
-
-    return feedClientRef.current;
+    return () => {
+      newFeedClient.dispose();
+    };
   }, [knock, feedChannelId, stableOptions]);
+
+  return feedClient;
 }
 
 export default useNotifications;

--- a/packages/react-core/src/modules/feed/hooks/useNotifications.ts
+++ b/packages/react-core/src/modules/feed/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import Knock, { Feed, FeedClientOptions } from "@knocklabs/client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { useStableOptions } from "../../core";
 
@@ -19,25 +19,24 @@ function useNotifications(
   feedChannelId: string,
   options: FeedClientOptions = {},
 ) {
-  const [feedClient, setFeedClient] = useState<Feed>(
+  const feedClientRef = useRef<Feed>(
     initializeFeedClient(knock, feedChannelId, options),
   );
   const stableOptions = useStableOptions(options);
 
   useEffect(() => {
-    const feedClient = initializeFeedClient(
+    feedClientRef.current = initializeFeedClient(
       knock,
       feedChannelId,
       stableOptions,
     );
-    setFeedClient(feedClient);
 
     return () => {
-      feedClient.dispose();
+      feedClientRef.current.dispose();
     };
   }, [knock, feedChannelId, stableOptions]);
 
-  return feedClient;
+  return feedClientRef.current;
 }
 
 export default useNotifications;

--- a/packages/react-core/src/modules/feed/hooks/useNotifications.ts
+++ b/packages/react-core/src/modules/feed/hooks/useNotifications.ts
@@ -3,24 +3,37 @@ import { useEffect, useState } from "react";
 
 import { useStableOptions } from "../../core";
 
+function initializeFeedClient(
+  knock: Knock,
+  feedChannelId: string,
+  options: FeedClientOptions = {},
+) {
+  const feedClient = knock.feeds.initialize(feedChannelId, options);
+  feedClient.store.subscribe((t) => feedClient.store.setState(t));
+  feedClient.listenForUpdates();
+  return feedClient;
+}
+
 function useNotifications(
   knock: Knock,
   feedChannelId: string,
   options: FeedClientOptions = {},
 ) {
-  const [feedClient, setFeedClient] = useState<Feed>();
+  const [feedClient, setFeedClient] = useState<Feed>(
+    initializeFeedClient(knock, feedChannelId, options),
+  );
   const stableOptions = useStableOptions(options);
 
   useEffect(() => {
-    const newFeedClient = knock.feeds.initialize(feedChannelId, stableOptions);
-
-    newFeedClient.store.subscribe((t) => newFeedClient.store.setState(t));
-
-    newFeedClient.listenForUpdates();
-    setFeedClient(newFeedClient);
+    const feedClient = initializeFeedClient(
+      knock,
+      feedChannelId,
+      stableOptions,
+    );
+    setFeedClient(feedClient);
 
     return () => {
-      newFeedClient.dispose();
+      feedClient.dispose();
     };
   }, [knock, feedChannelId, stableOptions]);
 


### PR DESCRIPTION
### Description
Refactors `useNotifications` to use `useEffect` instead of `useMemo` for initializing the Knock feed client. Previously, `useMemo` was used to set up the feed and call `dispose()` when dependencies changed. However, `useMemo` is not designed for side effects or cleanup—it simply memoizes a return value and does not run cleanup logic on component unmount. This meant that the feed client would not be disposed when the component unmounted, potentially leading to memory leaks or lingering subscriptions. By switching to `useEffect`, we ensure that the feed client is properly initialized and disposed of both when dependencies change and when the component unmounts, resulting in more predictable and stable behavior.

### Tasks
[KNO-8435](https://linear.app/knock/issue/KNO-8435/[sdk]-investigate-potential-memory-leak-with-useref-in-feed-client)