### PR TITLE
feat: adds  option for user identification control

### DIFF
--- a/.changeset/cool-shrimps-cough.md
+++ b/.changeset/cool-shrimps-cough.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-core": minor
+"@knocklabs/client": minor
+---
+
+feat: adds `identificationStrategy` option for user identification control

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -54,6 +54,7 @@ export type UserTokenExpiringCallback = (
 export interface AuthenticateOptions {
   onUserTokenExpiring?: UserTokenExpiringCallback;
   timeBeforeExpirationInMs?: number;
+  identificationStrategy?: "inline" | "skip";
 }
 
 export interface BulkOperation {

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -86,6 +86,7 @@ class Knock {
     let reinitializeApi = false;
     const currentApiClient = this.apiClient;
     const userId = this.getUserId(userIdOrUserWithProperties);
+    const identificationStrategy = options?.identificationStrategy || "inline";
 
     // If we've previously been initialized and the values have now changed, then we
     // need to reinitialize any stateful connections we have
@@ -120,11 +121,20 @@ class Knock {
       this.log("Reinitialized real-time connections");
     }
 
-    // Inline identify the user if we've been given an object with an id.
+    // We explicitly skip the inline identification if the strategy is set to "skip"
+    if (identificationStrategy === "skip") {
+      this.log("Skipping inline user identification");
+      return;
+    }
+
+    // Inline identify the user if we've been given an object with an id
+    // and the strategy is set to "inline".
     if (
+      identificationStrategy === "inline" &&
       typeof userIdOrUserWithProperties === "object" &&
       userIdOrUserWithProperties?.id
     ) {
+      this.log(`Identifying user ${userIdOrUserWithProperties.id} inline`);
       const { id, ...properties } = userIdOrUserWithProperties;
       this.user.identify(properties);
     }

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -37,9 +37,11 @@ export type KnockProviderProps = {
        */
       userId: Knock["userId"];
       user?: never;
+      identificationStrategy?: never;
     }
   | {
       user: UserWithProperties;
+      identificationStrategy?: AuthenticateOptions["identificationStrategy"];
       /**
        * @deprecated The `userId` prop is deprecated and will be removed in a future version.
        * Please pass the `user` prop instead containing an `id` value.
@@ -61,6 +63,7 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
   timeBeforeExpirationInMs,
   children,
   i18n,
+  identificationStrategy,
   ...props
 }) => {
   const userIdOrUserWithProperties = props?.user || props?.userId;
@@ -72,8 +75,15 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
       onUserTokenExpiring,
       timeBeforeExpirationInMs,
       logLevel,
+      identificationStrategy,
     }),
-    [host, onUserTokenExpiring, timeBeforeExpirationInMs, logLevel],
+    [
+      host,
+      onUserTokenExpiring,
+      timeBeforeExpirationInMs,
+      logLevel,
+      identificationStrategy,
+    ],
   );
 
   const knock = useAuthenticatedKnockClient(

--- a/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
+++ b/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts
@@ -17,6 +17,7 @@ function authenticateWithOptions(
   knock.authenticate(userIdOrUserWithProperties, userToken, {
     onUserTokenExpiring: options?.onUserTokenExpiring,
     timeBeforeExpirationInMs: options?.timeBeforeExpirationInMs,
+    identificationStrategy: options?.identificationStrategy,
   });
 }
 


### PR DESCRIPTION
### Description
- Adds `identificationStrategy` option to `KnockProvider` and `authentication` methods to control automatic user identification behavior.
- Supports two strategies: "inline" (default) automatically identifies users with provided properties, while "skip" prevents automatic identification entirely.
- Includes comprehensive test coverage across client, react-core packages and maintains full backwards compatibility with existing implementations.