### PR TITLE
feat: add as_user query param to list Slack channels method

### DIFF
--- a/.changeset/nice-turkeys-drum.md
+++ b/.changeset/nice-turkeys-drum.md
@@ -1,0 +1,7 @@
+---
+"slack-connect-example": patch
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+---
+
+feat: add as_user query param to list Slack channels method

--- a/examples/slack-connect-example/README.md
+++ b/examples/slack-connect-example/README.md
@@ -31,8 +31,8 @@ Note: you don't have to pre-create the tenant or connections object in Knock for
 ### Knock entities
 
 - `NEXT_PUBLIC_TENANT`: the ID of the tenant you want to use for holding the Slack access token
-- `NEXT_PUBLIC_SLACK_CHANNELS_RECIPIENT_COLLECTION`: the collection of the object that will store the slack channel connections (i.e. "projects")
-- `NEXT_PUBLIC_SLACK_CHANNELS_RECIPIENT_OBJECT_ID`: the id of the object that will store the slack channel connections (i.e. "projects")
+- `NEXT_PUBLIC_CONNECTIONS_COLLECTION`: the collection of the object that will store the slack channel connections (i.e. "projects")
+- `NEXT_PUBLIC_CONNECTIONS_OBJECT_ID`: the id of the object that will store the slack channel connections (i.e. "projects")
 
 ### Slack notification configuration
 

--- a/packages/client/src/clients/slack/index.ts
+++ b/packages/client/src/clients/slack/index.ts
@@ -31,7 +31,7 @@ class SlackClient {
   async getChannels(
     input: GetSlackChannelsInput,
   ): Promise<GetSlackChannelsResponse> {
-    const { knockChannelId, tenant } = input;
+    const { knockChannelId, tenant, asUser } = input;
     const queryOptions = input.queryOptions || {};
 
     const result = await this.instance.client().makeRequest({
@@ -43,6 +43,7 @@ class SlackClient {
           collection: TENANT_OBJECT_COLLECTION,
         },
         channel_id: knockChannelId,
+        as_user: asUser,
         query_options: {
           cursor: queryOptions.cursor,
           limit: queryOptions.limit,

--- a/packages/client/src/clients/slack/interfaces.ts
+++ b/packages/client/src/clients/slack/interfaces.ts
@@ -8,6 +8,7 @@ export type SlackChannelConnection = {
 export type GetSlackChannelsInput = {
   tenant: string;
   knockChannelId: string;
+  asUser?: boolean;
   queryOptions?: {
     limit?: number;
     cursor?: string;

--- a/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx
+++ b/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx
@@ -4,7 +4,10 @@ import { PropsWithChildren } from "react";
 
 import { slackProviderKey } from "../../core";
 import { useKnockClient } from "../../core";
-import { ConnectionStatus } from "../hooks/useSlackConnectionStatus";
+import {
+  ConnectionStatus,
+  SlackConnection,
+} from "../hooks/useSlackConnectionStatus";
 
 export interface KnockSlackProviderState {
   knockSlackChannelId: string;
@@ -13,6 +16,7 @@ export interface KnockSlackProviderState {
    * @deprecated Use `tenantId` instead. This field will be removed in a future release.
    */
   tenant: string;
+  connection: SlackConnection | null;
   connectionStatus: ConnectionStatus;
   setConnectionStatus: (connectionStatus: ConnectionStatus) => void;
   errorLabel: string | null;
@@ -46,6 +50,7 @@ export const KnockSlackProvider: React.FC<
   const knock = useKnockClient();
 
   const {
+    connection,
     connectionStatus,
     setConnectionStatus,
     errorLabel,
@@ -63,6 +68,7 @@ export const KnockSlackProvider: React.FC<
         errorLabel,
       })}
       value={{
+        connection,
         connectionStatus,
         setConnectionStatus,
         errorLabel,

--- a/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
+++ b/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts
@@ -45,13 +45,18 @@ function useSlackChannels({
   queryOptions,
 }: UseSlackChannelsOptions): UseSlackChannelOutput {
   const knock = useKnockClient();
-  const { knockSlackChannelId, tenantId, connectionStatus } =
+  const { knockSlackChannelId, tenantId, connection, connectionStatus } =
     useKnockSlackClient();
+
+  const asUser = useMemo(() => {
+    return connection?.ok && connection?.scopes?.includes("users:read.email");
+  }, [connection]);
 
   const fetchChannels = (queryKey: QueryKey) => {
     return knock.slack.getChannels({
       tenant: tenantId,
       knockChannelId: knockSlackChannelId,
+      asUser,
       queryOptions: {
         ...queryOptions,
         cursor: queryKey?.[1],

--- a/packages/react-core/src/modules/slack/hooks/useSlackConnectionStatus.ts
+++ b/packages/react-core/src/modules/slack/hooks/useSlackConnectionStatus.ts
@@ -3,6 +3,26 @@ import { useEffect, useState } from "react";
 
 import { useTranslations } from "../../i18n";
 
+// Connection based on https://api.slack.com/methods/auth.test#examples
+// Also includes x-oauth-scopes
+type SlackConnectionSuccess = {
+  ok: true;
+  url: string;
+  team: string;
+  user: string;
+  team_id: string;
+  user_id: string;
+  bot_id?: string;
+  scopes?: string[];
+};
+
+type SlackConnectionError = {
+  ok: false;
+  error: string;
+};
+
+export type SlackConnection = SlackConnectionSuccess | SlackConnectionError;
+
 export type ConnectionStatus =
   | "connecting"
   | "connected"
@@ -11,6 +31,7 @@ export type ConnectionStatus =
   | "disconnecting";
 
 type UseSlackConnectionStatusOutput = {
+  connection: SlackConnection | null;
   connectionStatus: ConnectionStatus;
   setConnectionStatus: (status: ConnectionStatus) => void;
   errorLabel: string | null;
@@ -37,6 +58,7 @@ function useSlackConnectionStatus(
   tenantId: string,
 ): UseSlackConnectionStatusOutput {
   const { t } = useTranslations();
+  const [connection, setConnection] = useState<SlackConnection | null>(null);
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("connecting");
   const [errorLabel, setErrorLabel] = useState<string | null>(null);
@@ -51,6 +73,8 @@ function useSlackConnectionStatus(
           tenant: tenantId,
           knockChannelId: knockSlackChannelId,
         });
+
+        setConnection(authRes.connection);
 
         if (authRes.connection?.ok) {
           return setConnectionStatus("connected");
@@ -90,6 +114,7 @@ function useSlackConnectionStatus(
   }, [connectionStatus, tenantId, knockSlackChannelId, knock.slack, t]);
 
   return {
+    connection,
     connectionStatus,
     setConnectionStatus,
     errorLabel,


### PR DESCRIPTION
### Description
Passes through the Slack `connection` from the auth check call to the list channels method so that when we fetch Slack channels we can know if the given token has the appropriate scopes. 

Q: This is used to avoid trying to resolve the Slack user id by email when the auth token doesn't have the right scopes. Do we want to add this complexity here or should we just always try to resolve the user id even if we may not have the right scopes? We'll still fallback either way to fetching all public channels. 
