### PR TITLE
fix: remove no-wait flag from expo build action

### DIFF
--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -25,4 +25,4 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Build on EAS
-        run: cd examples/expo-example && eas build --platform android --non-interactive --no-wait
+        run: cd examples/expo-example && eas build --platform android --non-interactive


### PR DESCRIPTION
### Description
Removes the no wait flag so we can actually evaluate if the expo build succeeded. This step currently isn't required to pass for PR merge because of the long build times.
