### PR TITLE
fix(KNO-9854): handle promise rejection when identifying inline

### DIFF
--- a/.changeset/short-masks-decide.md
+++ b/.changeset/short-masks-decide.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: handle promise rejection when identifying a user inline

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -136,7 +136,14 @@ class Knock {
     ) {
       this.log(`Identifying user ${userIdOrUserWithProperties.id} inline`);
       const { id, ...properties } = userIdOrUserWithProperties;
-      this.user.identify(properties);
+      this.user.identify(properties).catch((err) => {
+        const errorMessage =
+          err instanceof Error ? err.message : "Unknown error";
+
+        this.log(
+          `Error identifying user ${userIdOrUserWithProperties.id} inline:\n${errorMessage}`,
+        );
+      });
     }
 
     return;

--- a/packages/client/test/knock.test.ts
+++ b/packages/client/test/knock.test.ts
@@ -305,6 +305,30 @@ describe("Knock Client", () => {
         consoleSpy.mockRestore();
       }
     });
+
+    test("logs error when inline identification fails", async () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        const knock = new Knock("pk_test_12345", { logLevel: "debug" });
+        const identify = vi
+          .spyOn(knock.user, "identify")
+          .mockRejectedValue(new Error("The system is down"));
+
+        knock.authenticate({ id: "user_123", name: "John Doe" }, "token_456", {
+          identificationStrategy: "inline",
+        });
+
+        await vi.runAllTimersAsync();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "[Knock] Error identifying user user_123 inline:\nThe system is down",
+        );
+        expect(identify).toHaveBeenCalled();
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
   });
 
   describe("Client Management", () => {


### PR DESCRIPTION
### Description

`this.users.identify(properties)` returns a promise. This PR adds a `catch` so that we handle any rejection.

I looked into enabling [the `no-floating-promises` ESLint rule](https://typescript-eslint.io/rules/no-floating-promises/), but that requires some updates to our ESLint and TypeScript config files, so I’d like to ship this separately.

### Checklist
- [X] Tests have been added for new features or major refactors to existing features.
