### PR TITLE
feat: usePreferences hook

### DIFF
--- a/.changeset/plenty-ants-camp.md
+++ b/.changeset/plenty-ants-camp.md
@@ -3,4 +3,4 @@
 "@knocklabs/react": patch
 ---
 
-feat: adds `usePreferences` hook for fetching and updatings user preferences in react apps.
+feat: adds `usePreferences` hook for fetching and updating user preferences in react apps.

--- a/.changeset/plenty-ants-camp.md
+++ b/.changeset/plenty-ants-camp.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/react": patch
+---
+
+feat: adds `usePreferences` hook for fetching and updatings user preferences in react apps.

--- a/examples/nextjs-example/components/NotificationPreferences.tsx
+++ b/examples/nextjs-example/components/NotificationPreferences.tsx
@@ -1,0 +1,104 @@
+import type {
+  SetPreferencesProperties,
+  WorkflowPreferences,
+} from "@knocklabs/client";
+import { usePreferences } from "@knocklabs/react";
+import { Stack } from "@telegraph/layout";
+import { Text } from "@telegraph/typography";
+
+type WorkflowPreferencesProps = {
+  preferences: WorkflowPreferences | undefined;
+  onPreferencesChange: (preferenceSet: SetPreferencesProperties) => void;
+};
+
+const WorkflowPreferences = ({
+  preferences,
+  onPreferencesChange,
+}: WorkflowPreferencesProps) => {
+  return Object.entries(preferences ?? {}).map(([key, value]) => {
+    if (!value || typeof value === "boolean") {
+      return (
+        <Stack key={key} direction="row" gap="2">
+          <Text as="span">{key}</Text>
+          <input
+            type="checkbox"
+            checked={value}
+            onChange={(event) => {
+              const checked = event.target.checked;
+
+              onPreferencesChange({
+                workflows: {
+                  ...preferences,
+                  [key]: checked,
+                },
+                categories: {},
+                channel_types: {},
+              });
+            }}
+          />
+        </Stack>
+      );
+    }
+
+    if (typeof value === "object" && "channel_types" in value) {
+      return (
+        <Stack key={key} direction="column" gap="2">
+          <Text as="span">{key}</Text>
+          {Object.entries(value.channel_types).map(
+            ([channelKey, channelValue]) => {
+              if (typeof channelValue !== "boolean") return;
+
+              return (
+                <Stack key={channelKey} direction="row" gap="2" ml="8">
+                  <Text as="span">{channelKey}</Text>
+                  <input
+                    type="checkbox"
+                    checked={channelValue}
+                    onChange={(event) => {
+                      const checked = event.target.checked;
+
+                      onPreferencesChange({
+                        workflows: {
+                          ...preferences,
+                          [key]: {
+                            ...value,
+                            channel_types: {
+                              ...value.channel_types,
+                              [channelKey]: checked,
+                            },
+                          },
+                        },
+                        categories: {},
+                        channel_types: {},
+                      });
+                    }}
+                  />
+                </Stack>
+              );
+            },
+          )}
+        </Stack>
+      );
+    }
+  });
+};
+
+const NotificationPreferences = () => {
+  const { preferences, setPreferences } = usePreferences();
+
+  return (
+    <Stack border="px" rounded="3" padding="4" direction="column" gap="2">
+      <Text as="h1" size="4">
+        Notification Preferences
+      </Text>
+      {preferences?.workflows && (
+        <WorkflowPreferences
+          preferences={preferences?.workflows}
+          onPreferencesChange={setPreferences}
+        />
+      )}
+    </Stack>
+  );
+};
+
+export { NotificationPreferences };

--- a/examples/nextjs-example/pages/preferences.tsx
+++ b/examples/nextjs-example/pages/preferences.tsx
@@ -1,0 +1,35 @@
+import { KnockProvider } from "@knocklabs/react";
+import { useCallback } from "react";
+
+import { NotificationPreferences } from "../components/NotificationPreferences";
+import useIdentify from "../hooks/useIdentify";
+
+const Preferences = () => {
+  const { userId, userToken } = useIdentify();
+
+  const tokenRefreshHandler = useCallback(async () => {
+    // Refresh the user token 1s before it expires
+    const res = await fetch(`/api/auth?id=${userId}`);
+    const json = await res.json();
+
+    return json.userToken;
+  }, [userId]);
+
+  if (!userId) return;
+
+  return (
+    <KnockProvider
+      user={{ id: userId }}
+      userToken={userToken}
+      apiKey={process.env.NEXT_PUBLIC_KNOCK_PUBLIC_API_KEY!}
+      host={process.env.NEXT_PUBLIC_KNOCK_HOST}
+      onUserTokenExpiring={tokenRefreshHandler}
+      timeBeforeExpirationInMs={5000}
+      logLevel="debug"
+    >
+      <NotificationPreferences />
+    </KnockProvider>
+  );
+};
+
+export default Preferences;

