### PR TITLE
chore: only update guide group display logs if throttled

### DIFF
--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -626,7 +626,10 @@ export class KnockGuideClient {
 
     this.knock.user.markGuideStepAs<MarkAsArchivedParams, MarkGuideAsResponse>(
       "archived",
-      params,
+      {
+        ...params,
+        unthrottled: guide.bypass_global_group_limit,
+      },
     );
 
     return updatedStep;
@@ -747,12 +750,15 @@ export class KnockGuideClient {
       guide.steps = steps;
       const guides = { ...state.guides, [guide.key]: guide };
 
-      const guideGroupDisplayLogs = attrs.archived_at
-        ? {
-            ...state.guideGroupDisplayLogs,
-            [DEFAULT_GROUP_KEY]: attrs.archived_at,
-          }
-        : state.guideGroupDisplayLogs;
+      // If the guide is subject to throttled settings and we are marking as
+      // archived, then update the display logs to start a new throttle window.
+      const guideGroupDisplayLogs =
+        attrs.archived_at && !guide.bypass_global_group_limit
+          ? {
+              ...state.guideGroupDisplayLogs,
+              [DEFAULT_GROUP_KEY]: attrs.archived_at,
+            }
+          : state.guideGroupDisplayLogs;
 
       return { ...state, guides, guideGroupDisplayLogs };
     });

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -86,7 +86,9 @@ export type MarkAsSeenParams = GuideEngagementEventBaseParams & {
   tenant?: string;
 };
 export type MarkAsInteractedParams = GuideEngagementEventBaseParams;
-export type MarkAsArchivedParams = GuideEngagementEventBaseParams;
+export type MarkAsArchivedParams = GuideEngagementEventBaseParams & {
+  unthrottled?: boolean;
+};
 
 export type MarkGuideAsResponse = {
   status: "ok";


### PR DESCRIPTION
### Description
Archiving an unthrottled guide should not affect or start the throttle window for throttled guides.

[KNO-9221](https://linear.app/knock/issue/KNO-9221/switchboard-control-guide-group-display-logging-as-a-param)
