### PR TITLE
chore(KNO-9276): rename msTeamsBotId to graphApiClientId

### DIFF
--- a/.changeset/chilly-needles-boil.md
+++ b/.changeset/chilly-needles-boil.md
@@ -1,0 +1,6 @@
+---
+"ms-teams-connect-example": patch
+"@knocklabs/react": patch
+---
+
+Rename `msTeamsBotId` prop of `<MsTeamsAuthButton>` component to `graphApiClientId`

--- a/.changeset/nasty-roses-happen.md
+++ b/.changeset/nasty-roses-happen.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+Rename `msTeamsBotId` param of `useMsTeamsAuth` hook to `graphApiClientId`

--- a/examples/ms-teams-connect-example/.env.sample
+++ b/examples/ms-teams-connect-example/.env.sample
@@ -9,7 +9,7 @@ NEXT_PUBLIC_TENANT_ID=<tenant id>
 NEXT_PUBLIC_CONNECTIONS_COLLECTION=<connections object collection>
 NEXT_PUBLIC_CONNECTIONS_OBJECT_ID=<connections object id>
 
-NEXT_PUBLIC_MS_TEAMS_BOT_ID=<ms teams bot id>
+NEXT_PUBLIC_GRAPH_API_CLIENT_ID=<graph api client id>
 
 # You can find your MS Teams Channel ID in the Knock dashboard under
 # https://knock-dev.app/<ACCOUNT SLUG>/integrations/channels, navigate to

--- a/examples/ms-teams-connect-example/README.md
+++ b/examples/ms-teams-connect-example/README.md
@@ -26,7 +26,7 @@ Note: you don't have to pre-create the tenant or connections object in Knock for
 
 ### Microsoft Teams notification configuration
 
-- `NEXT_PUBLIC_MS_TEAMS_BOT_ID`: the ID of your Microsoft Teams bot
+- `NEXT_PUBLIC_GRAPH_API_CLIENT_ID`: the client ID of your Microsoft Graph API-enabled application registered with Microsoft Entra. This should match the "Graph API client ID" setting of your Microsoft Teams channel in the Knock dashboard.
 - `NEXT_PUBLIC_KNOCK_MS_TEAMS_CHANNEL_ID`: in the Knock dashboard on the Microsoft Teams channel
 - `NEXT_PUBLIC_REDIRECT_URL`: set this to http://localhost:3000/ if running locally
 