--- a/examples/nextjs-example/pages/preferences.tsx
+++ b/examples/nextjs-example/pages/preferences.tsx
@@ -8,7 +8,7 @@ const Preferences = () => {
   const { userId, userToken } = useIdentify();
 
   const tokenRefreshHandler = useCallback(async () => {
-    // Refresh the user token 1s before it expires
+    // Refresh the user token 5s before it expires
     const res = await fetch(`/api/auth?id=${userId}`);
     const json = await res.json();
 

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -66,3 +66,5 @@ export {
   useTranslations,
 } from "./modules/i18n";
 export { type RecipientObject } from "./interfaces";
+
+export { usePreferences } from "./modules/preferences";

--- a/packages/react-core/src/modules/preferences/hooks/index.ts
+++ b/packages/react-core/src/modules/preferences/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePreferences } from "./usePreferences";

--- a/packages/react-core/src/modules/preferences/hooks/usePreferences.ts
+++ b/packages/react-core/src/modules/preferences/hooks/usePreferences.ts
@@ -1,0 +1,69 @@
+import type {
+  GetPreferencesOptions,
+  PreferenceSet,
+  SetPreferencesProperties,
+} from "@knocklabs/client";
+import { useCallback } from "react";
+import useSWR, { type SWRResponse } from "swr";
+
+import { useKnockClient } from "../../core";
+
+type UsePreferencesReturn = {
+  preferences: PreferenceSet | undefined;
+  setPreferences: (setPreferencesProperties: SetPreferencesProperties) => void;
+  getAllPreferences: ReturnType<
+    typeof useKnockClient
+  >["user"]["getAllPreferences"];
+  isLoading: SWRResponse["isLoading"];
+  isValidating: SWRResponse["isValidating"];
+};
+
+const usePreferences = (
+  options: GetPreferencesOptions = {},
+): UsePreferencesReturn => {
+  const knock = useKnockClient();
+
+  const { preferenceSet, tenant } = options;
+
+  const CACHE_KEY = [
+    "preferences",
+    options.preferenceSet,
+    options.tenant,
+    knock.userId,
+  ];
+
+  const {
+    data: preferences,
+    isLoading,
+    isValidating,
+    mutate,
+  } = useSWR(knock.userId ? CACHE_KEY : null, () => {
+    return knock.user.getPreferences({ preferenceSet, tenant });
+  });
+
+  const setPreferences = useCallback(
+    (preferenceSetProperties: SetPreferencesProperties) => {
+      mutate(
+        knock.user.setPreferences(preferenceSetProperties, { preferenceSet }),
+        {
+          revalidate: false,
+        },
+      );
+    },
+    [mutate, knock.user, preferenceSet],
+  );
+
+  const getAllPreferences = useCallback(async () => {
+    return await knock.user.getAllPreferences();
+  }, [knock.user]);
+
+  return {
+    getAllPreferences,
+    setPreferences,
+    preferences,
+    isLoading,
+    isValidating,
+  };
+};
+
+export { usePreferences };

--- a/packages/react-core/src/modules/preferences/index.ts
+++ b/packages/react-core/src/modules/preferences/index.ts
@@ -1,0 +1,1 @@
+export { usePreferences } from "./hooks";

--- a/packages/react-core/test/preferences/usePreferences.test.tsx
+++ b/packages/react-core/test/preferences/usePreferences.test.tsx
@@ -30,7 +30,6 @@ function buildSWRMock() {
         // The real SWR implementation would call the fetcher and store the
         // promise result – we don't need the result here, just the side-effect
         // for our assertions.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         fetcher();
       }
 

--- a/packages/react-core/test/preferences/usePreferences.test.tsx
+++ b/packages/react-core/test/preferences/usePreferences.test.tsx
@@ -1,0 +1,169 @@
+import type { SetPreferencesProperties } from "@knocklabs/client";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePreferences } from "../../src/modules/preferences/hooks/usePreferences";
+
+// ----------------------------------------------------------------------------------
+// Shared mocks & helpers
+// ----------------------------------------------------------------------------------
+
+// Stub SWR mutate so we can assert calls
+const mutateMock = vi.fn();
+
+// Shared preferences payload used across tests and SWR mock.
+// Define it with `let` so it exists in temporal scope before initialization.
+let DEFAULT_PREFERENCES: Readonly<SetPreferencesProperties & { id?: string }>;
+
+// We'll assign the actual value *before* our tests run (see below). This avoids
+// the Temporal Dead Zone issue when the SWR mock factory is evaluated early by
+// Vitest's hoisting mechanism.
+
+// Build an SWR mock factory that invokes the provided fetcher so we can assert
+// that Knock.user.getPreferences is executed.
+function buildSWRMock() {
+  return {
+    __esModule: true,
+    default: (key: unknown, fetcher?: () => Promise<unknown>) => {
+      // SWR will only invoke the fetcher when the key is non-null.
+      if (key && typeof fetcher === "function") {
+        // The real SWR implementation would call the fetcher and store the
+        // promise result – we don't need the result here, just the side-effect
+        // for our assertions.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        fetcher();
+      }
+
+      return {
+        // Provide a dynamic getter so we don't evaluate `DEFAULT_PREFERENCES`
+        // before it has been initialised.
+        get data() {
+          return DEFAULT_PREFERENCES;
+        },
+        mutate: mutateMock,
+        isLoading: false,
+        isValidating: false,
+      };
+    },
+  };
+}
+
+vi.mock("swr", () => buildSWRMock());
+
+// ----------------------------------------------------------------------------------
+// Mock Knock client and surrounding hooks
+// ----------------------------------------------------------------------------------
+
+// We'll define these mocks now and (re)assign their resolved values once
+// `DEFAULT_PREFERENCES` is initialised.
+const mockGetPreferences = vi.fn();
+const mockSetPreferences = vi.fn().mockResolvedValue(undefined);
+const mockGetAllPreferences = vi.fn().mockResolvedValue({ all: true });
+
+// Declare the variable without immediate initialization to avoid TDZ issues
+let useKnockClientMock: ReturnType<typeof vi.fn>;
+
+vi.mock("../../src/modules/core", () => ({
+  useKnockClient: (...args: unknown[]) => useKnockClientMock(...args),
+}));
+
+function createKnockClient({ userId = "user_1" } = {}) {
+  return {
+    userId,
+    user: {
+      getPreferences: mockGetPreferences,
+      setPreferences: mockSetPreferences,
+      getAllPreferences: mockGetAllPreferences,
+    },
+  } as const;
+}
+
+// ----------------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------------
+
+describe("usePreferences", () => {
+  // Prepare mocks and shared data before each test
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    DEFAULT_PREFERENCES = {
+      workflows: {},
+      categories: {
+        email: {
+          channel_types: { email: true, in_app_feed: true },
+        },
+      },
+      channel_types: {},
+    };
+
+    mockGetPreferences.mockResolvedValue(DEFAULT_PREFERENCES);
+
+    // Provide a fresh mocked Knock client for each test run
+    useKnockClientMock = vi.fn();
+    useKnockClientMock.mockReturnValue(createKnockClient());
+  });
+
+  it("returns preference data and loading flags from SWR", () => {
+    const { result } = renderHook(() =>
+      usePreferences({ preferenceSet: "marketing", tenant: "tenant_1" }),
+    );
+
+    expect(result.current.preferences).toEqual(DEFAULT_PREFERENCES);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isValidating).toBe(false);
+
+    // The SWR mock calls the fetcher immediately, so Knock.user.getPreferences
+    // should have been invoked with the provided options
+    expect(mockGetPreferences).toHaveBeenCalledWith({
+      preferenceSet: "marketing",
+      tenant: "tenant_1",
+    });
+  });
+
+  it("exposes a setPreferences helper that forwards calls to Knock and triggers mutate", async () => {
+    const { result } = renderHook(() =>
+      usePreferences({ preferenceSet: "marketing" }),
+    );
+
+    const newPreferences: SetPreferencesProperties = {
+      workflows: {},
+      categories: {
+        sms: { channel_types: { sms: true } },
+      },
+      channel_types: {},
+    };
+
+    await act(async () => {
+      result.current.setPreferences(newPreferences);
+    });
+
+    expect(mockSetPreferences).toHaveBeenCalledWith(newPreferences, {
+      preferenceSet: "marketing",
+    });
+    expect(mutateMock).toHaveBeenCalled();
+  });
+
+  it("exposes getAllPreferences helper that proxies to Knock.user.getAllPreferences", async () => {
+    const { result } = renderHook(() => usePreferences());
+
+    await act(async () => {
+      await result.current.getAllPreferences();
+    });
+
+    expect(mockGetAllPreferences).toHaveBeenCalled();
+  });
+
+  it("does not fetch preferences when there is no authenticated user", () => {
+    // Override useKnockClient to return a client with no userId
+    useKnockClientMock.mockReturnValue(
+      createKnockClient({ userId: null as unknown as undefined }),
+    );
+
+    const callsBefore = mockGetPreferences.mock.calls.length;
+
+    renderHook(() => usePreferences());
+
+    expect(mockGetPreferences.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -120,4 +120,5 @@ export {
   type Translations,
   useTranslations,
   type RecipientObject,
+  usePreferences,
 } from "@knocklabs/react-core";


### PR DESCRIPTION
### Description
- Adds `usePreferences` hook.
- Fetches preferences based on the options provided to the hook.
- Updates preferences based on the options provided to the hook.
- Allows fetching of all preferences with the `getAllPreferences` function.
- Uses SWR to simplify code. 
- Adds comprehensive tests resulting in 100% test coverage on the hook.
- Updates `@knocklabs/react` to contain export for hook.
- Adds example app for utilizing the hook.
