### PR TITLE
fix: ensure `this` is bound to guide client instance in handleLocationChange

### DIFF
--- a/.changeset/polite-heads-greet.md
+++ b/.changeset/polite-heads-greet.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: ensure this is bound to guide client instance in handleLocationChange

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -620,14 +620,15 @@ export class KnockGuideClient {
     });
   }
 
-  private handleLocationChange() {
+  // Define as an arrow func property to always bind this to the class instance.
+  private handleLocationChange = () => {
     const href = window.location.href;
     if (this.store.state.location === href) return;
 
     this.knock.log(`[Guide] Handle Location change: ${href}`);
 
     this.store.setState((state) => ({ ...state, location: href }));
-  }
+  };
 
   private listenForLocationChangesFromWindow() {
     if (window?.history) {


### PR DESCRIPTION
### Description
Fixes this sentry error: knock-labs-inc.sentry.io/issues/6651972538




