### PR TITLE
feat: support image field in modal and card components

### DIFF
--- a/.changeset/tidy-weeks-dress.md
+++ b/.changeset/tidy-weeks-dress.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+Support an optional image field in Modal and Card components

--- a/packages/react/src/modules/guide/components/Banner/Banner.tsx
+++ b/packages/react/src/modules/guide/components/Banner/Banner.tsx
@@ -3,11 +3,7 @@ import clsx from "clsx";
 import React from "react";
 
 import { maybeNavigateToUrlWithDelay } from "../helpers";
-import {
-  ButtonContent,
-  TargetButton,
-  TargetButtonWithGuideContext,
-} from "../types";
+import { ButtonContent, TargetButton, TargetButtonWithGuide } from "../types";
 
 import "./styles.css";
 
@@ -181,10 +177,7 @@ DefaultView.displayName = "BannerView.Default";
 
 type BannerProps = {
   guideKey?: string;
-  onButtonClick?: (
-    e: React.MouseEvent,
-    target: TargetButtonWithGuideContext,
-  ) => void;
+  onButtonClick?: (e: React.MouseEvent, target: TargetButtonWithGuide) => void;
 };
 
 export const Banner: React.FC<BannerProps> = ({ guideKey, onButtonClick }) => {

--- a/packages/react/src/modules/guide/components/Card/Card.tsx
+++ b/packages/react/src/modules/guide/components/Card/Card.tsx
@@ -92,8 +92,8 @@ const Img: React.FC<
   return (
     <img
       className={clsx("knock-guide-card__img", className)}
-      {...props}
       alt={alt || ""}
+      {...props}
     >
       {children}
     </img>

--- a/packages/react/src/modules/guide/components/Card/styles.css
+++ b/packages/react/src/modules/guide/components/Card/styles.css
@@ -46,6 +46,11 @@
 .knock-guide-card__body > :last-child {
   margin-bottom: 0;
 }
+.knock-guide-card__img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
 .knock-guide-card__actions {
   display: flex;
   align-items: center;

--- a/packages/react/src/modules/guide/components/Modal/Modal.tsx
+++ b/packages/react/src/modules/guide/components/Modal/Modal.tsx
@@ -117,8 +117,8 @@ const Img: React.FC<
   return (
     <img
       className={clsx("knock-guide-modal__img", className)}
-      {...props}
       alt={alt || ""}
+      {...props}
     >
       {children}
     </img>
@@ -240,7 +240,7 @@ const DefaultView: React.FC<{
           >
             <Img
               src={content.image.url}
-              alt={content.image.alt || ""}
+              alt={content.image.alt}
               onClick={(e) => {
                 if (onImageClick) {
                   onImageClick(e, content.image!);

--- a/packages/react/src/modules/guide/components/Modal/styles.css
+++ b/packages/react/src/modules/guide/components/Modal/styles.css
@@ -54,6 +54,12 @@
   gap: var(--knock-spacing-3);
   margin-top: var(--knock-spacing-4);
 }
+.knock-guide-modal__img {
+  display: block;
+  margin-top: var(--knock-spacing-4);
+  max-width: 100%;
+  height: auto;
+}
 .knock-guide-modal__action {
   text-decoration: none;
   text-align: center;

--- a/packages/react/src/modules/guide/components/helpers.ts
+++ b/packages/react/src/modules/guide/components/helpers.ts
@@ -1,4 +1,4 @@
-const isValidHttpUrl = (input: string) => {
+export const isValidHttpUrl = (input: string) => {
   let url;
 
   try {

--- a/packages/react/src/modules/guide/components/types.ts
+++ b/packages/react/src/modules/guide/components/types.ts
@@ -1,5 +1,19 @@
 import { KnockGuide, KnockGuideStep } from "@knocklabs/client";
 
+export type ImageContent = {
+  url: string;
+  alt: string;
+  action: string;
+};
+
+export type TargetImage = ImageContent;
+
+export type TargetImageWithGuide = {
+  image: ImageContent;
+  step: KnockGuideStep;
+  guide: KnockGuide;
+};
+
 export type ButtonContent = {
   text: string;
   action: string;
@@ -9,7 +23,7 @@ export type TargetButton = ButtonContent & {
   name: string;
 };
 
-export type TargetButtonWithGuideContext = {
+export type TargetButtonWithGuide = {
   button: TargetButton;
   step: KnockGuideStep;
   guide: KnockGuide;


### PR DESCRIPTION
### What changed?

We are adding an optional image field to the Card and Modal out-of-the-box (OOTB) message types ([here](https://github.com/knocklabs/control/pull/5057)), which means our OOTB components need to be able to render it accordingly so this PR adds an image field to the Card and Modal components.

Also related: https://github.com/knocklabs/control/pull/5073

### Tasks
[KNO-8613](https://linear.app/knock/issue/KNO-8613/control-add-an-image-field-to-card-and-modal-ootb-schemas)

### Screenshots or Loom

**Card:** 
![CleanShot 2025-05-13 at 15 27 38@2x](https://github.com/user-attachments/assets/3681d37b-6c64-4b38-ac24-9fa7e7653e2d)

**Modal:**
![CleanShot 2025-05-13 at 16 26 54@2x](https://github.com/user-attachments/assets/274637d5-425a-44ec-b2be-448bf01ad4ca)

