### PR TITLE
chore: remove dependabot ignore deps that are no longer needed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,6 @@ updates:
         patterns:
           - "@telegraph/*"
     ignore:
-      - dependency-name: "@radix-ui/react-popover"
-      - dependency-name: "@radix-ui/react-visually-hidden"
       # nanoid >3 drops support for cjs
       - dependency-name: "nanoid"
         versions: [">=4.0.0"]
-      # We cannot upgrade tanstack store to >=0.7.0 at the moment until we are
-      # ready to require more recent typescript version (likely v5.4 or greater)
-      # See: https://github.com/knocklabs/javascript/pull/520
-      - dependency-name: "@tanstack/store"
-      - dependency-name: "@tanstack/react-store"


### PR DESCRIPTION
### Description
All of these deps were previously ignore because of react 19 and old typescript versions. This is no longer relevant so we should receive updates on these dependencies now.