### PR TITLE
fix(KNO-8590): fix CJS builds by downgrading nanoid

### DIFF
--- a/.changeset/salty-lies-battle.md
+++ b/.changeset/salty-lies-battle.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/client": patch
+---
+
+Fix CJS builds
+
+v0.14.6 of our client SDK did not support CJS. This version fixes CJS support.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
     ignore:
       - dependency-name: "@radix-ui/react-popover"
       - dependency-name: "@radix-ui/react-visually-hidden"
+      # nanoid >3 drops support for cjs
+      - dependency-name: "nanoid"
+        versions: [">=4.0.0"]

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -77,7 +77,7 @@
     "axios-retry": "^4.5.0",
     "eventemitter2": "^6.4.5",
     "jwt-decode": "^4.0.0",
-    "nanoid": "^3",
+    "nanoid": "^3.3.11",
     "phoenix": "1.7.19",
     "urlpattern-polyfill": "^10.0.0",
     "zustand": "^4.5.6"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -77,7 +77,7 @@
     "axios-retry": "^4.5.0",
     "eventemitter2": "^6.4.5",
     "jwt-decode": "^4.0.0",
-    "nanoid": "^5.1.5",
+    "nanoid": "^3",
     "phoenix": "1.7.19",
     "urlpattern-polyfill": "^10.0.0",
     "zustand": "^4.5.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,7 +4854,7 @@ __metadata:
     eventemitter2: "npm:^6.4.5"
     jsonwebtoken: "npm:^9.0.2"
     jwt-decode: "npm:^4.0.0"
-    nanoid: "npm:^5.1.5"
+    nanoid: "npm:^3"
     phoenix: "npm:1.7.19"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"
@@ -16882,21 +16882,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.6, nanoid@npm:^3.3.7, nanoid@npm:^3.3.8":
   version: 3.3.9
   resolution: "nanoid@npm:3.3.9"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/4515abe53db7b150cf77074558efc20d8e916d6910d557b5ce72e8bbf6f8e7554d3d7a0d180bfa65e5d8e99aa51b207aa8a3bf5f3b56233897b146d592e30b24
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^5.1.5":
-  version: 5.1.5
-  resolution: "nanoid@npm:5.1.5"
-  bin:
-    nanoid: bin/nanoid.js
-  checksum: 10c0/e6004f1ad6c7123eeb037062c4441d44982037dc043aabb162457ef6986e99964ba98c63c975f96c547403beb0bf95bc537bd7bf9a09baf381656acdc2975c3c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,7 +4854,7 @@ __metadata:
     eventemitter2: "npm:^6.4.5"
     jsonwebtoken: "npm:^9.0.2"
     jwt-decode: "npm:^4.0.0"
-    nanoid: "npm:^3"
+    nanoid: "npm:^3.3.11"
     phoenix: "npm:1.7.19"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"
@@ -16882,7 +16882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3":
+"nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:


### PR DESCRIPTION
[v4 of nanoid dropped support for CJS](https://github.com/ai/nanoid/blob/main/CHANGELOG.md#40), so this PR downgrades the client SDK’s nanoid dependency to the latest v3 release so that we restore support for CJS.
