### PR TITLE
feat: add support for "simple" activation url rules

### DIFF
--- a/.changeset/lemon-monkeys-hunt.md
+++ b/.changeset/lemon-monkeys-hunt.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+---
+
+add support for activation url rules in guide client

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -68,6 +68,14 @@ const checkForWindow = () => {
 export const guidesApiRootPath = (userId: string | undefined | null) =>
   `/v1/users/${userId}/guides`;
 
+const newUrl = (location: string) => {
+  try {
+    return new URL(location);
+  } catch {
+    return undefined;
+  }
+};
+
 // Detect debug params like "knock_guide_key" from URL.
 const detectDebugParams = (): DebugState => {
   const win = checkForWindow();
@@ -146,10 +154,9 @@ const predicate = (
   }
 
   const urlRules = guide.activation_url_rules || [];
+  const url = location ? newUrl(location) : undefined;
 
-  if (urlRules.length > 0 && location) {
-    const url = new URL(location);
-
+  if (urlRules.length > 0 && url) {
     const allowed = urlRules.reduce<boolean | undefined>((acc, urlRule) => {
       // Any matched block rule prevails so no need to evaluate further
       // as soon as there is one.

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -13,6 +13,7 @@ import {
   findDefaultGroup,
   formatFilters,
   mockDefaultGroup,
+  newUrl,
   predicateUrlPatterns,
   predicateUrlRules,
 } from "./helpers";
@@ -68,14 +69,6 @@ const checkForWindow = () => {
 
 export const guidesApiRootPath = (userId: string | undefined | null) =>
   `/v1/users/${userId}/guides`;
-
-const newUrl = (location: string) => {
-  try {
-    return new URL(location);
-  } catch {
-    return undefined;
-  }
-};
 
 // Detect debug params like "knock_guide_key" from URL.
 const detectDebugParams = (): DebugState => {

--- a/packages/client/src/clients/guide/helpers.ts
+++ b/packages/client/src/clients/guide/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  GuideActivationUrlRuleData,
   GuideData,
   GuideGroupData,
   KnockGuide,
@@ -95,4 +96,28 @@ export const checkIfThrottled = (
   // Both are in milliseconds since epoch (UTC), so direct comparison is
   // accurate regardless of local timezones.
   return currentTimeInMilliseconds <= throttleWindowEndInMilliseconds;
+};
+
+// Evaluates whether the given location url satisfies the url rule.
+export const evaluateUrlRule = (
+  urlRule: GuideActivationUrlRuleData,
+  url: URL,
+) => {
+  if (urlRule.variable === "pathname") {
+    if (urlRule.operator === "equal_to") {
+      const argument = urlRule.argument.startsWith("/")
+        ? urlRule.argument
+        : `/${urlRule.argument}`;
+
+      return argument === url.pathname;
+    }
+
+    if (urlRule.operator === "contains") {
+      return url.pathname.includes(urlRule.argument);
+    }
+
+    return false;
+  }
+
+  return false;
 };

--- a/packages/client/src/clients/guide/helpers.ts
+++ b/packages/client/src/clients/guide/helpers.ts
@@ -109,7 +109,10 @@ export const newUrl = (location: string) => {
 };
 
 // Evaluates whether the given location url satisfies the url rule.
-const evaluateUrlRule = (url: URL, urlRule: GuideActivationUrlRuleData) => {
+export const evaluateUrlRule = (
+  url: URL,
+  urlRule: GuideActivationUrlRuleData,
+) => {
   if (urlRule.variable === "pathname") {
     if (urlRule.operator === "equal_to") {
       const argument = urlRule.argument.startsWith("/")

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -25,6 +25,13 @@ export interface GuideStepData<TContent = Any> {
   content: TContent;
 }
 
+export interface GuideActivationUrlRuleData {
+  directive: "allow" | "block";
+  variable: "pathname";
+  operator: "equal_to" | "contains";
+  argument: string;
+}
+
 interface GuideActivationUrlPatternData {
   directive: "allow" | "block";
   pathname: string;
@@ -38,6 +45,7 @@ export interface GuideData<TContent = Any> {
   type: string;
   semver: string;
   steps: GuideStepData<TContent>[];
+  activation_url_rules: GuideActivationUrlRuleData[];
   activation_url_patterns: GuideActivationUrlPatternData[];
   bypass_global_group_limit: boolean;
   inserted_at: string;

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -25,7 +25,7 @@ export interface GuideStepData<TContent = Any> {
   content: TContent;
 }
 
-interface GuideActivationLocationRuleData {
+interface GuideActivationUrlPatternData {
   directive: "allow" | "block";
   pathname: string;
 }
@@ -38,7 +38,7 @@ export interface GuideData<TContent = Any> {
   type: string;
   semver: string;
   steps: GuideStepData<TContent>[];
-  activation_location_rules: GuideActivationLocationRuleData[];
+  activation_url_patterns: GuideActivationUrlPatternData[];
   bypass_global_group_limit: boolean;
   inserted_at: string;
   updated_at: string;
@@ -157,14 +157,13 @@ export interface KnockGuideStep<TContent = Any>
   markAsArchived: () => void;
 }
 
-interface KnockGuideActivationLocationRule
-  extends GuideActivationLocationRuleData {
+interface KnockGuideActivationUrlPattern extends GuideActivationUrlPatternData {
   pattern: URLPattern;
 }
 
 export interface KnockGuide<TContent = Any> extends GuideData<TContent> {
   steps: KnockGuideStep<TContent>[];
-  activation_location_rules: KnockGuideActivationLocationRule[];
+  activation_url_patterns: KnockGuideActivationUrlPattern[];
   getStep: () => KnockGuideStep<TContent> | undefined;
 }
 

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -165,7 +165,8 @@ export interface KnockGuideStep<TContent = Any>
   markAsArchived: () => void;
 }
 
-interface KnockGuideActivationUrlPattern extends GuideActivationUrlPatternData {
+export interface KnockGuideActivationUrlPattern
+  extends GuideActivationUrlPatternData {
   pattern: URLPattern;
 }
 

--- a/packages/client/test/clients/guide/helpers.test.ts
+++ b/packages/client/test/clients/guide/helpers.test.ts
@@ -14,7 +14,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("matches exact pathname without leading slash", () => {
@@ -26,7 +26,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("does not match different pathname", () => {
@@ -38,7 +38,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/settings");
 
-      expect(evaluateUrlRule(rule, url)).toBe(false);
+      expect(evaluateUrlRule(url, rule)).toBe(false);
     });
 
     test("does not match partial pathname", () => {
@@ -50,7 +50,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard");
 
-      expect(evaluateUrlRule(rule, url)).toBe(false);
+      expect(evaluateUrlRule(url, rule)).toBe(false);
     });
 
     test("matches nested pathnames exactly", () => {
@@ -62,7 +62,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/admin/settings");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
   });
 
@@ -76,7 +76,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("matches when pathname contains the argument in the middle", () => {
@@ -88,7 +88,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/super/admin/settings");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("does not match when pathname doesn't contain the argument", () => {
@@ -100,7 +100,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard");
 
-      expect(evaluateUrlRule(rule, url)).toBe(false);
+      expect(evaluateUrlRule(url, rule)).toBe(false);
     });
 
     test("is case sensitive", () => {
@@ -112,7 +112,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/admin");
 
-      expect(evaluateUrlRule(rule, url)).toBe(false);
+      expect(evaluateUrlRule(url, rule)).toBe(false);
     });
 
     test("matches with special characters", () => {
@@ -124,7 +124,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/settings/user-profile/edit");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
   });
 
@@ -138,7 +138,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/settings");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("works with block directive and contains", () => {
@@ -150,7 +150,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/user/private/data");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
   });
 
@@ -164,7 +164,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("handles empty argument with contains", () => {
@@ -177,7 +177,7 @@ describe("evaluateUrlRule", () => {
       const url = new URL("https://example.com/dashboard");
 
       // Empty string is contained in any string
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("handles URLs with query parameters", () => {
@@ -191,7 +191,7 @@ describe("evaluateUrlRule", () => {
         "https://example.com/dashboard?tab=overview&user=123",
       );
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("handles URLs with hash fragments", () => {
@@ -203,7 +203,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard#section-1");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("handles pathnames with trailing slashes", () => {
@@ -215,7 +215,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard/");
 
-      expect(evaluateUrlRule(rule, url)).toBe(true);
+      expect(evaluateUrlRule(url, rule)).toBe(true);
     });
 
     test("distinguishes between paths with and without trailing slashes", () => {
@@ -227,7 +227,7 @@ describe("evaluateUrlRule", () => {
       };
       const url = new URL("https://example.com/dashboard/");
 
-      expect(evaluateUrlRule(rule, url)).toBe(false);
+      expect(evaluateUrlRule(url, rule)).toBe(false);
     });
   });
 });

--- a/packages/client/test/clients/guide/helpers.test.ts
+++ b/packages/client/test/clients/guide/helpers.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "vitest";
+
+import { evaluateUrlRule } from "../../../src/clients/guide/helpers";
+import type { GuideActivationUrlRuleData } from "../../../src/clients/guide/types";
+
+describe("evaluateUrlRule", () => {
+  describe("pathname variable with equal_to operator", () => {
+    test("matches exact pathname with leading slash", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/dashboard",
+      };
+      const url = new URL("https://example.com/dashboard");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("matches exact pathname without leading slash", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "dashboard",
+      };
+      const url = new URL("https://example.com/dashboard");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("does not match different pathname", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/dashboard",
+      };
+      const url = new URL("https://example.com/settings");
+
+      expect(evaluateUrlRule(rule, url)).toBe(false);
+    });
+
+    test("does not match partial pathname", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/dash",
+      };
+      const url = new URL("https://example.com/dashboard");
+
+      expect(evaluateUrlRule(rule, url)).toBe(false);
+    });
+
+    test("matches nested pathnames exactly", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/admin/settings",
+      };
+      const url = new URL("https://example.com/admin/settings");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+  });
+
+  describe("pathname variable with contains operator", () => {
+    test("matches when pathname contains the argument", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "contains",
+        argument: "dash",
+      };
+      const url = new URL("https://example.com/dashboard");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("matches when pathname contains the argument in the middle", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "contains",
+        argument: "admin",
+      };
+      const url = new URL("https://example.com/super/admin/settings");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("does not match when pathname doesn't contain the argument", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "contains",
+        argument: "admin",
+      };
+      const url = new URL("https://example.com/dashboard");
+
+      expect(evaluateUrlRule(rule, url)).toBe(false);
+    });
+
+    test("is case sensitive", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "contains",
+        argument: "Admin",
+      };
+      const url = new URL("https://example.com/admin");
+
+      expect(evaluateUrlRule(rule, url)).toBe(false);
+    });
+
+    test("matches with special characters", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "contains",
+        argument: "user-profile",
+      };
+      const url = new URL("https://example.com/settings/user-profile/edit");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+  });
+
+  describe("block directive", () => {
+    test("works with block directive and equal_to", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "block",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/settings",
+      };
+      const url = new URL("https://example.com/settings");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("works with block directive and contains", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "block",
+        variable: "pathname",
+        operator: "contains",
+        argument: "private",
+      };
+      const url = new URL("https://example.com/user/private/data");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles root path", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/",
+      };
+      const url = new URL("https://example.com/");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("handles empty argument with contains", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "contains",
+        argument: "",
+      };
+      const url = new URL("https://example.com/dashboard");
+
+      // Empty string is contained in any string
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("handles URLs with query parameters", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/dashboard",
+      };
+      const url = new URL(
+        "https://example.com/dashboard?tab=overview&user=123",
+      );
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("handles URLs with hash fragments", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/dashboard",
+      };
+      const url = new URL("https://example.com/dashboard#section-1");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("handles pathnames with trailing slashes", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/dashboard/",
+      };
+      const url = new URL("https://example.com/dashboard/");
+
+      expect(evaluateUrlRule(rule, url)).toBe(true);
+    });
+
+    test("distinguishes between paths with and without trailing slashes", () => {
+      const rule: GuideActivationUrlRuleData = {
+        directive: "allow",
+        variable: "pathname",
+        operator: "equal_to",
+        argument: "/dashboard",
+      };
+      const url = new URL("https://example.com/dashboard/");
+
+      expect(evaluateUrlRule(rule, url)).toBe(false);
+    });
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -92,6 +92,7 @@ export {
   KnockGuideContext,
   useGuide,
   useGuides,
+  useGuideContext,
   type MsTeamsChannelQueryOptions,
   type MsTeamsTeamQueryOptions,
   KnockMsTeamsProvider,


### PR DESCRIPTION
### Description

Add support for handling "simple" activation url rules, as configured in https://github.com/knocklabs/control/pull/5840.

Note, a guide can have either `activation_url_rules` xor `activation_url_patterns`, but not both. 