### PR TITLE
fix(KNO-8593): fix feed initialization in React Native and Expo SDKs

### DIFF
--- a/.changeset/mighty-keys-slide.md
+++ b/.changeset/mighty-keys-slide.md
@@ -6,7 +6,13 @@
 Fix `ReferenceError` raised on feed initialization
 
 @knocklabs/react-native@0.6.13 and @knocklabs/expo@0.3.13 contained a bug in which the error
-`ReferenceError: Property 'crypto' doesn't exist` would occur whenever initializing the feed via the
-`useNotifications` hook or a call to `knock.feeds.initialize()`. This has been fixed by adding
+`ReferenceError: Property 'crypto' doesn't exist` would occur when initializing a feed via any of
+the following methods:
+
+- The `KnockFeedProvider` context provider
+- The `useNotifications` hook
+- A call to `knock.feeds.initialize()`
+
+This has been fixed by adding
 [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) as a
 dependency of our React Native and Expo SDKs.

--- a/.changeset/mighty-keys-slide.md
+++ b/.changeset/mighty-keys-slide.md
@@ -1,0 +1,12 @@
+---
+"@knocklabs/react-native": patch
+"@knocklabs/expo": patch
+---
+
+Fix `ReferenceError` raised on feed initialization
+
+@knocklabs/react-native@0.6.13 and @knocklabs/expo@0.3.13 contained a bug in which the error
+`ReferenceError: Property 'crypto' doesn't exist` would occur whenever initializing the feed via the
+`useNotifications` hook or a call to `knock.feeds.initialize()`. This has been fixed by adding
+[react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) as a
+dependency of our React Native and Expo SDKs.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -48,11 +48,13 @@
     "@knocklabs/client": "workspace:^",
     "@knocklabs/react-core": "workspace:^",
     "react-native-gesture-handler": "^2.25.0",
+    "react-native-get-random-values": "^1.11.0",
     "react-native-render-html": "^6.3.4",
     "react-native-svg": "^15.10.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.6",
+    "@types/react-native-get-random-values": "^1",
     "@types/react-native-htmlview": "^0.16.5",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "@typescript-eslint/parser": "^8.27.0",

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,4 +1,6 @@
-export * from "./modules/feed";
-export * from "./modules/push";
+import "react-native-get-random-values";
+
 export * from "@knocklabs/react-core";
 export * from "./assets";
+export * from "./modules/feed";
+export * from "./modules/push";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5039,6 +5039,7 @@ __metadata:
     "@knocklabs/client": "workspace:^"
     "@knocklabs/react-core": "workspace:^"
     "@types/react": "npm:^18.3.6"
+    "@types/react-native-get-random-values": "npm:^1"
     "@types/react-native-htmlview": "npm:^0.16.5"
     "@typescript-eslint/eslint-plugin": "npm:^8.19.1"
     "@typescript-eslint/parser": "npm:^8.27.0"
@@ -5049,6 +5050,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-native: "npm:^0.73.4"
     react-native-gesture-handler: "npm:^2.25.0"
+    react-native-get-random-values: "npm:^1.11.0"
     react-native-render-html: "npm:^6.3.4"
     react-native-svg: "npm:^15.10.1"
     rimraf: "npm:^6.0.1"
@@ -8466,6 +8468,13 @@ __metadata:
   peerDependencies:
     "@types/react": ^18.0.0
   checksum: 10c0/b163d35a6b32a79f5782574a7aeb12a31a647e248792bf437e6d596e2676961c394c5e3c6e91d1ce44ae90441dbaf93158efb4f051c0d61e2612f1cb04ce4faa
+  languageName: node
+  linkType: hard
+
+"@types/react-native-get-random-values@npm:^1":
+  version: 1.8.2
+  resolution: "@types/react-native-get-random-values@npm:1.8.2"
+  checksum: 10c0/66c0268151d0673bff88828d82d4087aeabbe29a8ffe433f50e2593cd04872fc890f0d2660203435d13412b10d866d24a3ab72981cf481e5676ccf88de12c235
   languageName: node
   linkType: hard
 
@@ -12955,6 +12964,13 @@ __metadata:
     iconv-lite: "npm:^0.4.24"
     tmp: "npm:^0.0.33"
   checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
+  languageName: node
+  linkType: hard
+
+"fast-base64-decode@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-base64-decode@npm:1.0.0"
+  checksum: 10c0/6d8feab513222a463d1cb58d24e04d2e04b0791ac6559861f99543daaa590e2636d040d611b40a50799bfb5c5304265d05e3658b5adf6b841a50ef6bf833d821
   languageName: node
   linkType: hard
 
@@ -18296,6 +18312,17 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/95eccc67fb07418ef76b84bcee4b29c16865e78afa367ec82d94b08554cfa7337158ab23937b785bd9a732e62c9c815b294a93d1b2c2cbdc7a8a1e7029f2ba35
+  languageName: node
+  linkType: hard
+
+"react-native-get-random-values@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "react-native-get-random-values@npm:1.11.0"
+  dependencies:
+    fast-base64-decode: "npm:^1.0.0"
+  peerDependencies:
+    react-native: ">=0.56"
+  checksum: 10c0/2ce71f1ab7f5b36d4a9dd59cc80b4aa75526f047c6680a7f1a388fa8b9a62efdacaf7b7de3be593c73e882773b2eee74916b00f7c8b158e40b46388998218586
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes feed initialization in our React Native and Expo SDKs by installing [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values). Nano ID requires this dependency when it’s used with React Native and Expo. See [this note in Nano ID’s README](https://github.com/ai/nanoid#react-native).

Before installing this dependency, the following error would occur:

```
(NOBRIDGE) ERROR  ReferenceError: Property 'crypto' doesn't exist

This error is located at:
    in KnockFeedProvider (at App.tsx:29)
    in InternalKnockExpoPushNotificationProvider (at KnockExpoPushNotificationProvider.tsx:267)
    in KnockPushNotificationProvider (at KnockExpoPushNotificationProvider.tsx:266)
    in KnockExpoPushNotificationProvider (at App.tsx:26)
    in KnockI18nProvider (at KnockProvider.tsx:59)
    in KnockProvider (at App.tsx:20)
    in App (at withDevTools.tsx:21)
    in withDevTools(App) (at renderApplication.js:57)
    in RCTView (at View.js:116)
    in View (at AppContainer.js:127)
    in RCTView (at View.js:116)
    in View (at AppContainer.js:155)
    in AppContainer (at renderApplication.js:50)
    in main(RootComponent) (at renderApplication.js:67)
```