### PR TITLE
feat(feed): optimistically update when unarchiving an item

### DIFF
--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -472,9 +472,46 @@ class Feed {
   }
 
   async markAsUnarchived(itemOrItems: FeedItemOrItems) {
-    this.optimisticallyPerformStatusUpdate(itemOrItems, "unarchived", {
-      archived_at: null,
-    });
+    const state = this.store.getState();
+
+    const items = Array.isArray(itemOrItems) ? itemOrItems : [itemOrItems];
+
+    const itemIds: string[] = items.map((item) => item.id);
+
+    const shouldOptimisticallyRemoveItems =
+      this.defaultOptions.archived === "only";
+
+    if (shouldOptimisticallyRemoveItems) {
+      // If any of the items are unseen or unread, then capture as we'll want to decrement
+      // the counts for these in the metadata we have
+      const unseenCount = items.filter((i) => !i.seen_at).length;
+      const unreadCount = items.filter((i) => !i.read_at).length;
+
+      // Build the new metadata
+      const updatedMetadata = {
+        ...state.metadata,
+        // Ensure that the counts don't ever go below 0 on archiving where the client state
+        // gets out of sync with the server state
+        total_count: Math.max(0, state.metadata.total_count - items.length),
+        unseen_count: Math.max(0, state.metadata.unseen_count - unseenCount),
+        unread_count: Math.max(0, state.metadata.unread_count - unreadCount),
+      };
+
+      // Remove the unarchived entries
+      const entriesToSet = state.items.filter(
+        (item) => !itemIds.includes(item.id),
+      );
+
+      state.setResult({
+        entries: entriesToSet,
+        meta: updatedMetadata,
+        page_info: state.pageInfo,
+      });
+    } else {
+      this.optimisticallyPerformStatusUpdate(itemOrItems, "unarchived", {
+        archived_at: null,
+      });
+    }
 
     return this.makeStatusUpdate(itemOrItems, "unarchived");
   }

--- a/packages/client/test/clients/feed/feed.test.ts
+++ b/packages/client/test/clients/feed/feed.test.ts
@@ -265,6 +265,132 @@ describe("Feed", () => {
     });
   });
 
+  describe("Optimistic Updates", () => {
+    test("marks a single item as archived and correctly removes it from the store", async () => {
+      const { knock, mockApiClient, cleanup } = getTestSetup();
+
+      try {
+        const originalItem = createUnreadFeedItem();
+
+        mockApiClient.makeRequest.mockResolvedValueOnce({
+          statusCode: "ok",
+          body: {
+            entries: [originalItem],
+            meta: {
+              total_count: 1,
+              unread_count: 0,
+              unseen_count: 0,
+            },
+            page_info: {
+              before: null,
+              after: null,
+              page_size: 50,
+            },
+          },
+        });
+
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {
+            archived: "exclude",
+          },
+          undefined,
+        );
+
+        await feed.fetch();
+
+        expect(feed.store.getState().items).toHaveLength(1);
+
+        const feedItem = {
+          ...originalItem,
+          archived_at: new Date().toISOString(),
+        };
+
+        mockApiClient.makeRequest.mockResolvedValueOnce({
+          statusCode: "ok",
+          body: [feedItem],
+        });
+
+        const result = await feed.markAsArchived(feedItem);
+
+        expect(mockApiClient.makeRequest).toHaveBeenNthCalledWith(2, {
+          method: "POST",
+          url: "/v1/messages/batch/archived",
+          data: { message_ids: [feedItem.id] },
+        });
+        expect(result).toEqual([feedItem]);
+
+        expect(feed.store.getState().items).toHaveLength(0);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("marks a single item as unarchived and correctly removes it from the store", async () => {
+      const { knock, mockApiClient, cleanup } = getTestSetup();
+
+      try {
+        const originalItem = createUnreadFeedItem({
+          archived_at: new Date().toISOString(),
+        });
+
+        mockApiClient.makeRequest.mockResolvedValueOnce({
+          statusCode: "ok",
+          body: {
+            entries: [originalItem],
+            meta: {
+              total_count: 1,
+              unread_count: 0,
+              unseen_count: 0,
+            },
+            page_info: {
+              before: null,
+              after: null,
+              page_size: 50,
+            },
+          },
+        });
+
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {
+            archived: "only",
+          },
+          undefined,
+        );
+
+        await feed.fetch();
+
+        expect(feed.store.getState().items).toHaveLength(1);
+
+        const feedItem = {
+          ...originalItem,
+          archived_at: null,
+        };
+
+        mockApiClient.makeRequest.mockResolvedValueOnce({
+          statusCode: "ok",
+          body: [feedItem],
+        });
+
+        const result = await feed.markAsUnarchived(feedItem);
+
+        expect(mockApiClient.makeRequest).toHaveBeenNthCalledWith(2, {
+          method: "POST",
+          url: "/v1/messages/batch/unarchived",
+          data: { message_ids: [feedItem.id] },
+        });
+        expect(result).toEqual([feedItem]);
+
+        expect(feed.store.getState().items).toHaveLength(0);
+      } finally {
+        cleanup();
+      }
+    });
+  });
+
   describe("Bulk Operations", () => {
     test("marks all items as seen", async () => {
       const { knock, mockApiClient, cleanup } = getTestSetup();


### PR DESCRIPTION
### Description
** Describe what, why and how of the changes clearly and concisely. Add any additional useful context or info, as necessary. **

If you had the feed default option to `archived: 'only'` then unarchiving an item is not optimistically removed from the list and would require the user to call `feed.fetch` again.  Instead we now use the same optimistic removing logic (should we consider moving this to it's own private fn?) as `markAsArchived` where if the archived option is set to `only` we remove the item.

I've written two new tests, the `markAsArchived` will pass on `main` but the `markAsUnarchived` will fail. Now they both pass.

### Screenshots or videos
** Attach any screenshots or recordings to visually illustrate the changes, as necessary. Delete if not relevant. **

This is a video of the bug in question:

https://github.com/user-attachments/assets/1482f9bd-cf3e-48c9-a97f-5cfa812a48c9

I can see that the item is recognised as `unarchived` because the button changes to archived as expected.
