### PR TITLE
fix: too many arguments passed to changeset error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           commit: "chore(repo): version packages for ${{ steps.release-type.outputs.release-type }}"
           title: "chore(repo): version packages for ${{ steps.release-type.outputs.release-type }}"
-          version: yarn changeset version && yarn install --mode=update-lockfile
+          version: yarn release:version
           publish: yarn release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:integration:react-19": "./integration/run-integration.sh 19.1.0",
     "test:integration:runner": "cd ./integration && yarn test:integration && cd ..",
     "type:check": "turbo type:check",
+    "release:version": "yarn changeset version && yarn install --mode=update-lockfile",
     "release:publish": "yarn build:packages && yarn workspaces foreach -Rpt --no-private --from '@knocklabs/*' npm publish --access public --tolerate-republish --tag \"$NPM_CONFIG_TAG\" && yarn changeset tag",
     "postinstall": "manypkg check"
   },


### PR DESCRIPTION
### Description
Got this error from our [latest action run](https://github.com/knocklabs/javascript/actions/runs/15933823587/job/44949018949) this should fix it 
```
🦋  error Too many arguments passed to changesets - we only accept the command name as an argument
```
