### PR TITLE
Make token (un)registration methods in KnockPushNotificationProvider awaitable

### DIFF
--- a/packages/react-native/src/modules/push/KnockPushNotificationProvider.tsx
+++ b/packages/react-native/src/modules/push/KnockPushNotificationProvider.tsx
@@ -3,11 +3,11 @@ import { useKnockClient } from "@knocklabs/react-core";
 import React, { createContext, useCallback, useContext } from "react";
 
 export interface KnockPushNotificationContextType {
-  registerPushTokenToChannel(token: string, channelId: string): Promise<void>;
+  registerPushTokenToChannel(token: string, channelId: string): Promise<ChannelData | void>;
   unregisterPushTokenFromChannel(
     token: string,
     channelId: string,
-  ): Promise<void>;
+  ): Promise<ChannelData | void>;
 }
 
 const KnockPushNotificationContext = createContext<
@@ -34,8 +34,8 @@ export const KnockPushNotificationProvider: React.FC<
   );
 
   const registerPushTokenToChannel = useCallback(
-    async (token: string, channelId: string): Promise<void> => {
-      knockClient.user
+    async (token: string, channelId: string): Promise<ChannelData | void> => {
+      return knockClient.user
         .getChannelData({ channelId: channelId })
         .then((result: ChannelData) => {
           const tokens: string[] = result.data["tokens"];
@@ -54,8 +54,8 @@ export const KnockPushNotificationProvider: React.FC<
   );
 
   const unregisterPushTokenFromChannel = useCallback(
-    async (token: string, channelId: string): Promise<void> => {
-      knockClient.user
+    async (token: string, channelId: string): Promise<ChannelData | void> => {
+      return knockClient.user
         .getChannelData({ channelId: channelId })
         .then((result: ChannelData) => {
           const tokens: string[] = result.data["tokens"];


### PR DESCRIPTION
### Description
The methods `registerPushTokenToChannel` and `unregisterPushTokenFromChannel` in the `KnockPushNotificationProvider` are currently async - however, they don't actually await any of the operations they perform. If you call these methods and await them, they promises they return will resolve before their actual operations are done.

Now, similar to `registerNewTokenDataOnServer`, the promises created within the functions are returned, so callers can properly await the completion of the operations.

