### PR TITLE
feat: add useGuides hook

### DIFF
--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -371,6 +371,8 @@ export class KnockGuideClient {
       return [];
     }
 
+    // console.log([...result.values()])
+
     // Return all selected guides, since we cannot apply the one-at-a-time limit
     // or throttle settings, but rather defer to the caller to decide which ones
     // to render. Note

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -371,8 +371,6 @@ export class KnockGuideClient {
       return [];
     }
 
-    // console.log([...result.values()])
-
     // Return all selected guides, since we cannot apply the one-at-a-time limit
     // or throttle settings, but rather defer to the caller to decide which ones
     // to render. Note

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -161,6 +161,7 @@ interface KnockGuideActivationLocationRule
 export interface KnockGuide extends GuideData {
   steps: KnockGuideStep[];
   activation_location_rules: KnockGuideActivationLocationRule[];
+  getStep: () => KnockGuideStep | undefined;
 }
 
 type QueryKey = string;

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -1185,7 +1185,7 @@ describe("KnockGuideClient", () => {
       const result = client.selectGuides(stateWithGuides);
 
       expect(result).toHaveLength(3);
-      expect(result.map(g => g.key).sort()).toEqual(["changelog", "system_status", "onboarding"]);
+      expect(result.map(g => g.key)).toEqual(["changelog", "system_status", "onboarding"]);
     });
 
     test("filters guides by key", () => {
@@ -1245,7 +1245,7 @@ describe("KnockGuideClient", () => {
 
       // Should exclude guides where all steps are archived
       expect(result).toHaveLength(2);
-      expect(result.map(g => g.key).sort()).toEqual(["system_status", "onboarding"]);
+      expect(result.map(g => g.key)).toEqual(["system_status", "onboarding"]);
     });
   });
 

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -349,6 +349,7 @@ describe("KnockGuideClient", () => {
       bypass_global_group_limit: false,
       inserted_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
     } as unknown as KnockGuide;
 
     const mockDefaultGroup = {
@@ -468,6 +469,7 @@ describe("KnockGuideClient", () => {
         ...mockGuide,
         bypass_global_group_limit: true,
         steps: [freshMockStep],
+        getStep: vi.fn().mockReturnValue(freshMockStep),
       } as unknown as KnockGuide;
 
       const client = new KnockGuideClient(mockKnock, channelId);
@@ -520,6 +522,7 @@ describe("KnockGuideClient", () => {
       const throttledGuide = {
         ...mockGuide,
         steps: [freshMockStep],
+        getStep: vi.fn().mockReturnValue(freshMockStep),
       } as unknown as KnockGuide;
 
       const client = new KnockGuideClient(mockKnock, channelId);
@@ -575,6 +578,7 @@ describe("KnockGuideClient", () => {
         ...mockGuide,
         bypass_global_group_limit: true,
         steps: [freshMockStep],
+        getStep: vi.fn().mockReturnValue(freshMockStep),
       } as unknown as KnockGuide;
 
       const client = new KnockGuideClient(mockKnock, channelId);
@@ -684,6 +688,7 @@ describe("KnockGuideClient", () => {
       bypass_global_group_limit: false,
       inserted_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
     } as unknown as KnockGuide;
 
     const mockGuideTwo = {
@@ -704,6 +709,7 @@ describe("KnockGuideClient", () => {
       bypass_global_group_limit: false,
       inserted_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
     } as unknown as KnockGuide;
 
     const mockGuideThree = {
@@ -718,6 +724,7 @@ describe("KnockGuideClient", () => {
       bypass_global_group_limit: false,
       inserted_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
     } as unknown as KnockGuide;
 
     const mockGuides = {
@@ -1084,6 +1091,164 @@ describe("KnockGuideClient", () => {
     });
   });
 
+  describe("selectGuides", () => {
+    const mockStep = {
+      ref: "step_1",
+      schema_key: "foo",
+      schema_semver: "1.0.0",
+      schema_variant_key: "default",
+      message: {
+        id: "msg_123",
+        seen_at: null,
+        read_at: null,
+        interacted_at: null,
+        archived_at: null,
+        link_clicked_at: null,
+      },
+      content: {},
+      markAsSeen: vi.fn(),
+      markAsInteracted: vi.fn(),
+      markAsArchived: vi.fn(),
+    } as unknown as KnockGuideStep;
+
+    const mockGuideOne = {
+      __typename: "Guide",
+      channel_id: channelId,
+      id: "guide_1",
+      key: "onboarding",
+      type: "card",
+      semver: "1.0.0",
+      steps: [mockStep],
+      activation_location_rules: [],
+      bypass_global_group_limit: false,
+      inserted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
+    } as unknown as KnockGuide;
+
+    const mockGuideTwo = {
+      __typename: "Guide",
+      channel_id: channelId,
+      id: "guide_2",
+      key: "changelog",
+      type: "card",
+      semver: "1.0.0",
+      steps: [mockStep],
+      activation_location_rules: [],
+      bypass_global_group_limit: false,
+      inserted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
+    } as unknown as KnockGuide;
+
+    const mockGuideThree = {
+      __typename: "Guide",
+      channel_id: channelId,
+      id: "guide_3",
+      key: "system_status",
+      type: "banner",
+      semver: "1.0.0",
+      steps: [mockStep],
+      activation_location_rules: [],
+      bypass_global_group_limit: false,
+      inserted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
+    } as unknown as KnockGuide;
+
+    const mockGuides = {
+      [mockGuideOne.key]: mockGuideOne,
+      [mockGuideTwo.key]: mockGuideTwo,
+      [mockGuideThree.key]: mockGuideThree,
+    };
+
+    const mockDefaultGroup = {
+      __typename: "GuideGroup",
+      key: "default",
+      display_sequence: ["changelog", "system_status", "onboarding"],
+      display_interval: 60,
+      inserted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as unknown as GuideGroupData;
+
+    const stateWithGuides = {
+      guideGroups: [mockDefaultGroup],
+      guideGroupDisplayLogs: {},
+      guides: mockGuides,
+      queries: {},
+      location: undefined,
+      counter: 0,
+    };
+
+    test("returns all guides without filters", () => {
+      const client = new KnockGuideClient(mockKnock, channelId);
+      const result = client.selectGuides(stateWithGuides);
+
+      expect(result).toHaveLength(3);
+      expect(result.map(g => g.key).sort()).toEqual(["changelog", "system_status", "onboarding"]);
+    });
+
+    test("filters guides by key", () => {
+      const client = new KnockGuideClient(mockKnock, channelId);
+      const result = client.selectGuides(stateWithGuides, { key: "onboarding" });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe("onboarding");
+    });
+
+    test("filters guides by type", () => {
+      const client = new KnockGuideClient(mockKnock, channelId);
+      const result = client.selectGuides(stateWithGuides, { type: "card" });
+
+      expect(result).toHaveLength(2);
+
+      expect(result[0].key).toBe("changelog");
+      expect(result[0].type).toBe("card");
+
+      expect(result[1].key).toBe("onboarding");
+      expect(result[1].type).toBe("card");
+    });
+
+    test("returns empty array when no guides match filters", () => {
+      const client = new KnockGuideClient(mockKnock, channelId);
+      const result = client.selectGuides(stateWithGuides, { type: "nonexistent" });
+
+      expect(result).toEqual([]);
+    });
+
+    test("excludes guides where all steps are archived", () => {
+      const stateWithArchivedGuide = {
+        guideGroups: [mockDefaultGroup],
+        guideGroupDisplayLogs: {},
+        guides: {
+          ...mockGuides,
+          [mockGuideTwo.key]: {
+            ...mockGuideTwo,
+            steps: [
+              {
+                ...mockStep,
+                message: {
+                  ...mockStep.message,
+                  archived_at: new Date().toISOString(),
+                }
+              }
+            ]
+          },
+        },
+        queries: {},
+        location: undefined,
+        counter: 0,
+      };
+
+      const client = new KnockGuideClient(mockKnock, channelId);
+      const result = client.selectGuides(stateWithArchivedGuide);
+
+      // Should exclude guides where all steps are archived
+      expect(result).toHaveLength(2);
+      expect(result.map(g => g.key).sort()).toEqual(["system_status", "onboarding"]);
+    });
+  });
+
   describe("guide socket event handling", () => {
     test("handles guide.added event", () => {
       const client = new KnockGuideClient(mockKnock, channelId);
@@ -1272,6 +1437,7 @@ describe("KnockGuideClient", () => {
       bypass_global_group_limit: false,
       inserted_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
     } as unknown as KnockGuide;
 
     const mockGuideTwo = {
@@ -1286,6 +1452,7 @@ describe("KnockGuideClient", () => {
       bypass_global_group_limit: false,
       inserted_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      getStep: vi.fn().mockReturnValue(mockStep),
     } as unknown as KnockGuide;
 
     const mockDefaultGroup = {

--- a/packages/react-core/src/modules/guide/hooks/useGuide.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuide.ts
@@ -17,7 +17,7 @@ export const useGuide = (filters: KnockGuideFilterParams): UseGuideReturn => {
 
   if (!filters.key && !filters.type) {
     throw new Error(
-      "useGuide must be used with at least one filter: either a guide key or a guide type",
+      "useGuide must be given at least one filter: { key?: string; type?: string; }",
     );
   }
 
@@ -27,7 +27,7 @@ export const useGuide = (filters: KnockGuideFilterParams): UseGuideReturn => {
     client.selectGuide(state, filters),
   );
 
-  const step = guide && guide.steps.find((s) => !s.message.archived_at);
+  const step = guide && guide.getStep();
 
   return { client, colorMode, guide, step };
 };

--- a/packages/react-core/src/modules/guide/hooks/useGuides.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuides.ts
@@ -1,0 +1,26 @@
+import { KnockGuide, KnockGuideFilterParams } from "@knocklabs/client";
+import { useStore } from "@tanstack/react-store";
+
+import { UseGuideContextReturn, useGuideContext } from "./useGuideContext";
+
+interface UseGuidesReturn extends UseGuideContextReturn {
+  guides: KnockGuide[];
+}
+
+export const useGuides = (filters: KnockGuideFilterParams): UseGuidesReturn => {
+  const context = useGuideContext();
+
+  if (!filters.key && !filters.type) {
+    throw new Error(
+      "useGuides must be given at least one filter: { key?: string; type?: string; }",
+    );
+  }
+
+  const { client, colorMode } = context;
+
+  const guides = useStore(client.store, (state) =>
+    client.selectGuides(state, filters),
+  );
+
+  return { client, colorMode, guides };
+};

--- a/packages/react-core/src/modules/guide/hooks/useGuides.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuides.ts
@@ -9,13 +9,6 @@ interface UseGuidesReturn extends UseGuideContextReturn {
 
 export const useGuides = (filters: KnockGuideFilterParams): UseGuidesReturn => {
   const context = useGuideContext();
-
-  if (!filters.key && !filters.type) {
-    throw new Error(
-      "useGuides must be given at least one filter: { key?: string; type?: string; }",
-    );
-  }
-
   const { client, colorMode } = context;
 
   const guides = useStore(client.store, (state) =>


### PR DESCRIPTION
### Description
Add the `useGuides` hook, which will return any matching selections without applying the group limit of one-at-a-time display or throttle settings.