### PR TITLE
feat: add auto socket manager to guide provider and client

### DIFF
--- a/.changeset/polite-bees-serve.md
+++ b/.changeset/polite-bees-serve.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+---
+
+feat: add auto socket manager to guide provider and client

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -405,7 +405,6 @@ export class KnockGuideClient {
     // Track the joined channel.
     this.socketChannel = newChannel;
 
-    // Start auto-disconnect management if enabled
     this.socketAutoDisconnectManager?.start();
   }
 

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -223,6 +223,10 @@ export type ConstructorOpts = {
   trackLocationFromWindow?: boolean;
   orderResolutionDuration?: number;
   throttleCheckInterval?: number;
+  /** Automatically manage socket connections based on tab visibility (defaults to false) */
+  auto_manage_socket_connection?: boolean;
+  /** Delay in milliseconds before disconnecting socket when tab becomes inactive (defaults to 2000) */
+  auto_manage_socket_connection_delay?: number;
 };
 
 export type GroupStage = {

--- a/packages/client/src/clients/shared/socketAutoDisconnectManager.ts
+++ b/packages/client/src/clients/shared/socketAutoDisconnectManager.ts
@@ -1,0 +1,142 @@
+export interface SocketAutoDisconnectOptions {
+  /** Enable auto-disconnect when tab becomes inactive */
+  enabled: boolean;
+  /** Delay in milliseconds before disconnecting (defaults to 2000) */
+  delay?: number;
+}
+
+export interface SocketAutoDisconnectParams {
+  onDisconnect: () => void;
+  onConnect: () => void;
+  isConnected: () => boolean;
+  log: (message: string) => void;
+  options: SocketAutoDisconnectOptions;
+}
+
+const DEFAULT_DISCONNECT_DELAY = 2000;
+
+/**
+ * Manages automatic socket disconnection based on tab visibility.
+ *
+ * When a tab becomes hidden, the socket will be disconnected after a configurable delay.
+ * When the tab becomes visible again, the socket will be reconnected if needed.
+ *
+ * This helps reduce resource usage for inactive tabs while maintaining good UX
+ * by avoiding unnecessary disconnects during brief tab switches.
+ */
+export class SocketAutoDisconnectManager {
+  private options: SocketAutoDisconnectOptions;
+  private onDisconnect: () => void;
+  private onConnect: () => void;
+  private isConnected: () => boolean;
+  private log: (message: string) => void;
+
+  private disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private visibilityChangeHandler: () => void = () => {};
+
+  private isListenerConnected = false;
+
+  constructor(private params: SocketAutoDisconnectParams) {
+    this.options = params.options;
+    this.onDisconnect = params.onDisconnect;
+    this.onConnect = params.onConnect;
+    this.isConnected = params.isConnected;
+    this.log = params.log;
+
+    this.log(
+      `[SocketAutoDisconnectManager] Initialized with options: ${JSON.stringify(this.options)}`,
+    );
+    this.visibilityChangeHandler = this.handleVisibilityChange.bind(this);
+  }
+
+  /**
+   * Start listening for visibility changes and managing socket connections
+   */
+  start(): void {
+    this.log("[SocketAutoDisconnectManager] Starting");
+    if (!this.options.enabled || this.isListenerConnected) {
+      this.log(
+        "[SocketAutoDisconnectManager] Not enabled or listener already connected, skipping",
+      );
+      return;
+    }
+
+    if (typeof document === "undefined") {
+      this.log("[SocketAutoDisconnectManager] Document is undefined, skipping");
+      return;
+    }
+
+    this.isListenerConnected = true;
+    document.addEventListener("visibilitychange", this.visibilityChangeHandler);
+  }
+
+  /**
+   * Stop listening for visibility changes and clean up
+   */
+  stop(): void {
+    if (typeof document === "undefined") return;
+
+    document.removeEventListener(
+      "visibilitychange",
+      this.visibilityChangeHandler,
+    );
+    this.isListenerConnected = false;
+
+    if (this.disconnectTimer) {
+      clearTimeout(this.disconnectTimer);
+      this.disconnectTimer = null;
+    }
+  }
+
+  /**
+   * Update the configuration options
+   */
+  updateOptions(options: SocketAutoDisconnectOptions): void {
+    const wasEnabled = this.options.enabled;
+    this.options = options;
+
+    if (!wasEnabled && options.enabled) {
+      this.start();
+    } else if (wasEnabled && !options.enabled) {
+      this.stop();
+    }
+  }
+
+  private handleVisibilityChange(): void {
+    const delay = this.options.delay ?? DEFAULT_DISCONNECT_DELAY;
+
+    // TODO: Clean up logs
+    if (document.visibilityState === "hidden") {
+      this.log(
+        `[SocketAutoDisconnectManager] Tab hidden, scheduling disconnect in ${delay}ms`,
+      );
+
+      // When the tab is hidden, disconnect the socket after a delay
+      this.disconnectTimer = setTimeout(() => {
+        this.log(
+          "[SocketAutoDisconnectManager] Disconnecting socket due to inactive tab",
+        );
+        this.onDisconnect();
+        this.disconnectTimer = null;
+      }, delay);
+    } else if (document.visibilityState === "visible") {
+      this.log("[SocketAutoDisconnectManager] Tab visible");
+
+      // When the tab becomes visible, clear the disconnect timer if active
+      // This handles cases where the tab is only briefly hidden
+      if (this.disconnectTimer) {
+        this.log(
+          "[SocketAutoDisconnectManager] Cancelling scheduled disconnect",
+        );
+        clearTimeout(this.disconnectTimer);
+        this.disconnectTimer = null;
+      }
+
+      // If the socket is not connected, try to reconnect
+      if (!this.isConnected()) {
+        this.log("[SocketAutoDisconnectManager] Reconnecting socket");
+        this.onConnect();
+      }
+    }
+  }
+}

--- a/packages/client/src/clients/shared/socketAutoDisconnectManager.ts
+++ b/packages/client/src/clients/shared/socketAutoDisconnectManager.ts
@@ -43,9 +43,6 @@ export class SocketAutoDisconnectManager {
     this.isConnected = params.isConnected;
     this.log = params.log;
 
-    this.log(
-      `[SocketAutoDisconnectManager] Initialized with options: ${JSON.stringify(this.options)}`,
-    );
     this.visibilityChangeHandler = this.handleVisibilityChange.bind(this);
   }
 
@@ -53,16 +50,11 @@ export class SocketAutoDisconnectManager {
    * Start listening for visibility changes and managing socket connections
    */
   start(): void {
-    this.log("[SocketAutoDisconnectManager] Starting");
     if (!this.options.enabled || this.isListenerConnected) {
-      this.log(
-        "[SocketAutoDisconnectManager] Not enabled or listener already connected, skipping",
-      );
       return;
     }
 
     if (typeof document === "undefined") {
-      this.log("[SocketAutoDisconnectManager] Document is undefined, skipping");
       return;
     }
 
@@ -88,29 +80,10 @@ export class SocketAutoDisconnectManager {
     }
   }
 
-  /**
-   * Update the configuration options
-   */
-  updateOptions(options: SocketAutoDisconnectOptions): void {
-    const wasEnabled = this.options.enabled;
-    this.options = options;
-
-    if (!wasEnabled && options.enabled) {
-      this.start();
-    } else if (wasEnabled && !options.enabled) {
-      this.stop();
-    }
-  }
-
   private handleVisibilityChange(): void {
     const delay = this.options.delay ?? DEFAULT_DISCONNECT_DELAY;
 
-    // TODO: Clean up logs
     if (document.visibilityState === "hidden") {
-      this.log(
-        `[SocketAutoDisconnectManager] Tab hidden, scheduling disconnect in ${delay}ms`,
-      );
-
       // When the tab is hidden, disconnect the socket after a delay
       this.disconnectTimer = setTimeout(() => {
         this.log(
@@ -120,14 +93,9 @@ export class SocketAutoDisconnectManager {
         this.disconnectTimer = null;
       }, delay);
     } else if (document.visibilityState === "visible") {
-      this.log("[SocketAutoDisconnectManager] Tab visible");
-
       // When the tab becomes visible, clear the disconnect timer if active
       // This handles cases where the tab is only briefly hidden
       if (this.disconnectTimer) {
-        this.log(
-          "[SocketAutoDisconnectManager] Cancelling scheduled disconnect",
-        );
         clearTimeout(this.disconnectTimer);
         this.disconnectTimer = null;
       }

--- a/packages/client/test/clients/feed/feed.test.ts
+++ b/packages/client/test/clients/feed/feed.test.ts
@@ -913,17 +913,34 @@ describe("Feed", () => {
           visibilityState: "visible",
         } as unknown as Document;
 
+        const mockSocket = {
+          disconnect: vi.fn(),
+          isConnected: vi.fn().mockReturnValue(true),
+          connect: vi.fn(),
+        };
+
+        const mockClient = {
+          socket: mockSocket,
+        };
+
+        vi.spyOn(knock, "client").mockReturnValue(
+          mockClient as unknown as ApiClient,
+        );
+
         const mockSocketManager = {
           join: vi.fn().mockReturnValue(vi.fn()),
           leave: vi.fn(),
         };
 
-        new Feed(
+        const feed = new Feed(
           knock,
           "01234567-89ab-cdef-0123-456789abcdef",
           { auto_manage_socket_connection: true },
           mockSocketManager as unknown as FeedSocketManager,
         );
+
+        // Start listening for updates to trigger the visibility listener setup
+        feed.listenForUpdates();
 
         expect(mockAddEventListener).toHaveBeenCalledWith(
           "visibilitychange",
@@ -971,7 +988,7 @@ describe("Feed", () => {
           leave: vi.fn(),
         };
 
-        new Feed(
+        const feed = new Feed(
           knock,
           "01234567-89ab-cdef-0123-456789abcdef",
           {
@@ -980,6 +997,9 @@ describe("Feed", () => {
           },
           mockSocketManager as unknown as FeedSocketManager,
         );
+
+        // Start listening for updates to trigger the visibility listener setup
+        feed.listenForUpdates();
 
         // Simulate visibility change to hidden
         mockDocument.visibilityState = "hidden";
@@ -1031,12 +1051,15 @@ describe("Feed", () => {
           leave: vi.fn(),
         };
 
-        new Feed(
+        const feed = new Feed(
           knock,
           "01234567-89ab-cdef-0123-456789abcdef",
           { auto_manage_socket_connection: true },
           mockSocketManager as unknown as FeedSocketManager,
         );
+
+        // Start listening for updates to trigger the visibility listener setup
+        feed.listenForUpdates();
 
         // Simulate visibility change to visible
         mockDocument.visibilityState = "visible";
@@ -1060,6 +1083,20 @@ describe("Feed", () => {
           visibilityState: "visible",
         } as unknown as Document;
 
+        const mockSocket = {
+          disconnect: vi.fn(),
+          isConnected: vi.fn().mockReturnValue(true),
+          connect: vi.fn(),
+        };
+
+        const mockClient = {
+          socket: mockSocket,
+        };
+
+        vi.spyOn(knock, "client").mockReturnValue(
+          mockClient as unknown as ApiClient,
+        );
+
         const mockSocketManager = {
           join: vi.fn().mockReturnValue(vi.fn()),
           leave: vi.fn(),
@@ -1071,6 +1108,9 @@ describe("Feed", () => {
           { auto_manage_socket_connection: true },
           mockSocketManager as unknown as FeedSocketManager,
         );
+
+        // Start listening for updates to trigger the visibility listener setup
+        feed.listenForUpdates();
 
         feed.dispose();
 

--- a/packages/client/test/clients/feed/feed.test.ts
+++ b/packages/client/test/clients/feed/feed.test.ts
@@ -939,7 +939,6 @@ describe("Feed", () => {
           mockSocketManager as unknown as FeedSocketManager,
         );
 
-        // Start listening for updates to trigger the visibility listener setup
         feed.listenForUpdates();
 
         expect(mockAddEventListener).toHaveBeenCalledWith(
@@ -998,7 +997,6 @@ describe("Feed", () => {
           mockSocketManager as unknown as FeedSocketManager,
         );
 
-        // Start listening for updates to trigger the visibility listener setup
         feed.listenForUpdates();
 
         // Simulate visibility change to hidden
@@ -1058,7 +1056,6 @@ describe("Feed", () => {
           mockSocketManager as unknown as FeedSocketManager,
         );
 
-        // Start listening for updates to trigger the visibility listener setup
         feed.listenForUpdates();
 
         // Simulate visibility change to visible
@@ -1109,7 +1106,6 @@ describe("Feed", () => {
           mockSocketManager as unknown as FeedSocketManager,
         );
 
-        // Start listening for updates to trigger the visibility listener setup
         feed.listenForUpdates();
 
         feed.dispose();

--- a/packages/client/test/clients/feed/index.test.ts
+++ b/packages/client/test/clients/feed/index.test.ts
@@ -86,7 +86,8 @@ describe("FeedClient", () => {
       feedClient.initialize("feed-3", defaultOptions);
 
       // Socket manager should only be created once
-      expect(mockKnock.client).toHaveBeenCalledTimes(3); // Once per feed
+      // But client() is called twice per feed: once for socket manager init, once for auto-disconnect manager init
+      expect(mockKnock.client).toHaveBeenCalledTimes(6); // Twice per feed (socket manager + auto-disconnect)
     });
   });
 

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -2726,7 +2726,6 @@ describe("KnockGuideClient", () => {
         },
       );
 
-      // Should initialize the manager
       expect(client["socketAutoDisconnectManager"]).toBeDefined();
 
       const startSpy = vi.spyOn(
@@ -2735,11 +2734,9 @@ describe("KnockGuideClient", () => {
       );
       const stopSpy = vi.spyOn(client["socketAutoDisconnectManager"]!, "stop");
 
-      // Should start on subscribe
       client.subscribe();
       expect(startSpy).toHaveBeenCalled();
 
-      // Should stop on cleanup
       client.cleanup();
       expect(stopSpy).toHaveBeenCalled();
     });
@@ -2757,10 +2754,8 @@ describe("KnockGuideClient", () => {
         },
       );
 
-      // Should not initialize manager when no socket available
       expect(client["socketAutoDisconnectManager"]).toBeUndefined();
 
-      // Should not throw error when no auto-disconnect manager exists
       expect(() => client.subscribe()).not.toThrow();
       expect(() => client.cleanup()).not.toThrow();
     });
@@ -2776,7 +2771,6 @@ describe("KnockGuideClient", () => {
       mockApiClient.socket = mockSocket as unknown as Socket;
       vi.mocked(mockKnock.client).mockReturnValue(mockApiClient as ApiClient);
 
-      // Test enabled=false
       const disabledClient = new KnockGuideClient(
         mockKnock,
         channelId,
@@ -2786,10 +2780,8 @@ describe("KnockGuideClient", () => {
         },
       );
 
-      // Manager is still created but with enabled=false
       expect(disabledClient["socketAutoDisconnectManager"]).toBeDefined();
 
-      // Test default (disabled)
       const defaultClient = new KnockGuideClient(mockKnock, channelId);
       expect(defaultClient["socketAutoDisconnectManager"]).toBeDefined();
     });

--- a/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx
+++ b/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx
@@ -25,6 +25,10 @@ export type KnockGuideProviderProps = {
   trackLocationFromWindow?: boolean;
   orderResolutionDuration?: number; // in milliseconds
   throttleCheckInterval?: number; // in milliseconds
+  /** Automatically manage socket connections based on tab visibility (defaults to false) */
+  autoManageSocketConnection?: boolean;
+  /** Delay in milliseconds before disconnecting socket when tab becomes inactive (defaults to 2000) */
+  autoManageSocketConnectionDelay?: number;
 };
 
 export const KnockGuideProvider: React.FC<
@@ -40,6 +44,8 @@ export const KnockGuideProvider: React.FC<
   // one render cyle first and close the group stage.
   orderResolutionDuration = 0,
   throttleCheckInterval,
+  autoManageSocketConnection,
+  autoManageSocketConnectionDelay,
   children,
 }) => {
   let knock: Knock;
@@ -57,6 +63,8 @@ export const KnockGuideProvider: React.FC<
       trackLocationFromWindow,
       orderResolutionDuration,
       throttleCheckInterval,
+      auto_manage_socket_connection: autoManageSocketConnection,
+      auto_manage_socket_connection_delay: autoManageSocketConnectionDelay,
     });
   }, [
     knock,
@@ -65,6 +73,8 @@ export const KnockGuideProvider: React.FC<
     trackLocationFromWindow,
     orderResolutionDuration,
     throttleCheckInterval,
+    autoManageSocketConnection,
+    autoManageSocketConnectionDelay,
   ]);
 
   React.useEffect(() => {


### PR DESCRIPTION
### Description
- Abstracts auto socket manager into its own class
- Uses in feed and guide client

I tested this locally while live previewing a guide and it successfully disconnects and reconnects and still receives live preview updates on the re-established connection. 

### Checklist
- [x] Tests have been added for new features or major refactors to existing features.

### Screenshots or videos
<img width="741" height="949" alt="CleanShot 2025-09-12 at 10 09 51" src="https://github.com/user-attachments/assets/b582cef8-2e33-44f2-8079-facc48721604" />

