### PR TITLE
fix: guard against no id to fix next build

### DIFF
--- a/examples/nextjs-example/pages/custom.tsx
+++ b/examples/nextjs-example/pages/custom.tsx
@@ -23,6 +23,8 @@ function ProviderComponent({ children }: { children: React.ReactNode }) {
     return json.userToken;
   }, [userId]);
 
+  if (!userId) return;
+
   return (
     <KnockProvider
       user={{ id: userId }}

--- a/examples/nextjs-example/pages/index.tsx
+++ b/examples/nextjs-example/pages/index.tsx
@@ -37,6 +37,8 @@ export default function Home() {
     return json.userToken;
   }, [userId]);
 
+  if (!userId) return;
+
   return (
     <KnockProvider
       user={{ id: userId }}


### PR DESCRIPTION
### Description
The code in the example app still try to run if there's no id, but we need an id. So this PR puts guards in front of running that code until `useIdentify` runs.
