### PR TITLE
fix(kno-9344): fix refused to set unsafe header "User-Agent"

### DIFF
--- a/.changeset/fuzzy-scissors-do.md
+++ b/.changeset/fuzzy-scissors-do.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: fixes refused to set unsafe header "User-Agent"

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -38,7 +38,7 @@ class ApiClient {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.apiKey}`,
         "X-Knock-User-Token": this.userToken,
-        "X-Knock-Client": this.getUserAgent(),
+        "X-Knock-Client": this.getKnockClientHeader(),
       },
     });
 
@@ -106,7 +106,7 @@ class ApiClient {
     return false;
   }
 
-  private getUserAgent() {
+  private getKnockClientHeader() {
     // Note: we're following format used in our Stainless SDKs:
     // https://github.com/knocklabs/knock-node/blob/main/src/client.ts#L335
     // If we add the env var to turbo.json, it caches it so the version

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -38,7 +38,7 @@ class ApiClient {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.apiKey}`,
         "X-Knock-User-Token": this.userToken,
-        "User-Agent": this.getUserAgent(),
+        "X-Knock-Client": this.getUserAgent(),
       },
     });
 

--- a/packages/client/test/api.test.ts
+++ b/packages/client/test/api.test.ts
@@ -499,7 +499,7 @@ describe("API Client", () => {
   });
 
   describe("Request Configuration", () => {
-    test("sets correct user agent header", () => {
+    test("sets correct x-knock-client header", () => {
       const apiClient = new ApiClient({
         host: "https://api.knock.app",
         apiKey: "pk_test_12345",
@@ -510,7 +510,7 @@ describe("API Client", () => {
       const axiosClient = (apiClient as unknown as Record<string, unknown>)
         .axiosClient as { defaults: { headers: Record<string, string> } };
 
-      expect(axiosClient.defaults.headers["User-Agent"]).toBe(
+      expect(axiosClient.defaults.headers["X-Knock-Client"]).toBe(
         `Knock/ClientJS ${packageJson.version}`,
       );
     });


### PR DESCRIPTION
### Description

This PR changes the user agent header from `User-Agent` to `X-Knock-Client` in the API client to better follow HTTP header conventions for custom headers. The corresponding test has been updated to reflect this change.

Users were seeing a warning in the console:
```
Refused to set unsafe header "User-Agent"
```

[From MDN docs:](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_request_header)

> Note: The User-Agent header used to be forbidden, but no longer is. However, Chrome still silently drops the header from Fetch requests (see Chromium bug 571722).


### Checklist
- [X] Tests have been added for new features or major refactors to existing features.

https://linear.app/knock/issue/KNO-9344/sdk-errors-caused-by-sdk-setting-user-agent-header