### PR TITLE
fix: run ci/cd job on main push to sync test coverage to codecov for head branch

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,6 +3,9 @@ name: CI/CD
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Description
The `CI/CD` job wasn't being ran on the `main` branch. This meant that when codecov tried to compare test coverage to the head branch, it would have no coverage to compare to and we'd see a warning (screenshot). This PR updates the `CI/CD` job to run on a main push in addition to the previous triggers so that the head branch can be synced to codecov.

<img width="809" height="169" alt="image" src="https://github.com/user-attachments/assets/2b71ee40-2621-4066-afca-4c1ab7cb3812" />

