### PR TITLE
fix: set git user in action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
           yarn changeset version
           yarn install --mode=update-lockfile
 
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
           git add -A
           git commit -m "chore(repo): exit canary prerelease mode on merge to main"
           git push


### PR DESCRIPTION
### Description
 Ugh [this action](https://github.com/knocklabs/javascript/actions/runs/15909742565/job/44873795118) failed because I didn't set the git user, my robot lied to me. Now I'm setting the user based on [these docs](https://github.com/knocklabs/javascript/actions/runs/15909742565/job/44873795118). Hopefully this is the last CI fix 🙃.

