### PR TITLE
chore: changeset to release new versions (guide activation location rules)

### DIFF
--- a/.changeset/fancy-bats-spend.md
+++ b/.changeset/fancy-bats-spend.md
@@ -1,0 +1,8 @@
+---
+"guide-example": patch
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+"@knocklabs/react-core": patch
+---
+
+activation location rules support for guides


### PR DESCRIPTION
Forgot to include a changeset in [the previous PR](https://github.com/knocklabs/javascript/pull/503) to release new versions. 