### PR TITLE
chore(KNO-8659): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+package.json @knocklabs/product
+yarn.lock @knocklabs/product

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    reviewers:
-      - "knocklabs/product"
     versioning-strategy: increase
     open-pull-requests-limit: 5
     groups:


### PR DESCRIPTION
### Description

This PR:
- Adds a `CODEOWNERS` file
- Removes the `reviewers` configuration option in `dependabot.yml`

See [_Dependabot reviewers configuration option being replaced by code owners_ on the GitHub blog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

### Checklist
- [X] Tests have been added for new features or major refactors to existing features.
