### PR TITLE
feat: add content type generic for guide step content

### DIFF
--- a/examples/guide-example/src/App.tsx
+++ b/examples/guide-example/src/App.tsx
@@ -11,8 +11,14 @@ import "@knocklabs/react/dist/index.css";
 import { useEffect, useState } from "react";
 import { Link, Route, Routes } from "react-router";
 
+interface ChangelogCardContent {
+  headline: string;
+  title: string;
+  body: string;
+}
+
 const ChangelogCard = () => {
-  const { guide, step } = useGuide({ type: "changelog-card" });
+  const { guide, step } = useGuide<ChangelogCardContent>({ type: "changelog-card" });
 
   useEffect(() => {
     if (step) step.markAsSeen();

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -466,10 +466,10 @@ export class KnockGuideClient {
     return [...result.values()];
   }
 
-  selectGuide<GuideContent = Any>(
+  selectGuide<C = Any>(
     state: StoreState,
     filters: SelectFilterParams = {},
-  ): KnockGuide<GuideContent> | undefined {
+  ): KnockGuide<C> | undefined {
     if (Object.keys(state.guides).length === 0) {
       return undefined;
     }

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -15,6 +15,7 @@ import {
   mockDefaultGroup,
 } from "./helpers";
 import {
+  Any,
   ConstructorOpts,
   DebugState,
   GetGuidesQueryParams,
@@ -465,7 +466,10 @@ export class KnockGuideClient {
     return [...result.values()];
   }
 
-  selectGuide(state: StoreState, filters: SelectFilterParams = {}) {
+  selectGuide<GuideContent = Any>(
+    state: StoreState,
+    filters: SelectFilterParams = {},
+  ): KnockGuide<GuideContent> | undefined {
     if (Object.keys(state.guides).length === 0) {
       return undefined;
     }

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -447,7 +447,10 @@ export class KnockGuideClient {
   // Store selector
   //
 
-  selectGuides(state: StoreState, filters: SelectFilterParams = {}) {
+  selectGuides<C = Any>(
+    state: StoreState,
+    filters: SelectFilterParams = {},
+  ): KnockGuide<C>[] {
     if (Object.keys(state.guides).length === 0) {
       return [];
     }

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -4,6 +4,9 @@ import { GenericData } from "@knocklabs/types";
 // Fetch guides API
 //
 
+// eslint-disable-next-line
+export type Any = any;
+
 export interface StepMessageState {
   id: string;
   seen_at: string | null;
@@ -13,14 +16,13 @@ export interface StepMessageState {
   link_clicked_at: string | null;
 }
 
-export interface GuideStepData {
+export interface GuideStepData<TContent = Any> {
   ref: string;
   schema_key: string;
   schema_semver: string;
   schema_variant_key: string;
   message: StepMessageState;
-  // eslint-disable-next-line
-  content: any;
+  content: TContent;
 }
 
 interface GuideActivationLocationRuleData {
@@ -28,14 +30,14 @@ interface GuideActivationLocationRuleData {
   pathname: string;
 }
 
-export interface GuideData {
+export interface GuideData<TContent = Any> {
   __typename: "Guide";
   channel_id: string;
   id: string;
   key: string;
   type: string;
   semver: string;
-  steps: GuideStepData[];
+  steps: GuideStepData<TContent>[];
   activation_location_rules: GuideActivationLocationRuleData[];
   bypass_global_group_limit: boolean;
   inserted_at: string;
@@ -148,7 +150,8 @@ export type GuideSocketEvent =
 // Guide client
 //
 
-export interface KnockGuideStep extends GuideStepData {
+export interface KnockGuideStep<TContent = Any>
+  extends GuideStepData<TContent> {
   markAsSeen: () => void;
   markAsInteracted: (params?: { metadata?: GenericData }) => void;
   markAsArchived: () => void;
@@ -159,10 +162,10 @@ interface KnockGuideActivationLocationRule
   pattern: URLPattern;
 }
 
-export interface KnockGuide extends GuideData {
-  steps: KnockGuideStep[];
+export interface KnockGuide<TContent = Any> extends GuideData<TContent> {
+  steps: KnockGuideStep<TContent>[];
   activation_location_rules: KnockGuideActivationLocationRule[];
-  getStep: () => KnockGuideStep | undefined;
+  getStep: () => KnockGuideStep<TContent> | undefined;
 }
 
 type QueryKey = string;

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -4,7 +4,7 @@ import { GenericData } from "@knocklabs/types";
 // Fetch guides API
 //
 
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Any = any;
 
 export interface StepMessageState {

--- a/packages/react-core/src/modules/guide/hooks/useGuide.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuide.ts
@@ -29,7 +29,7 @@ export const useGuide = <C = Any>(
   const { client, colorMode } = context;
 
   const guide = useStore(client.store, (state) =>
-    client.selectGuide(state, filters),
+    client.selectGuide<C>(state, filters),
   );
 
   const step = guide && guide.getStep();

--- a/packages/react-core/src/modules/guide/hooks/useGuide.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuide.ts
@@ -7,14 +7,17 @@ import { useStore } from "@tanstack/react-store";
 
 import { UseGuideContextReturn, useGuideContext } from "./useGuideContext";
 
-interface UseGuideReturn<GuideContent> extends UseGuideContextReturn {
-  guide: KnockGuide<GuideContent> | undefined;
-  step: KnockGuideStep<GuideContent> | undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+interface UseGuideReturn<C = Any> extends UseGuideContextReturn {
+  guide: KnockGuide<C> | undefined;
+  step: KnockGuideStep<C> | undefined;
 }
 
-export const useGuide = <GuideContent = any>(
+export const useGuide = <C = Any>(
   filters: KnockGuideFilterParams,
-): UseGuideReturn<GuideContent> => {
+): UseGuideReturn<C> => {
   const context = useGuideContext();
 
   if (!filters.key && !filters.type) {

--- a/packages/react-core/src/modules/guide/hooks/useGuide.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuide.ts
@@ -7,12 +7,14 @@ import { useStore } from "@tanstack/react-store";
 
 import { UseGuideContextReturn, useGuideContext } from "./useGuideContext";
 
-interface UseGuideReturn extends UseGuideContextReturn {
-  guide: KnockGuide | undefined;
-  step: KnockGuideStep | undefined;
+interface UseGuideReturn<GuideContent> extends UseGuideContextReturn {
+  guide: KnockGuide<GuideContent> | undefined;
+  step: KnockGuideStep<GuideContent> | undefined;
 }
 
-export const useGuide = (filters: KnockGuideFilterParams): UseGuideReturn => {
+export const useGuide = <GuideContent = any>(
+  filters: KnockGuideFilterParams,
+): UseGuideReturn<GuideContent> => {
   const context = useGuideContext();
 
   if (!filters.key && !filters.type) {

--- a/packages/react-core/src/modules/guide/hooks/useGuides.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuides.ts
@@ -17,7 +17,7 @@ export const useGuides = <C = Any>(
   const { client, colorMode } = context;
 
   const guides = useStore(client.store, (state) =>
-    client.selectGuides(state, filters),
+    client.selectGuides<C>(state, filters),
   );
 
   return { client, colorMode, guides };

--- a/packages/react-core/src/modules/guide/hooks/useGuides.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuides.ts
@@ -3,13 +3,16 @@ import { useStore } from "@tanstack/react-store";
 
 import { UseGuideContextReturn, useGuideContext } from "./useGuideContext";
 
-interface UseGuidesReturn extends UseGuideContextReturn {
-  guides: KnockGuide[];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+interface UseGuidesReturn<C = Any> extends UseGuideContextReturn {
+  guides: KnockGuide<C>[];
 }
 
-export const useGuides = (
+export const useGuides = <C = Any>(
   filters: Pick<KnockGuideFilterParams, "type">,
-): UseGuidesReturn => {
+): UseGuidesReturn<C> => {
   const context = useGuideContext();
   const { client, colorMode } = context;
 


### PR DESCRIPTION
### Description

Adds a generic type parameter for typing guide step contents, which users can pass in when using the `useGuide(s)` hooks or calling the `selecteGuide(s)` methods in the guide client.

Note, there is a corresponding CLI PR (https://github.com/knocklabs/knock-cli/pull/575) to add a new `knock guide generate-types` command which generates types for all guides in a given environment automatically.