--- a/examples/ms-teams-connect-example/pages/index.tsx
+++ b/examples/ms-teams-connect-example/pages/index.tsx
@@ -111,7 +111,9 @@ export default function Home() {
               </div>
               <div style={{ margin: "10px", padding: "10px" }}>
                 <MsTeamsAuthButton
-                  graphApiClientId={process.env.NEXT_PUBLIC_MS_TEAMS_BOT_ID!}
+                  graphApiClientId={
+                    process.env.NEXT_PUBLIC_GRAPH_API_CLIENT_ID!
+                  }
                   redirectUrl={redirectUrl}
                   onAuthenticationComplete={onAuthComplete}
                 />
@@ -132,7 +134,9 @@ export default function Home() {
               <MsTeamsAuthContainer
                 actionButton={
                   <MsTeamsAuthButton
-                    graphApiClientId={process.env.NEXT_PUBLIC_MS_TEAMS_BOT_ID!}
+                    graphApiClientId={
+                      process.env.NEXT_PUBLIC_GRAPH_API_CLIENT_ID!
+                    }
                     redirectUrl={redirectUrl}
                     onAuthenticationComplete={onAuthComplete}
                   />

--- a/examples/ms-teams-connect-example/pages/index.tsx
+++ b/examples/ms-teams-connect-example/pages/index.tsx
@@ -111,7 +111,7 @@ export default function Home() {
               </div>
               <div style={{ margin: "10px", padding: "10px" }}>
                 <MsTeamsAuthButton
-                  msTeamsBotId={process.env.NEXT_PUBLIC_MS_TEAMS_BOT_ID!}
+                  graphApiClientId={process.env.NEXT_PUBLIC_MS_TEAMS_BOT_ID!}
                   redirectUrl={redirectUrl}
                   onAuthenticationComplete={onAuthComplete}
                 />
@@ -132,7 +132,7 @@ export default function Home() {
               <MsTeamsAuthContainer
                 actionButton={
                   <MsTeamsAuthButton
-                    msTeamsBotId={process.env.NEXT_PUBLIC_MS_TEAMS_BOT_ID!}
+                    graphApiClientId={process.env.NEXT_PUBLIC_MS_TEAMS_BOT_ID!}
                     redirectUrl={redirectUrl}
                     onAuthenticationComplete={onAuthComplete}
                   />

--- a/integration/tests/react/ms-teams/MsTeamsComponents.test.tsx
+++ b/integration/tests/react/ms-teams/MsTeamsComponents.test.tsx
@@ -1,14 +1,13 @@
-import React from "react";
 import {
-  KnockProvider,
   KnockMsTeamsProvider,
+  KnockProvider,
   MsTeamsAuthButton,
   MsTeamsAuthContainer,
   MsTeamsChannelCombobox,
 } from "@knocklabs/react";
 import { render } from "@testing-library/react";
-import { describe, it  } from "vitest";
-
+import React from "react";
+import { describe, it } from "vitest";
 
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <KnockProvider apiKey="test" userId="user">
@@ -19,7 +18,15 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 );
 
 describe("MsTeams components render", () => {
-  it("MsTeamsAuthButton renders", () => {
+  it("MsTeamsAuthButton renders with graphApiClientId prop", () => {
+    render(
+      <Wrapper>
+        <MsTeamsAuthButton graphApiClientId="clientId" />
+      </Wrapper>,
+    );
+  });
+
+  it("MsTeamsAuthButton renders with deprecated msTeamsBotId prop", () => {
     render(
       <Wrapper>
         <MsTeamsAuthButton msTeamsBotId="bot" />
@@ -38,8 +45,13 @@ describe("MsTeams components render", () => {
   it("MsTeamsChannelCombobox renders", () => {
     render(
       <Wrapper>
-        <MsTeamsChannelCombobox msTeamsChannelsRecipientObject={{ objectId: "1", collection: "users" }} />
+        <MsTeamsChannelCombobox
+          msTeamsChannelsRecipientObject={{
+            objectId: "1",
+            collection: "users",
+          }}
+        />
       </Wrapper>,
     );
   });
-}); 
+});

--- a/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsAuth.ts
+++ b/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsAuth.ts
@@ -15,7 +15,7 @@ interface UseMsTeamsAuthOutput {
 }
 
 function useMsTeamsAuth(
-  msTeamsBotId: string,
+  graphApiClientId: string,
   redirectUrl?: string,
 ): UseMsTeamsAuthOutput {
   const knock = useKnockClient();
@@ -43,7 +43,7 @@ function useMsTeamsAuth(
         public_key: knock.apiKey,
         user_token: knock.userToken,
       }),
-      client_id: msTeamsBotId,
+      client_id: graphApiClientId,
       redirect_uri: authRedirectUri,
     };
     return `${MS_TEAMS_ADMINCONSENT_URL}?${new URLSearchParams(rawParams)}`;
@@ -53,7 +53,7 @@ function useMsTeamsAuth(
     knockMsTeamsChannelId,
     knock.apiKey,
     knock.userToken,
-    msTeamsBotId,
+    graphApiClientId,
     authRedirectUri,
   ]);
 

--- a/packages/react/src/modules/ms-teams/components/MsTeamsAuthButton/MsTeamsAuthButton.tsx
+++ b/packages/react/src/modules/ms-teams/components/MsTeamsAuthButton/MsTeamsAuthButton.tsx
@@ -12,17 +12,32 @@ import { MsTeamsIcon } from "../MsTeamsIcon";
 
 import "./styles.css";
 
-export interface MsTeamsAuthButtonProps {
-  msTeamsBotId: string;
+export type MsTeamsAuthButtonProps = {
   redirectUrl?: string;
   onAuthenticationComplete?: (authenticationResp: string) => void;
-}
+} & (
+  | {
+      /**
+       * The client ID of your Microsoft Graph API-enabled application registered with Microsoft Entra. This should
+       * match the "Graph API client ID" setting of your Microsoft Teams channel in the Knock dashboard.
+       */
+      graphApiClientId: string;
+    }
+  | {
+      /**
+       * @deprecated Use `graphApiClientId` instead. This field will be removed in a future release.
+       */
+      msTeamsBotId: string;
+    }
+);
 
-export const MsTeamsAuthButton: FunctionComponent<MsTeamsAuthButtonProps> = ({
-  msTeamsBotId,
-  redirectUrl,
-  onAuthenticationComplete,
-}) => {
+export const MsTeamsAuthButton: FunctionComponent<MsTeamsAuthButtonProps> = (
+  props: MsTeamsAuthButtonProps,
+) => {
+  const { redirectUrl, onAuthenticationComplete } = props;
+  const graphApiClientId =
+    "graphApiClientId" in props ? props.graphApiClientId : props.msTeamsBotId;
+
   const { t } = useTranslations();
   const knock = useKnockClient();
 
@@ -35,7 +50,7 @@ export const MsTeamsAuthButton: FunctionComponent<MsTeamsAuthButtonProps> = ({
   } = useKnockMsTeamsClient();
 
   const { buildMsTeamsAuthUrl, disconnectFromMsTeams } = useMsTeamsAuth(
-    msTeamsBotId,
+    graphApiClientId,
     redirectUrl,
   );
 

--- a/packages/react/src/modules/ms-teams/components/MsTeamsAuthButton/MsTeamsAuthButton.tsx
+++ b/packages/react/src/modules/ms-teams/components/MsTeamsAuthButton/MsTeamsAuthButton.tsx
@@ -31,10 +31,11 @@ export type MsTeamsAuthButtonProps = {
     }
 );
 
-export const MsTeamsAuthButton: FunctionComponent<MsTeamsAuthButtonProps> = (
-  props: MsTeamsAuthButtonProps,
-) => {
-  const { redirectUrl, onAuthenticationComplete } = props;
+export const MsTeamsAuthButton: FunctionComponent<MsTeamsAuthButtonProps> = ({
+  redirectUrl,
+  onAuthenticationComplete,
+  ...props
+}) => {
   const graphApiClientId =
     "graphApiClientId" in props ? props.graphApiClientId : props.msTeamsBotId;
 

--- a/packages/react/test/ms-teams/MsTeamsAuthButton.test.tsx
+++ b/packages/react/test/ms-teams/MsTeamsAuthButton.test.tsx
@@ -38,7 +38,9 @@ describe("MsTeamsAuthButton", () => {
       errorLabel: null,
     };
 
-    const { getByText } = render(<MsTeamsAuthButton msTeamsBotId="bot" />);
+    const { getByText } = render(
+      <MsTeamsAuthButton graphApiClientId="clientId" />,
+    );
 
     const btn = getByText("msTeamsConnect").closest("button") as HTMLElement;
     fireEvent.click(btn);
@@ -53,7 +55,9 @@ describe("MsTeamsAuthButton", () => {
       errorLabel: "Error",
     };
 
-    const { getByText } = render(<MsTeamsAuthButton msTeamsBotId="bot" />);
+    const { getByText } = render(
+      <MsTeamsAuthButton graphApiClientId="clientId" />,
+    );
 
     expect(getByText("Error")).toBeInTheDocument();
   });


### PR DESCRIPTION
### Description

This PR renames the `msTeamsBotId` prop of `<MsTeamsAuthButton>`, and the param of the same name of the `useMsTeamsAuth` hook, to `graphApiClientId`.

This PR will only be merged after knocklabs/control#5573 is released.

### Checklist
- [X] Tests have been added for new features or major refactors to existing features.
