### PR TITLE
fix: canary release process

### DIFF
--- a/.changeset/spotty-plums-clap.md
+++ b/.changeset/spotty-plums-clap.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+---
+
+feat: Migrates the internal store library from zustand to @tanstack/store. This is a non-breaking change that maintains backwards compatibility with the @knocklabs/client and @knocklabs/react-core packages.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,8 @@ jobs:
       - name: Verify pre.json for pre-release branches
         if: steps.release-type.outputs.release-type != 'stable'
         run: |
-          tag=${{ steps.release-type.outputs.release-type }}
-          test -f .changeset/pre.json && grep "\"tag\": \"$tag\"" .changeset/pre.json \
-            || (echo "Expected .changeset/pre.json with tag=$tag" && exit 1)
+          jq -e '.mode=="pre" and .tag=="'${{ steps.release-type.outputs.release-type }}'"' .changeset/pre.json \
+            || { echo "::error::Incorrect prerelease mode for this branch"; exit 1; }
 
       # Prevent a stable release from being published if the repository
       # is still in Changesets prerelease mode (canary or rc).
@@ -90,7 +89,14 @@ jobs:
           commit: "chore(repo): version packages for ${{ steps.release-type.outputs.release-type }}"
           title: "chore(repo): version packages for ${{ steps.release-type.outputs.release-type }}"
           version: yarn changeset version
-          publish: yarn release
+          publish: |
+            # Map branch → correct npm dist-tag
+            TAG=${{ steps.release-type.outputs.release-type }}
+            [ "$TAG" = "stable" ] && TAG=latest
+            echo "NPM_CONFIG_TAG=$TAG" >> "$GITHUB_ENV"
+
+            # Publish with Changesets (honours NPM_CONFIG_TAG env-var)
+            yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:integration:runner": "cd ./integration && yarn test:integration && cd ..",
     "type:check": "turbo type:check",
     "release": "yarn build:packages && yarn changeset tag",
-    "release:publish": "yarn workspaces foreach -Rpt --no-private --from '@knocklabs/*' npm publish --access public --tolerate-republish",
     "postinstall": "manypkg check"
   },
   "prettier": "@knocklabs/prettier-config",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:integration:react-19": "./integration/run-integration.sh 19.1.0",
     "test:integration:runner": "cd ./integration && yarn test:integration && cd ..",
     "type:check": "turbo type:check",
-    "release": "yarn build:packages && yarn release:publish && yarn changeset tag",
+    "release": "yarn build:packages && yarn changeset tag",
     "release:publish": "yarn workspaces foreach -Rpt --no-private --from '@knocklabs/*' npm publish --access public --tolerate-republish",
     "postinstall": "manypkg check"
   },


### PR DESCRIPTION
### Description
- Updates `publish` script to correctly publish the tag that is set in the workflow
- Guards against prelease mode by throwing an error 
- Adds changeset for previous changes to test release 
