### PR TITLE
fix: ignore messages that don't come from Knock in KnockExpoPushNotificationProvider

### DIFF
--- a/.changeset/short-cameras-see.md
+++ b/.changeset/short-cameras-see.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/expo": patch
+---
+
+updates KnockExpoPushNotificationProvider to ignore messages that do not come from knock

--- a/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
+++ b/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
@@ -169,10 +169,20 @@ const InternalKnockExpoPushNotificationProvider: React.FC<
     async (
       notification: Notifications.Notification,
       status: MessageEngagementStatus,
-    ): Promise<Message> => {
-      const messageId = notification.request.content.data[
+    ): Promise<Message | void> => {
+      const messageId = notification.request.content.data?.[
         "knock_message_id"
-      ] as string;
+      ] as string | undefined;
+
+      // Skip status update if this isn't a Knock notification
+      // Fixes issue: https://github.com/knocklabs/javascript/issues/589
+      if (!messageId) {
+        knockClient.log(
+          "[Knock] Skipping status update for non-Knock notification",
+        );
+        return;
+      }
+
       return knockClient.messages.updateStatus(messageId, status);
     },
     [knockClient],


### PR DESCRIPTION
### Description
As reported in #589, the `KnockExpoPushNotificationProvider` tries to process messages that don't come from knock which results in 404 errors. This PR adds a check to `updateKnockMessageStatusFromNotification` that ensures that only messages which contain `knock_message_id` are processed, the rest being ignored. 
