### PR TITLE
fix: unstable user prop for KnockProvider

### DIFF
--- a/.changeset/shaky-dolls-occur.md
+++ b/.changeset/shaky-dolls-occur.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+fix: make the user prop to KnockProvider stable by comparing equality, and prevent re-instantiating the knock client unnecessarily

--- a/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
+++ b/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
@@ -50,7 +50,9 @@ function useAuthenticatedKnockClient(
   options: AuthenticatedKnockClientOptions = {},
 ) {
   const knockRef = React.useRef<Knock | undefined>(undefined);
+
   const stableOptions = useStableOptions(options);
+  const stableUserIdOrObject = useStableOptions(userIdOrUserWithProperties);
 
   return React.useMemo(() => {
     const userId =
@@ -94,7 +96,7 @@ function useAuthenticatedKnockClient(
     knockRef.current = knock;
 
     return knock;
-  }, [apiKey, userIdOrUserWithProperties, userToken, stableOptions]);
+  }, [apiKey, stableUserIdOrObject, userToken, stableOptions]);
 }
 
 export default useAuthenticatedKnockClient;

--- a/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
+++ b/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
@@ -56,9 +56,9 @@ function useAuthenticatedKnockClient(
 
   return React.useMemo(() => {
     const userId =
-      typeof userIdOrUserWithProperties === "string"
-        ? userIdOrUserWithProperties
-        : userIdOrUserWithProperties?.id;
+      typeof stableUserIdOrObject === "string"
+        ? stableUserIdOrObject
+        : stableUserIdOrObject?.id;
 
     const currentKnock = knockRef.current;
 
@@ -70,7 +70,7 @@ function useAuthenticatedKnockClient(
     ) {
       authenticateWithOptions(
         currentKnock,
-        userIdOrUserWithProperties,
+        stableUserIdOrObject,
         userToken,
         stableOptions,
       );
@@ -89,7 +89,7 @@ function useAuthenticatedKnockClient(
 
     authenticateWithOptions(
       knock,
-      userIdOrUserWithProperties,
+      stableUserIdOrObject,
       userToken,
       stableOptions,
     );


### PR DESCRIPTION
### Description
Fixes an issue reported here: https://knocklabs.slack.com/archives/C079G6X3DD4/p1752604990749029

With the [recent changes](https://github.com/knocklabs/javascript/pull/626) we shipped for inline identifying a user in KnockProvider, we now take a `user` prop as an object. And this can lead to re-initializing the knock client, which causes downstream effects like re-initializing the guide client multiple times over a render cycle. 

In this PR we use `useStableOptions` for `userIdOrUserWithProperties` as it is used in the `useAuthenticatedKnockClient` hook's dep array. 
