### PR TITLE
chore(KNO-8638): add tests for useNotifications hook

### DIFF
--- a/packages/react-core/test/feed/useNotifications.test.tsx
+++ b/packages/react-core/test/feed/useNotifications.test.tsx
@@ -13,7 +13,7 @@ describe("useNotifications", () => {
     knock = new Knock("test_api_key");
   });
 
-  test("initializes and returns a new feed client (strict mode off)", () => {
+  test("initializes and returns a new feed client", () => {
     vi.spyOn(knock.feeds, "initialize");
 
     const options: FeedClientOptions = {
@@ -38,54 +38,8 @@ describe("useNotifications", () => {
     expect(feedClient.defaultOptions).toEqual(options);
   });
 
-  test("initializes and returns a new feed client (strict mode on)", () => {
-    vi.spyOn(knock.feeds, "initialize");
-    vi.spyOn(knock.feeds, "removeInstance");
-
-    const options: FeedClientOptions = {
-      archived: "include",
-      page_size: 10,
-      status: "all",
-    };
-
-    const { result } = renderHook(
-      () => useNotifications(knock, TEST_FEED_CHANNEL_ID, options),
-      { reactStrictMode: true },
-    );
-
-    const feedClient = result.current;
-
-    // useState initializers and useEffect hooks run twice in strict mode,
-    // so we should see 3 calls to initialize (2 in the useState initializer,
-    // 1 in the useEffect hook when the disposed feed is reinitialized)
-
-    expect(knock.feeds.initialize).toHaveBeenCalledTimes(3);
-    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
-      1,
-      TEST_FEED_CHANNEL_ID,
-      options,
-    );
-    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
-      2,
-      TEST_FEED_CHANNEL_ID,
-      options,
-    );
-    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
-      3,
-      TEST_FEED_CHANNEL_ID,
-      options,
-    );
-
-    expect(knock.feeds.removeInstance).toHaveBeenCalledTimes(1);
-    const disposedFeedClient = vi.mocked(knock.feeds.removeInstance).mock
-      .calls?.[0]?.[0];
-    // The disposed feed client should have the same feed ID,
-    // but should *not* be the same feed client instance
-    expect(disposedFeedClient?.feedId).toEqual(TEST_FEED_CHANNEL_ID);
-    expect(disposedFeedClient).not.toBe(feedClient);
-  });
-
-  test("disposes feed client on unmount", () => {
+  // KNO-8595: useNotifications hook does not dispose of feed client when component unmounts
+  test.fails("disposes feed client on unmount", () => {
     vi.spyOn(knock.feeds, "initialize");
     vi.spyOn(knock.feeds, "removeInstance");
 

--- a/packages/react-core/test/feed/useNotifications.test.tsx
+++ b/packages/react-core/test/feed/useNotifications.test.tsx
@@ -1,0 +1,200 @@
+import Knock, { FeedClientOptions } from "@knocklabs/client";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import useNotifications from "../../src/modules/feed/hooks/useNotifications";
+
+const TEST_FEED_CHANNEL_ID = "e84d5ddc-fd69-44ad-a431-68d784b8c306";
+
+describe("useNotifications", () => {
+  let knock: Knock;
+
+  beforeEach(() => {
+    knock = new Knock("test_api_key");
+  });
+
+  test("initializes and returns a new feed client (strict mode off)", () => {
+    vi.spyOn(knock.feeds, "initialize");
+
+    const options: FeedClientOptions = {
+      archived: "include",
+      page_size: 10,
+      status: "all",
+    };
+
+    const { result } = renderHook(
+      () => useNotifications(knock, TEST_FEED_CHANNEL_ID, options),
+      { reactStrictMode: false },
+    );
+
+    expect(knock.feeds.initialize).toHaveBeenCalledExactlyOnceWith(
+      TEST_FEED_CHANNEL_ID,
+      options,
+    );
+
+    const feedClient = result.current;
+    expect(feedClient).toBeDefined();
+    expect(feedClient.feedId).toEqual(TEST_FEED_CHANNEL_ID);
+    expect(feedClient.defaultOptions).toEqual(options);
+  });
+
+  test("initializes and returns a new feed client (strict mode on)", () => {
+    vi.spyOn(knock.feeds, "initialize");
+    vi.spyOn(knock.feeds, "removeInstance");
+
+    const options: FeedClientOptions = {
+      archived: "include",
+      page_size: 10,
+      status: "all",
+    };
+
+    const { result } = renderHook(
+      () => useNotifications(knock, TEST_FEED_CHANNEL_ID, options),
+      { reactStrictMode: true },
+    );
+
+    const feedClient = result.current;
+
+    // useState initializers and useEffect hooks run twice in strict mode,
+    // so we should see 3 calls to initialize (2 in the useState initializer,
+    // 1 in the useEffect hook when the disposed feed is reinitialized)
+
+    expect(knock.feeds.initialize).toHaveBeenCalledTimes(3);
+    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
+      1,
+      TEST_FEED_CHANNEL_ID,
+      options,
+    );
+    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
+      2,
+      TEST_FEED_CHANNEL_ID,
+      options,
+    );
+    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
+      3,
+      TEST_FEED_CHANNEL_ID,
+      options,
+    );
+
+    expect(knock.feeds.removeInstance).toHaveBeenCalledTimes(1);
+    const disposedFeedClient = vi.mocked(knock.feeds.removeInstance).mock
+      .calls?.[0]?.[0];
+    // The disposed feed client should have the same feed ID,
+    // but should *not* be the same feed client instance
+    expect(disposedFeedClient?.feedId).toEqual(TEST_FEED_CHANNEL_ID);
+    expect(disposedFeedClient).not.toBe(feedClient);
+  });
+
+  test("disposes feed client on unmount", () => {
+    vi.spyOn(knock.feeds, "initialize");
+    vi.spyOn(knock.feeds, "removeInstance");
+
+    const options: FeedClientOptions = {
+      archived: "include",
+      page_size: 10,
+      status: "all",
+    };
+
+    const { result, unmount } = renderHook(() =>
+      useNotifications(knock, TEST_FEED_CHANNEL_ID, options),
+    );
+
+    const feedClient = result.current;
+
+    // A feed client was initialized
+    expect(knock.feeds.initialize).toHaveBeenCalledTimes(1);
+    expect(result.current).toBeDefined();
+
+    unmount();
+
+    // The feed client was disposed
+    expect(knock.feeds.removeInstance).toHaveBeenCalledExactlyOnceWith(
+      feedClient,
+    );
+
+    // No additional feed clients were initialized
+    expect(knock.feeds.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  test("disposes existing feed client when feed ID changes", () => {
+    vi.spyOn(knock.feeds, "initialize");
+    vi.spyOn(knock.feeds, "removeInstance");
+
+    const feedId1 = TEST_FEED_CHANNEL_ID;
+    const feedId2 = "86784a77-b9ea-4683-85b3-7362b426e810";
+
+    const options: FeedClientOptions = {
+      archived: "include",
+      page_size: 10,
+      status: "all",
+    };
+
+    const { result, rerender } = renderHook(
+      (feedId: string) => useNotifications(knock, feedId, options),
+      { initialProps: feedId1 },
+    );
+
+    const feedClient1 = result.current;
+    rerender(feedId2);
+    const feedClient2 = result.current;
+
+    // The old feed client should be disposed
+    expect(knock.feeds.removeInstance).toHaveBeenCalledExactlyOnceWith(
+      feedClient1,
+    );
+
+    expect(knock.feeds.initialize).toHaveBeenCalledTimes(2);
+    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(2, feedId2, options);
+
+    // A new feed client should be created
+    expect(feedClient2).toBeDefined();
+    expect(feedClient2).not.toBe(feedClient1);
+    expect(feedClient2.feedId).toEqual(feedId2);
+    expect(feedClient2.defaultOptions).toEqual(options);
+  });
+
+  test("disposes existing feed client when options change", () => {
+    vi.spyOn(knock.feeds, "initialize");
+    vi.spyOn(knock.feeds, "removeInstance");
+
+    const options1: FeedClientOptions = {
+      archived: "include",
+      page_size: 10,
+      status: "all",
+    };
+
+    const options2: FeedClientOptions = {
+      archived: "exclude",
+      page_size: 10,
+      status: "read",
+    };
+
+    const { result, rerender } = renderHook(
+      (options: FeedClientOptions) =>
+        useNotifications(knock, TEST_FEED_CHANNEL_ID, options),
+      { initialProps: options1 },
+    );
+
+    const feedClient1 = result.current;
+    rerender(options2);
+    const feedClient2 = result.current;
+
+    // The old feed client should be disposed
+    expect(knock.feeds.removeInstance).toHaveBeenCalledExactlyOnceWith(
+      feedClient1,
+    );
+
+    expect(knock.feeds.initialize).toHaveBeenCalledTimes(2);
+    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
+      2,
+      TEST_FEED_CHANNEL_ID,
+      options2,
+    );
+
+    // A new feed client should be created
+    expect(feedClient2).toBeDefined();
+    expect(feedClient2).not.toBe(feedClient1);
+    expect(feedClient2.feedId).toEqual(TEST_FEED_CHANNEL_ID);
+    expect(feedClient2.defaultOptions).toEqual(options2);
+  });
+});

--- a/packages/react-core/test/feed/useNotifications.test.tsx
+++ b/packages/react-core/test/feed/useNotifications.test.tsx
@@ -22,9 +22,8 @@ describe("useNotifications", () => {
       status: "all",
     };
 
-    const { result } = renderHook(
-      () => useNotifications(knock, TEST_FEED_CHANNEL_ID, options),
-      { reactStrictMode: false },
+    const { result } = renderHook(() =>
+      useNotifications(knock, TEST_FEED_CHANNEL_ID, options),
     );
 
     expect(knock.feeds.initialize).toHaveBeenCalledExactlyOnceWith(
@@ -57,7 +56,7 @@ describe("useNotifications", () => {
 
     // A feed client was initialized
     expect(knock.feeds.initialize).toHaveBeenCalledTimes(1);
-    expect(result.current).toBeDefined();
+    expect(feedClient).toBeDefined();
 
     unmount();
 
@@ -98,6 +97,7 @@ describe("useNotifications", () => {
     );
 
     expect(knock.feeds.initialize).toHaveBeenCalledTimes(2);
+    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(1, feedId1, options);
     expect(knock.feeds.initialize).toHaveBeenNthCalledWith(2, feedId2, options);
 
     // A new feed client should be created
@@ -139,6 +139,11 @@ describe("useNotifications", () => {
     );
 
     expect(knock.feeds.initialize).toHaveBeenCalledTimes(2);
+    expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
+      1,
+      TEST_FEED_CHANNEL_ID,
+      options1,
+    );
     expect(knock.feeds.initialize).toHaveBeenNthCalledWith(
       2,
       TEST_FEED_CHANNEL_ID,


### PR DESCRIPTION
### Description

I’m working on refactoring the `useNotifications` hook to fix a memory leak that occurs due to the fact that the hook does not dispose of feed clients on unmount. I’m adding some test coverage to make sure I don’t break existing functionality.

### Checklist
- [X] Tests have been added for new features or major refactors to existing features.
