### PR TITLE
fix: prevent popover from reopening when clicking notification icon button

### DIFF
--- a/.changeset/public-pants-obey.md
+++ b/.changeset/public-pants-obey.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+fix: prevent popover from reopening when clicking notification icon button

--- a/packages/react/src/modules/feed/components/NotificationFeedPopover/NotificationFeedPopover.tsx
+++ b/packages/react/src/modules/feed/components/NotificationFeedPopover/NotificationFeedPopover.tsx
@@ -43,9 +43,22 @@ export const NotificationFeedPopover: React.FC<
   const { colorMode, feedClient, useFeedStore } = useKnockFeed();
   const store = useFeedStore();
 
-  const { ref: popperRef } = useComponentVisible(isVisible, onClose, {
-    closeOnClickOutside,
-  });
+  const { ref: popperRef } = useComponentVisible(
+    isVisible,
+    (event) => {
+      // If the button is clicked, let that onClick handler handle the close
+      if (
+        event.target instanceof Element &&
+        buttonRef.current?.contains(event.target)
+      ) {
+        return;
+      }
+      onClose(event);
+    },
+    {
+      closeOnClickOutside,
+    },
+  );
 
   useEffect(() => {
     // Whenever the feed is opened, we want to invoke the `onOpen` callback

--- a/packages/react/test/feed/NotificationFeedPopover.test.tsx
+++ b/packages/react/test/feed/NotificationFeedPopover.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import React, { createRef } from "react";
 import { describe, expect, test, vi } from "vitest";
 
@@ -66,5 +66,32 @@ describe("NotificationFeedPopover", () => {
     );
 
     expect(popover.style.visibility).toBe("visible");
+  });
+
+  test("onClose is not called when clicking the button but is called when clicking outside", () => {
+    const buttonRef = createRef<HTMLButtonElement>();
+    const onClose = vi.fn();
+
+    const { container } = render(
+      <>
+        <button ref={buttonRef}>toggle</button>
+        <NotificationFeedPopover
+          isVisible={true}
+          onClose={onClose}
+          buttonRef={buttonRef}
+        />
+        <div data-testid="outside">Outside element</div>
+      </>,
+    );
+
+    // Click the button - onClose should not be called
+    const button = container.querySelector("button");
+    fireEvent.click(button!);
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Click outside - onClose should be called
+    const outsideElement = container.querySelector("[data-testid='outside']");
+    fireEvent.click(outsideElement!);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Description
As outlined in #191, when clicking the `<NotificationIconButton/>` while the `<NotificationFeedPopover/>` component is open, the popover will reopen instead of closing. This was happening because we weren't detecting if the `closeOnOutsideClick` handler was triggered by clicking on the `<NotificationIconButton/>`. This PR adds a check to the `closeOnOutsideClick` handler to skip the `onClose` event when the `<NotificationIconButton/>` is clicked and instead let the button handle the `onClose` instead. Also, we add a test to verify this functionality. 
