### PR TITLE
fix(KNO-9711): Add step_ref field to NotificationSource

### DIFF
--- a/.changeset/ten-experts-retire.md
+++ b/.changeset/ten-experts-retire.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix() Add step_ref to NotificationSource

--- a/.changeset/ten-experts-retire.md
+++ b/.changeset/ten-experts-retire.md
@@ -2,4 +2,6 @@
 "@knocklabs/client": patch
 ---
 
-fix() Add step_ref to NotificationSource
+fix(KNO-9711) Add step_ref to NotificationSource
+
+Add optional nullable field corresponding to API spec

--- a/packages/client/src/clients/messages/interfaces.ts
+++ b/packages/client/src/clients/messages/interfaces.ts
@@ -14,6 +14,7 @@ export interface NotificationSource {
   key: string;
   version_id: string;
   categories: string[];
+  step_ref?: string | null;
 }
 
 export type MessageEngagementStatus =


### PR DESCRIPTION
### Description

Add step_ref field corresponding to...

node SDK:
https://github.com/knocklabs/knock-node/blob/a7d10173d6b444c720b5f4941101fcce1674001d/src/resources/messages/messages.ts#L462-L465

Open API spec:
https://github.com/knocklabs/switchboard/blob/cbb39e9448b3df09cc8e0b1228de0307eb85afe7/lib/switchboard_web/specs/messages/message.ex#L131-L136


**Testing:**

Using local version of knock/client package, run the examples/client-example and verify that still works

<img width="1931" height="1019" alt="image" src="https://github.com/user-attachments/assets/11d786a3-e21d-45ca-85bb-92fe5c5cc636" />
