### PR TITLE
feat: add junit reporter for more granular test coverage data

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,3 +43,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: knocklabs/javascript
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules
 
 # Testing
 coverage
+test-report.junit.xml
 
 # Turbo
 .turbo

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run --config=./vitest/config.ts --workspace=./vitest/workspaces.ts",
     "test:watch": "vitest run --config=./vitest/config.ts --workspace=./vitest/workspaces.ts --watch",
     "test:coverage": "vitest run --config=./vitest/config.ts --workspace=./vitest/workspaces.ts --coverage",
-    "test:ci": "vitest run --config=./vitest/config.ts --workspace=./vitest/workspaces.ts --silent --coverage",
+    "test:ci": "vitest run --config=./vitest/config.ts --workspace=./vitest/workspaces.ts --silent --coverage --reporter=junit --outputFile=test-report.junit.xml",
     "type:check": "turbo type:check",
     "release": "yarn build:packages && yarn release:publish && yarn changeset tag",
     "release:publish": "yarn workspaces foreach -Rpt --no-private --from '@knocklabs/*' npm publish --access public --tolerate-republish",


### PR DESCRIPTION
### Description
Codecov has this nice test analytics feature that I think would be useful, seems easy enough to implement too!
> Test Analytics offers data on test run times, failure rates, and identifies flaky tests to help decrease the risk of deployment failures and make it easier to ship new features quickly.
