### PR TITLE
fix: bump down tanstack store packages to 0.6.x

### DIFF
--- a/.changeset/tricky-houses-swim.md
+++ b/.changeset/tricky-houses-swim.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+---
+
+downgrade tanstack store deps to 0.6.x to work in older TS version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,8 @@ updates:
       # nanoid >3 drops support for cjs
       - dependency-name: "nanoid"
         versions: [">=4.0.0"]
+      # We cannot upgrade tanstack store to >=0.7.0 at the moment until we are
+      # ready to require more recent typescript version (likely v5.4 or greater)
+      # See: https://github.com/knocklabs/javascript/pull/520
       - dependency-name: "@tanstack/store"
       - dependency-name: "@tanstack/react-store"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
       # nanoid >3 drops support for cjs
       - dependency-name: "nanoid"
         versions: [">=4.0.0"]
+      - dependency-name: "@tanstack/store"
+      - dependency-name: "@tanstack/react-store"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.0",
     "@knocklabs/types": "workspace:^",
-    "@tanstack/store": "^0.7.0",
+    "@tanstack/store": "0.6.0",
     "@types/phoenix": "^1.6.6",
     "axios": "^1.8.4",
     "axios-retry": "^4.5.0",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@knocklabs/client": "workspace:^",
-    "@tanstack/react-store": "^0.7.0",
+    "@tanstack/react-store": "0.6.1",
     "date-fns": "^4.0.0",
     "fast-deep-equal": "^3.1.3",
     "swr": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4841,7 +4841,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.27.0"
     "@babel/runtime": "npm:^7.27.0"
     "@knocklabs/types": "workspace:^"
-    "@tanstack/store": "npm:^0.7.0"
+    "@tanstack/store": "npm:0.6.0"
     "@types/jsonwebtoken": "npm:^9.0.9"
     "@types/phoenix": "npm:^1.6.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.19.1"
@@ -4975,7 +4975,7 @@ __metadata:
   resolution: "@knocklabs/react-core@workspace:packages/react-core"
   dependencies:
     "@knocklabs/client": "workspace:^"
-    "@tanstack/react-store": "npm:^0.7.0"
+    "@tanstack/react-store": "npm:0.6.1"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/react": "npm:^16.2.0"
     "@types/react": "npm:^18.3.6"
@@ -7841,23 +7841,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-store@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@tanstack/react-store@npm:0.7.0"
+"@tanstack/react-store@npm:0.6.1":
+  version: 0.6.1
+  resolution: "@tanstack/react-store@npm:0.6.1"
   dependencies:
-    "@tanstack/store": "npm:0.7.0"
-    use-sync-external-store: "npm:^1.4.0"
+    "@tanstack/store": "npm:0.6.0"
+    use-sync-external-store: "npm:^1.2.2"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/7e971ae3c547d0d803133f07737e7cc7cf381e959b4fab3f55755b28c194688392f5b921d3d43b8c9c81bdc721ea8878c680d4ca28a1ccd59e8a64ab7bcfd0f8
+  checksum: 10c0/f16046e27c1323037688e33d7958132786bd671d2c70a8b18f3df6b3115f9fc86a0a5f5c1001d4befdc690a8ebfb4ffa59be9c26df7ddd9829ae3ca6a6668f24
   languageName: node
   linkType: hard
 
-"@tanstack/store@npm:0.7.0, @tanstack/store@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@tanstack/store@npm:0.7.0"
-  checksum: 10c0/17003f1eba25bb6e9e2557ffb5d9c63cac09aa46f57d670a917727665ccc0b72d8d421ea1c07451257554aa5d14dbfff46875e7ed6a81f133b0738065f3162df
+"@tanstack/store@npm:0.6.0":
+  version: 0.6.0
+  resolution: "@tanstack/store@npm:0.6.0"
+  checksum: 10c0/72fbd772b757b53885d628ed486e00d75d16cac2002111bf0fed18382f62f4d3bd936e5c5fbc053af5752910d8c8b2aaec6de48cacc2f17c9fefc8929c153840
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR downgrades the `@tanstack/store` package to v0.6.0 (and `@tanstack/react-store` to v0.6.1) in order to fix the [type error](https://github.com/knocklabs/control/actions/runs/14764163532/job/41451741651?pr=4994) we are seeing in [the dependabot PR](https://github.com/knocklabs/control/pull/5033) to upgrade our `@knocklabs/react` package to the latest. It's further discussed in this slack thread:  https://knocklabs.slack.com/archives/C06A1FCF9L3/p1746214176542269.

To summarize what's going on:
* In #480, we upgraded the `@tanstack/store` and `@tanstack/react-store` deps to the latest v0.7.0 in order to support React 19 in our SDKs (React 19 was added as a peer dep in `@tanstack/react-store` at v0.6.1)
* It appears the `@tanstack/store` latest version v0.7.0 has a minimum typescript version requirement (likely 5.4 or greater), and causing type errors when used with older typescript version (https://github.com/TanStack/store/issues/188), including our control dashboard repo
* Testing it out locally, running 0.6.x versions of `@tanstack/store` deps (specifically `@tanstack/react-store` at 0.6.1 because that is when they added React 19 as a peer dep, does make the type errors go away

So tldr, it looks like we have to be at 0.6.x version with tanstack store deps at minimum in order to support React 19, but cannot go to the latest at 0.7.x since that requires newer typescript version and will likely cause issues if you are running older version like ourselves. I added to the dependabot `ignore` rules since we are stuck at 0.6.x until we are ready to require typescript 5+.

