### PR TITLE
Setup typedoc for markdown generation

### DIFF
--- a/TYPEDOC_SETUP.md
+++ b/TYPEDOC_SETUP.md
@@ -1,0 +1,101 @@
+# TypeDoc Setup Summary
+
+This document summarizes the TypeDoc setup that has been configured for the `@knocklabs/javascript` repository.
+
+## What Was Set Up
+
+### 1. Dependencies Installed
+- `typedoc` - Core TypeDoc library
+- `typedoc-plugin-markdown` - Plugin to generate Markdown output instead of HTML
+- `typedoc-plugin-frontmatter` - Plugin to add frontmatter to generated files for better static site integration
+
+### 2. Configuration File
+Created `typedoc.json` with the following key settings:
+- **Output format**: MDX files (for compatibility with modern documentation sites)
+- **Entry point**: `./packages/react-core/src/index.ts` (focused on the react-core package)
+- **Output directory**: `./_typedocs` (top-level directory as requested)
+- **Plugins**: Markdown generation with frontmatter support
+- **Error handling**: Skip type checking errors to allow documentation generation even with build issues
+
+### 3. NPM Scripts Added
+Added three new scripts to `package.json`:
+- `docs:generate` - Runs TypeDoc to generate documentation
+- `docs:clean` - Removes the previous documentation directory
+- `docs:build` - Cleans and regenerates documentation in one command
+
+### 4. Convenience Script
+Created `generate-docs.sh` - A user-friendly script that:
+- Provides colored output and progress indicators
+- Shows helpful information about generated files
+- Includes direct file links for easy access
+
+### 5. Enhanced Documentation
+Added comprehensive TypeDoc comments to key hooks:
+- **`useGuide`** - Hook for retrieving individual guides with detailed examples
+- **`useGuides`** - Hook for retrieving multiple guides with filtering examples
+- Both include full JSDoc comments with parameter descriptions, return types, examples, and TypeScript generics documentation
+
+## Usage
+
+### Quick Start
+```bash
+# Generate documentation with the convenience script
+./generate-docs.sh
+
+# Or use yarn commands directly
+yarn docs:build
+```
+
+### Generated Files
+- `_typedocs/index.mdx` - Main documentation index
+- `_typedocs/globals.mdx` - Complete API reference
+- `_typedocs/README.md` - Documentation about the generated files
+- `_typedocs/_media/` - Static assets
+
+## Features
+
+### MDX Output
+The documentation is generated in MDX format, making it compatible with:
+- Docusaurus
+- Next.js with MDX support
+- Gatsby
+- Any static site generator supporting MDX
+
+### Comprehensive Coverage
+The generated documentation includes:
+- All exported functions, hooks, and interfaces
+- Type parameters and generic constraints
+- Parameter descriptions with types
+- Return type documentation
+- Real-world usage examples
+- GitHub source links for each item
+
+### Example Documentation Quality
+The `useGuide` hook documentation includes:
+- Detailed description of functionality
+- TypeScript generic parameter documentation
+- Parameter documentation with types
+- Return value descriptions
+- Multiple usage examples showing different scenarios
+- Error handling documentation
+
+## Integration Tips
+
+1. **Copy to Documentation Site**: Copy MDX files to your docs directory
+2. **Frontmatter**: Files include layout hints for easy integration
+3. **Source Links**: GitHub links connect docs back to source code
+4. **Type Safety**: All TypeScript types are preserved and documented
+
+## Files Created/Modified
+
+### New Files
+- `typedoc.json` - TypeDoc configuration
+- `generate-docs.sh` - Convenience script
+- `_typedocs/` - Generated documentation directory
+
+### Modified Files
+- `package.json` - Added documentation scripts and dependencies
+- `packages/react-core/src/modules/guide/hooks/useGuide.ts` - Enhanced documentation
+- `packages/react-core/src/modules/guide/hooks/useGuides.ts` - Enhanced documentation
+
+This setup provides a solid foundation for maintaining comprehensive API documentation that stays in sync with your codebase.

--- a/_typedocs/_media/CONTRIBUTING.md
+++ b/_typedocs/_media/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing Guide
+
+## Developing locally
+
+### Monorepo setup
+
+The current monorepo setup is based on:
+
+- [Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/), used for managing multiple packages from a single repository.
+- [Turborepo](https://turbo.build/repo/docs), used for task running and task output caching.
+- [GitHub Actions](https://docs.github.com/en/actions), used for quality checks and automated release orchestration.
+
+Packages are inside the [packages](/packages) directory. Refer to each package's README for specific instructions on installation and usage.
+
+### Packages
+
+- `react` - Knock React SDK with hooks and components for building web notification experiences
+- `react-native` - Knock React Native SDK with hooks and components for building mobile notification experiences
+- `react-core` - Internal utilities shared by the React and React Native SDKs
+- `eslint-config`, `typescript-config` - Shared configuration for our packages and examples
+
+### Examples
+
+- `nextjs-example` - A sample Next.js app showing how to use the Knock in-app feed
+
+### Prerequisites
+
+1. Have a version of Yarn and Node installed that is compatible with the versions defined in `.tool-versions`.
+2. Install dependencies. **Always run `yarn` from the root of the monorepo**, so that dependencies are installed correctly for all packages:
+
+```sh
+# Install dependencies
+yarn
+# Add a dependency
+yarn workspace <workspace> add <package>
+```
+
+3. Build all packages or run them locally:
+
+```sh
+# Build all packages
+yarn build
+
+# or run them in development
+yarn dev
+```

--- a/_typedocs/_media/LICENSE
+++ b/_typedocs/_media/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Knock Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_typedocs/globals.mdx
+++ b/_typedocs/globals.mdx
@@ -1,0 +1,1944 @@
+---
+layout: docs
+sidebar_position: 1
+---
+
+[**@knocklabs/javascript v{projectVersion}**](index.mdx)
+
+***
+
+# @knocklabs/javascript v0.10.4
+
+## Enumerations
+
+### FilterStatus
+
+Defined in: [packages/react-core/src/modules/core/constants.ts:1](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/constants.ts#L1)
+
+#### Enumeration Members
+
+##### All
+
+> **All**: `"all"`
+
+Defined in: [packages/react-core/src/modules/core/constants.ts:2](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/constants.ts#L2)
+
+##### Read
+
+> **Read**: `"read"`
+
+Defined in: [packages/react-core/src/modules/core/constants.ts:3](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/constants.ts#L3)
+
+##### Unseen
+
+> **Unseen**: `"unseen"`
+
+Defined in: [packages/react-core/src/modules/core/constants.ts:4](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/constants.ts#L4)
+
+##### Unread
+
+> **Unread**: `"unread"`
+
+Defined in: [packages/react-core/src/modules/core/constants.ts:5](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/constants.ts#L5)
+
+## Interfaces
+
+### KnockProviderState
+
+Defined in: [packages/react-core/src/modules/core/context/KnockProvider.tsx:12](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/context/KnockProvider.tsx#L12)
+
+#### Properties
+
+##### knock
+
+> **knock**: `Knock`
+
+Defined in: [packages/react-core/src/modules/core/context/KnockProvider.tsx:13](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/context/KnockProvider.tsx#L13)
+
+***
+
+### KnockFeedProviderState
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:11](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L11)
+
+#### Properties
+
+##### knock
+
+> **knock**: `Knock`
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:12](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L12)
+
+##### feedClient
+
+> **feedClient**: `Feed`
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:13](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L13)
+
+##### useFeedStore()
+
+> **useFeedStore**: \<`T`\>(`selector?`) => `T`
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:14](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L14)
+
+###### Type Parameters
+
+###### T
+
+`T` = `FeedStoreState`
+
+###### Parameters
+
+###### selector?
+
+[`Selector`](/docs/globals.mdx#selector)\<`T`\>
+
+###### Returns
+
+`T`
+
+##### colorMode
+
+> **colorMode**: [`ColorMode`](/docs/globals.mdx#colormode)
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:15](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L15)
+
+***
+
+### KnockFeedProviderProps
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:22](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L22)
+
+#### Properties
+
+##### feedId
+
+> **feedId**: `undefined` \| `string`
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:24](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L24)
+
+##### colorMode?
+
+> `optional` **colorMode**: [`ColorMode`](/docs/globals.mdx#colormode)
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:27](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L27)
+
+##### defaultFeedOptions?
+
+> `optional` **defaultFeedOptions**: `any`
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:30](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L30)
+
+***
+
+### KnockI18nProviderProps
+
+Defined in: [packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx:8](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx#L8)
+
+#### Properties
+
+##### i18n?
+
+> `optional` **i18n**: [`I18nContent`](/docs/globals.mdx#i18ncontent)
+
+Defined in: [packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx:9](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx#L9)
+
+***
+
+### Translations
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:4](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L4)
+
+#### Properties
+
+##### archiveRead
+
+> `readonly` **archiveRead**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:5](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L5)
+
+##### emptyFeedTitle
+
+> `readonly` **emptyFeedTitle**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:6](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L6)
+
+##### emptyFeedBody
+
+> `readonly` **emptyFeedBody**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:7](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L7)
+
+##### notifications
+
+> `readonly` **notifications**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:8](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L8)
+
+##### poweredBy
+
+> `readonly` **poweredBy**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:9](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L9)
+
+##### markAllAsRead
+
+> `readonly` **markAllAsRead**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:10](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L10)
+
+##### archiveNotification
+
+> `readonly` **archiveNotification**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:11](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L11)
+
+##### all
+
+> `readonly` **all**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:12](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L12)
+
+##### unread
+
+> `readonly` **unread**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:13](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L13)
+
+##### read
+
+> `readonly` **read**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:14](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L14)
+
+##### unseen
+
+> `readonly` **unseen**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:15](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L15)
+
+##### msTeamsChannelSetError
+
+> `readonly` **msTeamsChannelSetError**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:16](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L16)
+
+##### msTeamsConnect
+
+> `readonly` **msTeamsConnect**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:17](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L17)
+
+##### msTeamsConnected
+
+> `readonly` **msTeamsConnected**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:18](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L18)
+
+##### msTeamsConnecting
+
+> `readonly` **msTeamsConnecting**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:19](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L19)
+
+##### msTeamsConnectionErrorExists
+
+> `readonly` **msTeamsConnectionErrorExists**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:20](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L20)
+
+##### msTeamsConnectionErrorOccurred
+
+> `readonly` **msTeamsConnectionErrorOccurred**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:21](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L21)
+
+##### msTeamsConnectContainerDescription
+
+> `readonly` **msTeamsConnectContainerDescription**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:22](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L22)
+
+##### msTeamsDisconnect
+
+> `readonly` **msTeamsDisconnect**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:23](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L23)
+
+##### msTeamsDisconnecting
+
+> `readonly` **msTeamsDisconnecting**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:24](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L24)
+
+##### msTeamsError
+
+> `readonly` **msTeamsError**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:25](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L25)
+
+##### msTeamsReconnect
+
+> `readonly` **msTeamsReconnect**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:26](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L26)
+
+##### msTeamsTenantIdNotSet
+
+> `readonly` **msTeamsTenantIdNotSet**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:27](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L27)
+
+##### slackConnectChannel
+
+> `readonly` **slackConnectChannel**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:28](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L28)
+
+##### slackChannelId
+
+> `readonly` **slackChannelId**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:29](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L29)
+
+##### slackConnecting
+
+> `readonly` **slackConnecting**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:30](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L30)
+
+##### slackDisconnecting
+
+> `readonly` **slackDisconnecting**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:31](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L31)
+
+##### slackConnect
+
+> `readonly` **slackConnect**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:32](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L32)
+
+##### slackConnected
+
+> `readonly` **slackConnected**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:33](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L33)
+
+##### slackConnectContainerDescription
+
+> `readonly` **slackConnectContainerDescription**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:34](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L34)
+
+##### slackSearchbarDisconnected
+
+> `readonly` **slackSearchbarDisconnected**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:35](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L35)
+
+##### slackSearchbarNoChannelsConnected
+
+> `readonly` **slackSearchbarNoChannelsConnected**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:36](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L36)
+
+##### slackSearchbarNoChannelsFound
+
+> `readonly` **slackSearchbarNoChannelsFound**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:37](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L37)
+
+##### slackSearchbarChannelsError
+
+> `readonly` **slackSearchbarChannelsError**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:38](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L38)
+
+##### slackSearchChannels
+
+> `readonly` **slackSearchChannels**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:39](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L39)
+
+##### slackConnectionErrorOccurred
+
+> `readonly` **slackConnectionErrorOccurred**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:40](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L40)
+
+##### slackConnectionErrorExists
+
+> `readonly` **slackConnectionErrorExists**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:41](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L41)
+
+##### slackChannelAlreadyConnected
+
+> `readonly` **slackChannelAlreadyConnected**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:42](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L42)
+
+##### slackError
+
+> `readonly` **slackError**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:43](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L43)
+
+##### slackDisconnect
+
+> `readonly` **slackDisconnect**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:44](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L44)
+
+##### slackChannelSetError
+
+> `readonly` **slackChannelSetError**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:45](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L45)
+
+##### slackAccessTokenNotSet
+
+> `readonly` **slackAccessTokenNotSet**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:46](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L46)
+
+##### slackReconnect
+
+> `readonly` **slackReconnect**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:47](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L47)
+
+***
+
+### I18nContent
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:50](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L50)
+
+#### Properties
+
+##### translations
+
+> `readonly` **translations**: `Partial`\<[`Translations`](/docs/globals.mdx#translations)\>
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:51](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L51)
+
+##### locale
+
+> `readonly` **locale**: `string`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:52](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L52)
+
+***
+
+### KnockMsTeamsProviderState
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:9](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L9)
+
+#### Properties
+
+##### knockMsTeamsChannelId
+
+> **knockMsTeamsChannelId**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:10](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L10)
+
+##### tenantId
+
+> **tenantId**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:11](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L11)
+
+##### connectionStatus
+
+> **connectionStatus**: `ConnectionStatus`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:12](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L12)
+
+##### setConnectionStatus()
+
+> **setConnectionStatus**: (`connectionStatus`) => `void`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:13](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L13)
+
+###### Parameters
+
+###### connectionStatus
+
+`ConnectionStatus`
+
+###### Returns
+
+`void`
+
+##### errorLabel
+
+> **errorLabel**: `null` \| `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:14](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L14)
+
+##### setErrorLabel()
+
+> **setErrorLabel**: (`label`) => `void`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:15](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L15)
+
+###### Parameters
+
+###### label
+
+`string`
+
+###### Returns
+
+`void`
+
+##### actionLabel
+
+> **actionLabel**: `null` \| `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:16](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L16)
+
+##### setActionLabel()
+
+> **setActionLabel**: (`label`) => `void`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:17](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L17)
+
+###### Parameters
+
+###### label
+
+`null` | `string`
+
+###### Returns
+
+`void`
+
+***
+
+### KnockMsTeamsProviderProps
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:23](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L23)
+
+#### Properties
+
+##### knockMsTeamsChannelId
+
+> **knockMsTeamsChannelId**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:24](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L24)
+
+##### tenantId
+
+> **tenantId**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:25](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L25)
+
+***
+
+### KnockSlackProviderState
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:9](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L9)
+
+#### Properties
+
+##### knockSlackChannelId
+
+> **knockSlackChannelId**: `string`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:10](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L10)
+
+##### tenantId
+
+> **tenantId**: `string`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:11](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L11)
+
+##### ~~tenant~~
+
+> **tenant**: `string`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:15](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L15)
+
+###### Deprecated
+
+Use `tenantId` instead. This field will be removed in a future release.
+
+##### connectionStatus
+
+> **connectionStatus**: `ConnectionStatus`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:16](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L16)
+
+##### setConnectionStatus()
+
+> **setConnectionStatus**: (`connectionStatus`) => `void`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:17](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L17)
+
+###### Parameters
+
+###### connectionStatus
+
+`ConnectionStatus`
+
+###### Returns
+
+`void`
+
+##### errorLabel
+
+> **errorLabel**: `null` \| `string`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:18](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L18)
+
+##### setErrorLabel()
+
+> **setErrorLabel**: (`label`) => `void`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:19](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L19)
+
+###### Parameters
+
+###### label
+
+`string`
+
+###### Returns
+
+`void`
+
+##### actionLabel
+
+> **actionLabel**: `null` \| `string`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:20](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L20)
+
+##### setActionLabel()
+
+> **setActionLabel**: (`label`) => `void`
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:21](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L21)
+
+###### Parameters
+
+###### label
+
+`null` | `string`
+
+###### Returns
+
+`void`
+
+## Type Aliases
+
+### RecipientObject
+
+> **RecipientObject** = `object`
+
+Defined in: [packages/react-core/src/interfaces.ts:1](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/interfaces.ts#L1)
+
+#### Properties
+
+##### objectId
+
+> **objectId**: `string`
+
+Defined in: [packages/react-core/src/interfaces.ts:2](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/interfaces.ts#L2)
+
+##### collection
+
+> **collection**: `string`
+
+Defined in: [packages/react-core/src/interfaces.ts:3](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/interfaces.ts#L3)
+
+***
+
+### ColorMode
+
+> **ColorMode** = `"light"` \| `"dark"`
+
+Defined in: [packages/react-core/src/modules/core/constants.ts:8](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/constants.ts#L8)
+
+***
+
+### KnockProviderProps
+
+> **KnockProviderProps** = `object` & \{ `userId`: `Knock`\[`"userId"`\]; `user?`: `never`; `identificationStrategy?`: `never`; \} \| \{ `user`: `UserWithProperties`; `identificationStrategy?`: `AuthenticateOptions`\[`"identificationStrategy"`\]; `userId?`: `never`; \}
+
+Defined in: [packages/react-core/src/modules/core/context/KnockProvider.tsx:18](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/context/KnockProvider.tsx#L18)
+
+#### Type Declaration
+
+##### apiKey
+
+> **apiKey**: `string` \| `undefined`
+
+##### host?
+
+> `optional` **host**: `string`
+
+##### userToken?
+
+> `optional` **userToken**: `Knock`\[`"userToken"`\]
+
+##### onUserTokenExpiring?
+
+> `optional` **onUserTokenExpiring**: `AuthenticateOptions`\[`"onUserTokenExpiring"`\]
+
+##### timeBeforeExpirationInMs?
+
+> `optional` **timeBeforeExpirationInMs**: `AuthenticateOptions`\[`"timeBeforeExpirationInMs"`\]
+
+##### i18n?
+
+> `optional` **i18n**: [`I18nContent`](/docs/globals.mdx#i18ncontent)
+
+##### logLevel?
+
+> `optional` **logLevel**: `LogLevel`
+
+***
+
+### Selector()
+
+> **Selector**\<`T`\> = (`state`) => `T`
+
+Defined in: [packages/react-core/src/modules/feed/hooks/useNotificationStore.ts:4](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/hooks/useNotificationStore.ts#L4)
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+#### Parameters
+
+##### state
+
+`FeedStoreState`
+
+#### Returns
+
+`T`
+
+***
+
+### KnockGuideProviderProps
+
+> **KnockGuideProviderProps** = `object`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:19](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L19)
+
+#### Properties
+
+##### channelId
+
+> **channelId**: `string`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:20](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L20)
+
+##### readyToTarget
+
+> **readyToTarget**: `boolean`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:21](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L21)
+
+##### listenForUpdates?
+
+> `optional` **listenForUpdates**: `boolean`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:22](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L22)
+
+##### colorMode?
+
+> `optional` **colorMode**: [`ColorMode`](/docs/globals.mdx#colormode)
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:23](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L23)
+
+##### targetParams?
+
+> `optional` **targetParams**: `KnockGuideTargetParams`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:24](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L24)
+
+##### trackLocationFromWindow?
+
+> `optional` **trackLocationFromWindow**: `boolean`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:25](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L25)
+
+##### orderResolutionDuration?
+
+> `optional` **orderResolutionDuration**: `number`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:26](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L26)
+
+##### throttleCheckInterval?
+
+> `optional` **throttleCheckInterval**: `number`
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:27](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L27)
+
+***
+
+### MsTeamsTeamQueryOptions
+
+> **MsTeamsTeamQueryOptions** = `object`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:1](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L1)
+
+#### Properties
+
+##### maxCount?
+
+> `optional` **maxCount**: `number`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:2](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L2)
+
+##### limitPerPage?
+
+> `optional` **limitPerPage**: `number`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:3](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L3)
+
+##### filter?
+
+> `optional` **filter**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:4](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L4)
+
+##### select?
+
+> `optional` **select**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:5](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L5)
+
+***
+
+### MsTeamsChannelQueryOptions
+
+> **MsTeamsChannelQueryOptions** = `object`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:8](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L8)
+
+#### Properties
+
+##### filter?
+
+> `optional` **filter**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:9](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L9)
+
+##### select?
+
+> `optional` **select**: `string`
+
+Defined in: [packages/react-core/src/modules/ms-teams/interfaces.ts:10](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/interfaces.ts#L10)
+
+***
+
+### KnockSlackProviderProps
+
+> **KnockSlackProviderProps** = \{ `knockSlackChannelId`: `string`; `tenant`: `string`; \} \| \{ `knockSlackChannelId`: `string`; `tenantId`: `string`; \}
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:27](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L27)
+
+#### Type Declaration
+
+\{ `knockSlackChannelId`: `string`; `tenant`: `string`; \}
+
+##### knockSlackChannelId
+
+> **knockSlackChannelId**: `string`
+
+##### ~~tenant~~
+
+> **tenant**: `string`
+
+###### Deprecated
+
+Use `tenantId` instead. This field will be removed in a future release.
+
+\{ `knockSlackChannelId`: `string`; `tenantId`: `string`; \}
+
+##### knockSlackChannelId
+
+> **knockSlackChannelId**: `string`
+
+##### tenantId
+
+> **tenantId**: `string`
+
+***
+
+### ContainerObject
+
+> **ContainerObject** = [`RecipientObject`](/docs/globals.mdx#recipientobject)
+
+Defined in: [packages/react-core/src/modules/slack/interfaces.ts:3](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/interfaces.ts#L3)
+
+***
+
+### SlackChannelQueryOptions
+
+> **SlackChannelQueryOptions** = `object`
+
+Defined in: [packages/react-core/src/modules/slack/interfaces.ts:5](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/interfaces.ts#L5)
+
+#### Properties
+
+##### maxCount?
+
+> `optional` **maxCount**: `number`
+
+Defined in: [packages/react-core/src/modules/slack/interfaces.ts:6](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/interfaces.ts#L6)
+
+##### limitPerPage?
+
+> `optional` **limitPerPage**: `number`
+
+Defined in: [packages/react-core/src/modules/slack/interfaces.ts:7](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/interfaces.ts#L7)
+
+##### excludeArchived?
+
+> `optional` **excludeArchived**: `boolean`
+
+Defined in: [packages/react-core/src/modules/slack/interfaces.ts:8](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/interfaces.ts#L8)
+
+##### types?
+
+> `optional` **types**: `string`
+
+Defined in: [packages/react-core/src/modules/slack/interfaces.ts:9](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/interfaces.ts#L9)
+
+##### teamId?
+
+> `optional` **teamId**: `string`
+
+Defined in: [packages/react-core/src/modules/slack/interfaces.ts:10](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/interfaces.ts#L10)
+
+## Variables
+
+### KnockProvider
+
+> `const` **KnockProvider**: `React.FC`\<`PropsWithChildren`\<[`KnockProviderProps`](/docs/globals.mdx#knockproviderprops)\>\>
+
+Defined in: [packages/react-core/src/modules/core/context/KnockProvider.tsx:57](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/context/KnockProvider.tsx#L57)
+
+***
+
+### KnockFeedProvider
+
+> `const` **KnockFeedProvider**: `React.FC`\<`PropsWithChildren`\<[`KnockFeedProviderProps`](/docs/globals.mdx#knockfeedproviderprops)\>\>
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:33](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L33)
+
+***
+
+### KnockGuideContext
+
+> `const` **KnockGuideContext**: `Context`\<`undefined` \| `KnockGuideProviderValue`\>
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:15](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L15)
+
+***
+
+### KnockGuideProvider
+
+> `const` **KnockGuideProvider**: `React.FC`\<`React.PropsWithChildren`\<[`KnockGuideProviderProps`](/docs/globals.mdx#knockguideproviderprops)\>\>
+
+Defined in: [packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx:30](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/context/KnockGuideProvider.tsx#L30)
+
+***
+
+### I18nContext
+
+> `const` **I18nContext**: `Context`\<[`I18nContent`](/docs/globals.mdx#i18ncontent)\>
+
+Defined in: [packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx:6](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx#L6)
+
+***
+
+### KnockI18nProvider
+
+> `const` **KnockI18nProvider**: `FunctionComponent`\<`PropsWithChildren`\<[`KnockI18nProviderProps`](/docs/globals.mdx#knocki18nproviderprops)\>\>
+
+Defined in: [packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx:12](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/context/KnockI18nProvider.tsx#L12)
+
+***
+
+### locales
+
+> `const` **locales**: `object`
+
+Defined in: [packages/react-core/src/modules/i18n/languages/index.ts:55](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/languages/index.ts#L55)
+
+#### Type Declaration
+
+##### en
+
+> **en**: [`I18nContent`](/docs/globals.mdx#i18ncontent)
+
+##### de
+
+> **de**: [`I18nContent`](/docs/globals.mdx#i18ncontent)
+
+***
+
+### KnockMsTeamsProvider
+
+> `const` **KnockMsTeamsProvider**: `React.FC`\<`PropsWithChildren`\<[`KnockMsTeamsProviderProps`](/docs/globals.mdx#knockmsteamsproviderprops)\>\>
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:28](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L28)
+
+***
+
+### KnockSlackProvider
+
+> `const` **KnockSlackProvider**: `React.FC`\<`PropsWithChildren`\<[`KnockSlackProviderProps`](/docs/globals.mdx#knockslackproviderprops)\>\>
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:40](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L40)
+
+## Functions
+
+### useKnockClient()
+
+> **useKnockClient**(): `Knock`
+
+Defined in: [packages/react-core/src/modules/core/context/KnockProvider.tsx:103](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/context/KnockProvider.tsx#L103)
+
+#### Returns
+
+`Knock`
+
+***
+
+### ~~useAuthenticatedKnockClient()~~
+
+#### Call Signature
+
+> **useAuthenticatedKnockClient**(`apiKey`, `userIdOrUserWithProperties`, `userToken?`, `options?`): `Knock`
+
+Defined in: [packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts:35](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts#L35)
+
+##### Parameters
+
+###### apiKey
+
+`string`
+
+###### userIdOrUserWithProperties
+
+`UserId`
+
+###### userToken?
+
+`any`
+
+###### options?
+
+`any`
+
+##### Returns
+
+`Knock`
+
+##### Deprecated
+
+Passing `userId` as a `string` is deprecated and will be removed in a future version.
+Please pass a `user` object instead containing an `id` value.
+example:
+```ts
+useAuthenticatedKnockClient("pk_test_12345", { id: "user_123" });
+```
+
+#### Call Signature
+
+> **useAuthenticatedKnockClient**(`apiKey`, `userIdOrUserWithProperties`, `userToken?`, `options?`): `Knock`
+
+Defined in: [packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts:41](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/hooks/useAuthenticatedKnockClient.ts#L41)
+
+##### Parameters
+
+###### apiKey
+
+`string`
+
+###### userIdOrUserWithProperties
+
+`UserIdOrUserWithProperties`
+
+###### userToken?
+
+`any`
+
+###### options?
+
+`any`
+
+##### Returns
+
+`Knock`
+
+##### Deprecated
+
+Passing `userId` as a `string` is deprecated and will be removed in a future version.
+Please pass a `user` object instead containing an `id` value.
+example:
+```ts
+useAuthenticatedKnockClient("pk_test_12345", { id: "user_123" });
+```
+
+***
+
+### useStableOptions()
+
+> **useStableOptions**\<`T`\>(`options`): `T`
+
+Defined in: [packages/react-core/src/modules/core/hooks/useStableOptions.ts:4](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/hooks/useStableOptions.ts#L4)
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+#### Parameters
+
+##### options
+
+`T`
+
+#### Returns
+
+`T`
+
+***
+
+### formatBadgeCount()
+
+> **formatBadgeCount**(`count`): `string` \| `number`
+
+Defined in: [packages/react-core/src/modules/core/utils.ts:5](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/utils.ts#L5)
+
+#### Parameters
+
+##### count
+
+`number`
+
+#### Returns
+
+`string` \| `number`
+
+***
+
+### formatTimestamp()
+
+> **formatTimestamp**(`ts`, `options`): `string`
+
+Defined in: [packages/react-core/src/modules/core/utils.ts:13](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/utils.ts#L13)
+
+#### Parameters
+
+##### ts
+
+`string`
+
+##### options
+
+`FormatTimestampOptions` = `{}`
+
+#### Returns
+
+`string`
+
+***
+
+### toSentenceCase()
+
+> **toSentenceCase**(`string`): `string`
+
+Defined in: [packages/react-core/src/modules/core/utils.ts:29](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/utils.ts#L29)
+
+#### Parameters
+
+##### string
+
+`string`
+
+#### Returns
+
+`string`
+
+***
+
+### renderNodeOrFallback()
+
+> **renderNodeOrFallback**(`node`, `fallback`): `ReactNode`
+
+Defined in: [packages/react-core/src/modules/core/utils.ts:33](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/utils.ts#L33)
+
+#### Parameters
+
+##### node
+
+`ReactNode`
+
+##### fallback
+
+`ReactNode`
+
+#### Returns
+
+`ReactNode`
+
+***
+
+### feedProviderKey()
+
+> **feedProviderKey**(`userId`, `feedId`, `options`): `string`
+
+Defined in: [packages/react-core/src/modules/core/utils.ts:41](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/utils.ts#L41)
+
+#### Parameters
+
+##### userId
+
+`Knock`
+
+##### feedId
+
+`string`
+
+##### options
+
+`FeedClientOptions` = `{}`
+
+#### Returns
+
+`string`
+
+***
+
+### slackProviderKey()
+
+> **slackProviderKey**(`__namedParameters`): `string`
+
+Defined in: [packages/react-core/src/modules/core/utils.ts:62](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/utils.ts#L62)
+
+#### Parameters
+
+##### \_\_namedParameters
+
+###### knockSlackChannelId
+
+`string`
+
+###### tenantId
+
+`string`
+
+###### connectionStatus
+
+`string`
+
+###### errorLabel
+
+`null` \| `string`
+
+#### Returns
+
+`string`
+
+***
+
+### msTeamsProviderKey()
+
+> **msTeamsProviderKey**(`__namedParameters`): `string`
+
+Defined in: [packages/react-core/src/modules/core/utils.ts:82](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/core/utils.ts#L82)
+
+#### Parameters
+
+##### \_\_namedParameters
+
+###### knockMsTeamsChannelId
+
+`string`
+
+###### tenantId
+
+`string`
+
+###### connectionStatus
+
+`string`
+
+###### errorLabel
+
+`null` \| `string`
+
+#### Returns
+
+`string`
+
+***
+
+### useKnockFeed()
+
+> **useKnockFeed**(): [`KnockFeedProviderState`](/docs/globals.mdx#knockfeedproviderstate)
+
+Defined in: [packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx:61](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/context/KnockFeedProvider.tsx#L61)
+
+#### Returns
+
+[`KnockFeedProviderState`](/docs/globals.mdx#knockfeedproviderstate)
+
+***
+
+### useFeedSettings()
+
+> **useFeedSettings**(`feedClient`): `object`
+
+Defined in: [packages/react-core/src/modules/feed/hooks/useFeedSettings.ts:10](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/hooks/useFeedSettings.ts#L10)
+
+#### Parameters
+
+##### feedClient
+
+`Feed`
+
+#### Returns
+
+`object`
+
+##### settings
+
+> **settings**: `null` \| `FeedSettings`
+
+##### loading
+
+> **loading**: `boolean`
+
+***
+
+### useCreateNotificationStore()
+
+> **useCreateNotificationStore**(`feedClient`): \<`T`\>(`selector?`) => `T`
+
+Defined in: [packages/react-core/src/modules/feed/hooks/useNotificationStore.ts:12](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/hooks/useNotificationStore.ts#L12)
+
+Create a hook factory that provides access to the TanStack Store with optional selector support.
+This pattern allows for flexible store access with or without selectors while maintaining
+type safety. The selector can be passed either to useCreateNotificationStore or
+useNotificationStore, with the latter taking precedence.
+
+#### Parameters
+
+##### feedClient
+
+`Feed`
+
+#### Returns
+
+> \<`T`\>(`selector?`): `T`
+
+##### Type Parameters
+
+###### T
+
+`T` = `FeedStoreState`
+
+##### Parameters
+
+###### selector?
+
+[`Selector`](/docs/globals.mdx#selector)\<`T`\>
+
+##### Returns
+
+`T`
+
+***
+
+### useNotificationStore()
+
+#### Call Signature
+
+> **useNotificationStore**(`feedClient`): `FeedStoreState`
+
+Defined in: [packages/react-core/src/modules/feed/hooks/useNotificationStore.ts:44](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/hooks/useNotificationStore.ts#L44)
+
+A hook used to access content within the notification store.
+
+##### Parameters
+
+###### feedClient
+
+`Feed`
+
+##### Returns
+
+`FeedStoreState`
+
+##### Examples
+
+```ts
+const { items, metadata } = useNotificationStore(feedClient);
+```
+
+A selector can be used to access a subset of the store state.
+
+```ts
+const { items, metadata } = useNotificationStore(feedClient, (state) => ({
+  items: state.items,
+  metadata: state.metadata,
+}));
+```
+
+#### Call Signature
+
+> **useNotificationStore**\<`T`\>(`feedClient`, `selector`): `T`
+
+Defined in: [packages/react-core/src/modules/feed/hooks/useNotificationStore.ts:45](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/hooks/useNotificationStore.ts#L45)
+
+A hook used to access content within the notification store.
+
+##### Type Parameters
+
+###### T
+
+`T`
+
+##### Parameters
+
+###### feedClient
+
+`Feed`
+
+###### selector
+
+[`Selector`](/docs/globals.mdx#selector)\<`T`\>
+
+##### Returns
+
+`T`
+
+##### Examples
+
+```ts
+const { items, metadata } = useNotificationStore(feedClient);
+```
+
+A selector can be used to access a subset of the store state.
+
+```ts
+const { items, metadata } = useNotificationStore(feedClient, (state) => ({
+  items: state.items,
+  metadata: state.metadata,
+}));
+```
+
+***
+
+### useNotifications()
+
+> **useNotifications**(`knock`, `feedChannelId`, `options`): `Feed`
+
+Defined in: [packages/react-core/src/modules/feed/hooks/useNotifications.ts:11](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/feed/hooks/useNotifications.ts#L11)
+
+#### Parameters
+
+##### knock
+
+`Knock`
+
+##### feedChannelId
+
+`string`
+
+##### options
+
+`FeedClientOptions` = `{}`
+
+#### Returns
+
+`Feed`
+
+***
+
+### useGuide()
+
+> **useGuide**\<`C`\>(`filters`): `UseGuideReturn`\<`C`\>
+
+Defined in: [packages/react-core/src/modules/guide/hooks/useGuide.ts:72](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/hooks/useGuide.ts#L72)
+
+Hook for retrieving and managing a specific guide based on filters.
+
+This hook allows you to access a specific guide from the Knock system by providing
+filter criteria such as key or type. It returns the guide object along with its
+current step and provides access to the guide context.
+
+#### Type Parameters
+
+##### C
+
+`C` = `any`
+
+The custom data type for guide content
+
+#### Parameters
+
+##### filters
+
+`KnockGuideFilterParams`
+
+Filter parameters to identify the guide
+
+#### Returns
+
+`UseGuideReturn`\<`C`\>
+
+An object containing:
+- `guide`: The matched guide object or undefined if no match
+- `step`: The current step of the guide or undefined
+- `client`: The Knock client instance from context
+- `colorMode`: The current color mode from context
+
+#### Throws
+
+When neither key nor type filters are provided
+
+#### Examples
+
+```typescript
+// Get a guide by key
+const { guide, step, client } = useGuide({ key: 'onboarding-guide' });
+
+if (guide) {
+  console.log('Guide title:', guide.title);
+  if (step) {
+    console.log('Current step:', step.title);
+  }
+}
+```
+
+```typescript
+// Get a guide by type
+const { guide, step } = useGuide({ type: 'tutorial' });
+
+// Use with custom content type
+interface CustomGuideData {
+  category: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+}
+
+const { guide } = useGuide<CustomGuideData>({ key: 'advanced-tutorial' });
+```
+
+***
+
+### useGuideContext()
+
+> **useGuideContext**(): `UseGuideContextReturn`
+
+Defined in: [packages/react-core/src/modules/guide/hooks/useGuideContext.ts:11](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/hooks/useGuideContext.ts#L11)
+
+#### Returns
+
+`UseGuideContextReturn`
+
+***
+
+### useGuides()
+
+> **useGuides**\<`C`\>(`filters`): `UseGuidesReturn`\<`C`\>
+
+Defined in: [packages/react-core/src/modules/guide/hooks/useGuides.ts:62](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/guide/hooks/useGuides.ts#L62)
+
+Hook for retrieving and managing multiple guides based on type filters.
+
+This hook allows you to access multiple guides from the Knock system by providing
+a type filter. It returns an array of guide objects that match the specified type
+along with access to the guide context.
+
+#### Type Parameters
+
+##### C
+
+`C` = `any`
+
+The custom data type for guide content
+
+#### Parameters
+
+##### filters
+
+`Pick`\<`KnockGuideFilterParams`, `"type"`\>
+
+Filter parameters to identify guides
+
+#### Returns
+
+`UseGuidesReturn`\<`C`\>
+
+An object containing:
+- `guides`: Array of guides matching the filter
+- `client`: The Knock client instance from context
+- `colorMode`: The current color mode from context
+
+#### Examples
+
+```typescript
+// Get all tutorial guides
+const { guides, client } = useGuides({ type: 'tutorial' });
+
+console.log(`Found ${guides.length} tutorial guides`);
+guides.forEach(guide => {
+  console.log('Guide:', guide.title);
+});
+```
+
+```typescript
+// Use with custom content type
+interface TutorialData {
+  difficulty: 'beginner' | 'intermediate' | 'advanced';
+  estimatedTime: number;
+}
+
+const { guides } = useGuides<TutorialData>({ type: 'tutorial' });
+
+// Filter by difficulty
+const beginnerGuides = guides.filter(guide => 
+  guide.data?.difficulty === 'beginner'
+);
+```
+
+***
+
+### useTranslations()
+
+> **useTranslations**(): `object`
+
+Defined in: [packages/react-core/src/modules/i18n/hooks/useTranslations.ts:6](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/i18n/hooks/useTranslations.ts#L6)
+
+#### Returns
+
+`object`
+
+##### locale
+
+> **locale**: `string`
+
+##### t()
+
+> **t**: (`key`) => `undefined` \| `string`
+
+###### Parameters
+
+###### key
+
+keyof [`Translations`](/docs/globals.mdx#translations)
+
+###### Returns
+
+`undefined` \| `string`
+
+***
+
+### useKnockMsTeamsClient()
+
+> **useKnockMsTeamsClient**(): [`KnockMsTeamsProviderState`](/docs/globals.mdx#knockmsteamsproviderstate)
+
+Defined in: [packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx:66](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/context/KnockMsTeamsProvider.tsx#L66)
+
+#### Returns
+
+[`KnockMsTeamsProviderState`](/docs/globals.mdx#knockmsteamsproviderstate)
+
+***
+
+### useConnectedMsTeamsChannels()
+
+> **useConnectedMsTeamsChannels**(`__namedParameters`): `UseConnectedMsTeamsChannelsOutput`
+
+Defined in: [packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts:27](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/hooks/useConnectedMsTeamsChannels.ts#L27)
+
+#### Parameters
+
+##### \_\_namedParameters
+
+`UseConnectedMsTeamsChannelsProps`
+
+#### Returns
+
+`UseConnectedMsTeamsChannelsOutput`
+
+***
+
+### useMsTeamsAuth()
+
+> **useMsTeamsAuth**(`graphApiClientId`, `redirectUrl?`): `UseMsTeamsAuthOutput`
+
+Defined in: [packages/react-core/src/modules/ms-teams/hooks/useMsTeamsAuth.ts:17](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsAuth.ts#L17)
+
+#### Parameters
+
+##### graphApiClientId
+
+`string`
+
+##### redirectUrl?
+
+`string`
+
+#### Returns
+
+`UseMsTeamsAuthOutput`
+
+***
+
+### useMsTeamsChannels()
+
+> **useMsTeamsChannels**(`__namedParameters`): `UseMsTeamsChannelsOutput`
+
+Defined in: [packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts:21](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsChannels.ts#L21)
+
+#### Parameters
+
+##### \_\_namedParameters
+
+`UseMsTeamsChannelsProps`
+
+#### Returns
+
+`UseMsTeamsChannelsOutput`
+
+***
+
+### useMsTeamsConnectionStatus()
+
+> **useMsTeamsConnectionStatus**(`knock`, `knockMsTeamsChannelId`, `tenantId`): `UseMsTeamsConnectionStatusOutput`
+
+Defined in: [packages/react-core/src/modules/ms-teams/hooks/useMsTeamsConnectionStatus.ts:22](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsConnectionStatus.ts#L22)
+
+#### Parameters
+
+##### knock
+
+`Knock`
+
+##### knockMsTeamsChannelId
+
+`string`
+
+##### tenantId
+
+`string`
+
+#### Returns
+
+`UseMsTeamsConnectionStatusOutput`
+
+***
+
+### useMsTeamsTeams()
+
+> **useMsTeamsTeams**(`__namedParameters`): `UseMsTeamsTeamsOutput`
+
+Defined in: [packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts:43](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/ms-teams/hooks/useMsTeamsTeams.ts#L43)
+
+#### Parameters
+
+##### \_\_namedParameters
+
+`UseMsTeamsTeamsOptions`
+
+#### Returns
+
+`UseMsTeamsTeamsOutput`
+
+***
+
+### usePreferences()
+
+> **usePreferences**(`options`): `UsePreferencesReturn`
+
+Defined in: [packages/react-core/src/modules/preferences/hooks/usePreferences.ts:21](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/preferences/hooks/usePreferences.ts#L21)
+
+#### Parameters
+
+##### options
+
+`GetPreferencesOptions` = `{}`
+
+#### Returns
+
+`UsePreferencesReturn`
+
+***
+
+### useKnockSlackClient()
+
+> **useKnockSlackClient**(): [`KnockSlackProviderState`](/docs/globals.mdx#knockslackproviderstate)
+
+Defined in: [packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx:83](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/context/KnockSlackProvider.tsx#L83)
+
+#### Returns
+
+[`KnockSlackProviderState`](/docs/globals.mdx#knockslackproviderstate)
+
+***
+
+### useConnectedSlackChannels()
+
+> **useConnectedSlackChannels**(`__namedParameters`): `UseConnectedSlackChannelsOutput`
+
+Defined in: [packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts:27](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/hooks/useConnectedSlackChannels.ts#L27)
+
+#### Parameters
+
+##### \_\_namedParameters
+
+`UseConnectedSlackChannelsProps`
+
+#### Returns
+
+`UseConnectedSlackChannelsOutput`
+
+***
+
+### useSlackAuth()
+
+> **useSlackAuth**(`slackClientId`, `redirectUrl?`, `options?`): `UseSlackAuthOutput`
+
+Defined in: [packages/react-core/src/modules/slack/hooks/useSlackAuth.ts:48](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/hooks/useSlackAuth.ts#L48)
+
+#### Parameters
+
+##### slackClientId
+
+`string`
+
+##### redirectUrl?
+
+`string`
+
+##### options?
+
+`string`[] | `UseSlackAuthOptions`
+
+#### Returns
+
+`UseSlackAuthOutput`
+
+***
+
+### useSlackChannels()
+
+> **useSlackChannels**(`__namedParameters`): `UseSlackChannelOutput`
+
+Defined in: [packages/react-core/src/modules/slack/hooks/useSlackChannels.ts:44](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/hooks/useSlackChannels.ts#L44)
+
+#### Parameters
+
+##### \_\_namedParameters
+
+`UseSlackChannelsOptions`
+
+#### Returns
+
+`UseSlackChannelOutput`
+
+***
+
+### useSlackConnectionStatus()
+
+> **useSlackConnectionStatus**(`knock`, `knockSlackChannelId`, `tenantId`): `UseSlackConnectionStatusOutput`
+
+Defined in: [packages/react-core/src/modules/slack/hooks/useSlackConnectionStatus.ts:34](https://github.com/knocklabs/javascript/blob/main/packages/react-core/src/modules/slack/hooks/useSlackConnectionStatus.ts#L34)
+
+#### Parameters
+
+##### knock
+
+`Knock`
+
+##### knockSlackChannelId
+
+`string`
+
+##### tenantId
+
+`string`
+
+#### Returns
+
+`UseSlackConnectionStatusOutput`
+
+***
+
+### useStore()
+
+#### Call Signature
+
+> **useStore**\<`TState`, `TSelected`\>(`store`, `selector?`): `TSelected`
+
+Defined in: node\_modules/@tanstack/react-store/dist/cjs/index.d.cts:7
+
+##### Type Parameters
+
+###### TState
+
+`TState`
+
+###### TSelected
+
+`TSelected` = `NoInfer`\<`TState`\>
+
+##### Parameters
+
+###### store
+
+`Store`\<`TState`, `any`\>
+
+###### selector?
+
+(`state`) => `TSelected`
+
+##### Returns
+
+`TSelected`
+
+#### Call Signature
+
+> **useStore**\<`TState`, `TSelected`\>(`store`, `selector?`): `TSelected`
+
+Defined in: node\_modules/@tanstack/react-store/dist/cjs/index.d.cts:8
+
+##### Type Parameters
+
+###### TState
+
+`TState`
+
+###### TSelected
+
+`TSelected` = `NoInfer`\<`TState`\>
+
+##### Parameters
+
+###### store
+
+`Derived`\<`TState`, `any`\>
+
+###### selector?
+
+(`state`) => `TSelected`
+
+##### Returns
+
+`TSelected`

--- a/_typedocs/index.mdx
+++ b/_typedocs/index.mdx
@@ -1,0 +1,34 @@
+---
+layout: docs
+sidebar_position: 1
+---
+
+**@knocklabs/javascript v{projectVersion}**
+
+***
+
+# Offical Knock JavaScript SDKs
+
+---
+
+Knock is flexible, reliable notifications infrastructure that's built to scale with you. Use our APIs to engage users, power cross-channel workflows, and manage notification preferences.
+
+---
+
+## Get Started with Knock
+
+1. [Sign up for an account](https://dashboard.knock.app/signup)
+2. Follow the [Quick start guide](https://docs.knock.app/getting-started/quick-start) to integrate Knock into an app
+3. Explore the [Knock Documentation](https://docs.knock.app/) for more in-depth guides
+
+This repository contains all the Knock JavaScript SDKs and example applications to help you get started with Knock.
+
+## How to Contribute
+
+Community contributions are welcome! If you'd like to contribute, please read our [contribution guide](_media/CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the MIT license.
+
+See [LICENSE](_media/LICENSE) for more information.

--- a/generate-docs.sh
+++ b/generate-docs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# TypeDoc Documentation Generator Script
+# This script generates TypeDoc documentation for the @knocklabs/javascript repository
+
+set -e
+
+echo "🚀 Starting TypeDoc documentation generation..."
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}ℹ️  Cleaning previous documentation...${NC}"
+yarn docs:clean
+
+echo -e "${BLUE}ℹ️  Generating TypeDoc documentation...${NC}"
+yarn docs:generate
+
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Documentation generated successfully!${NC}"
+    echo -e "${GREEN}📁 Documentation location: ./_typedocs${NC}"
+    echo ""
+    echo -e "${YELLOW}📖 To view the documentation:${NC}"
+    echo -e "   - Open ./_typedocs/index.mdx to see the main index"
+    echo -e "   - Browse ./_typedocs/globals.mdx for the full API reference"
+    echo -e "   - All files are in MDX format for easy integration with documentation sites"
+    echo ""
+    echo -e "${YELLOW}🔗 Quick links:${NC}"
+    echo -e "   - Main index: file://$(pwd)/_typedocs/index.mdx"
+    echo -e "   - API reference: file://$(pwd)/_typedocs/globals.mdx"
+else
+    echo -e "${RED}❌ Documentation generation failed!${NC}"
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "test:integration:react-19": "./integration/run-integration.sh 19.1.0",
     "test:integration:runner": "cd ./integration && yarn test:integration && cd ..",
     "type:check": "turbo type:check",
+    "docs:generate": "typedoc",
+    "docs:clean": "rm -rf _typedocs",
+    "docs:build": "yarn docs:clean && yarn docs:generate",
     "release:version": "yarn changeset version && yarn install --mode=update-lockfile",
     "release:publish": "yarn build:packages && yarn workspaces foreach -Rpt --no-private --from '@knocklabs/*' npm publish --access public --tolerate-republish --tag \"$NPM_CONFIG_TAG\" && yarn changeset tag",
     "postinstall": "manypkg check"
@@ -48,7 +51,12 @@
     "@manypkg/cli": "^0.25.0",
     "@vitest/coverage-v8": "^3.2.4",
     "prettier": "^3.5.3",
+    "rimraf": "^6.0.1",
     "turbo": "^2.5.4",
+    "typedoc": "^0.28.13",
+    "typedoc-plugin-frontmatter": "^1.3.0",
+    "typedoc-plugin-markdown": "^4.9.0",
+    "typescript": "^5.9.2",
     "vitest": "^3.1.1"
   },
   "engines": {

--- a/packages/react-core/src/modules/guide/hooks/useGuide.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuide.ts
@@ -10,11 +10,65 @@ import { UseGuideContextReturn, useGuideContext } from "./useGuideContext";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Any = any;
 
-interface UseGuideReturn<C = Any> extends UseGuideContextReturn {
+/**
+ * Return type for the useGuide hook.
+ * 
+ * @template C - The custom data type for guide content
+ */
+export interface UseGuideReturn<C = Any> extends UseGuideContextReturn {
+  /** The guide object matching the provided filters, or undefined if no guide matches */
   guide: KnockGuide<C> | undefined;
+  /** The current step of the guide, or undefined if no guide or no current step */
   step: KnockGuideStep<C> | undefined;
 }
 
+/**
+ * Hook for retrieving and managing a specific guide based on filters.
+ * 
+ * This hook allows you to access a specific guide from the Knock system by providing
+ * filter criteria such as key or type. It returns the guide object along with its
+ * current step and provides access to the guide context.
+ * 
+ * @template C - The custom data type for guide content
+ * @param filters - Filter parameters to identify the guide
+ * @param filters.key - Optional unique key to identify a specific guide
+ * @param filters.type - Optional type to filter guides by their type
+ * 
+ * @returns An object containing:
+ * - `guide`: The matched guide object or undefined if no match
+ * - `step`: The current step of the guide or undefined
+ * - `client`: The Knock client instance from context
+ * - `colorMode`: The current color mode from context
+ * 
+ * @throws {Error} When neither key nor type filters are provided
+ * 
+ * @example
+ * ```typescript
+ * // Get a guide by key
+ * const { guide, step, client } = useGuide({ key: 'onboarding-guide' });
+ * 
+ * if (guide) {
+ *   console.log('Guide title:', guide.title);
+ *   if (step) {
+ *     console.log('Current step:', step.title);
+ *   }
+ * }
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * // Get a guide by type
+ * const { guide, step } = useGuide({ type: 'tutorial' });
+ * 
+ * // Use with custom content type
+ * interface CustomGuideData {
+ *   category: string;
+ *   difficulty: 'easy' | 'medium' | 'hard';
+ * }
+ * 
+ * const { guide } = useGuide<CustomGuideData>({ key: 'advanced-tutorial' });
+ * ```
+ */
 export const useGuide = <C = Any>(
   filters: KnockGuideFilterParams,
 ): UseGuideReturn<C> => {

--- a/packages/react-core/src/modules/guide/hooks/useGuides.ts
+++ b/packages/react-core/src/modules/guide/hooks/useGuides.ts
@@ -6,10 +6,59 @@ import { UseGuideContextReturn, useGuideContext } from "./useGuideContext";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Any = any;
 
-interface UseGuidesReturn<C = Any> extends UseGuideContextReturn {
+/**
+ * Return type for the useGuides hook.
+ * 
+ * @template C - The custom data type for guide content
+ */
+export interface UseGuidesReturn<C = Any> extends UseGuideContextReturn {
+  /** Array of guides matching the provided filters */
   guides: KnockGuide<C>[];
 }
 
+/**
+ * Hook for retrieving and managing multiple guides based on type filters.
+ * 
+ * This hook allows you to access multiple guides from the Knock system by providing
+ * a type filter. It returns an array of guide objects that match the specified type
+ * along with access to the guide context.
+ * 
+ * @template C - The custom data type for guide content
+ * @param filters - Filter parameters to identify guides
+ * @param filters.type - Required type to filter guides by their type
+ * 
+ * @returns An object containing:
+ * - `guides`: Array of guides matching the filter
+ * - `client`: The Knock client instance from context
+ * - `colorMode`: The current color mode from context
+ * 
+ * @example
+ * ```typescript
+ * // Get all tutorial guides
+ * const { guides, client } = useGuides({ type: 'tutorial' });
+ * 
+ * console.log(`Found ${guides.length} tutorial guides`);
+ * guides.forEach(guide => {
+ *   console.log('Guide:', guide.title);
+ * });
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * // Use with custom content type
+ * interface TutorialData {
+ *   difficulty: 'beginner' | 'intermediate' | 'advanced';
+ *   estimatedTime: number;
+ * }
+ * 
+ * const { guides } = useGuides<TutorialData>({ type: 'tutorial' });
+ * 
+ * // Filter by difficulty
+ * const beginnerGuides = guides.filter(guide => 
+ *   guide.data?.difficulty === 'beginner'
+ * );
+ * ```
+ */
 export const useGuides = <C = Any>(
   filters: Pick<KnockGuideFilterParams, "type">,
 ): UseGuidesReturn<C> => {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "./packages/react-core/src/index.ts"
+  ],
+  "out": "./_typedocs",
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter"
+  ],
+  "theme": "markdown",
+  "readme": "./README.md",
+  "name": "@knocklabs/javascript",
+  "includeVersion": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeExternals": false,
+  "skipErrorChecking": true,
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "categorizeByGroup": true,
+  "defaultCategory": "Other",
+  "categoryOrder": [
+    "Hooks",
+    "Components", 
+    "Types",
+    "Interfaces",
+    "Functions",
+    "Classes",
+    "Other"
+  ],
+  "sort": [
+    "source-order"
+  ],
+  "kindSortOrder": [
+    "Document",
+    "Project",
+    "Module",
+    "Namespace",
+    "Enum",
+    "EnumMember",
+    "Class",
+    "Interface",
+    "TypeAlias",
+    "Constructor",
+    "Property",
+    "Variable",
+    "Function",
+    "Accessor",
+    "Method",
+    "Parameter",
+    "TypeParameter",
+    "TypeLiteral",
+    "CallSignature",
+    "ConstructorSignature",
+    "IndexSignature",
+    "GetSignature",
+    "SetSignature"
+  ],
+  "hideGenerator": true,
+  "hideBreadcrumbs": false,
+  "outputFileStrategy": "modules",
+  "fileExtension": ".mdx",
+  "entryFileName": "index.mdx",
+  "membersWithOwnFile": [
+    "Class",
+    "Interface",
+    "TypeAlias"
+  ],
+  "flattenOutputFiles": false,
+  "publicPath": "/docs/",
+  "githubPages": false,
+  "gitRevision": "main",
+  "sourceLinkTemplate": "https://github.com/knocklabs/javascript/blob/{gitRevision}/{path}#L{line}",
+  "frontmatterGlobals": {
+    "layout": "docs",
+    "sidebar_position": 1
+  },
+  "textContentMappings": {
+    "header.title": "{projectName} v{projectVersion}",
+    "header.docs": "Documentation"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,6 +3422,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gerrit0/mini-shiki@npm:^3.12.0":
+  version: 3.13.0
+  resolution: "@gerrit0/mini-shiki@npm:3.13.0"
+  dependencies:
+    "@shikijs/engine-oniguruma": "npm:^3.13.0"
+    "@shikijs/langs": "npm:^3.13.0"
+    "@shikijs/themes": "npm:^3.13.0"
+    "@shikijs/types": "npm:^3.13.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/bc45e9f80c3583b32ede3aee870cdc37ce658618f7d1609416ac110ec0e764ff4114fa3690ced02d901980d8335b2b39d0b202c6f81ee863e09de28ce4caa323
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -4060,7 +4073,12 @@ __metadata:
     "@manypkg/cli": "npm:^0.25.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
     prettier: "npm:^3.5.3"
+    rimraf: "npm:^6.0.1"
     turbo: "npm:^2.5.4"
+    typedoc: "npm:^0.28.13"
+    typedoc-plugin-frontmatter: "npm:^1.3.0"
+    typedoc-plugin-markdown: "npm:^4.9.0"
+    typescript: "npm:^5.9.2"
     vitest: "npm:^3.1.1"
   languageName: unknown
   linkType: soft
@@ -6193,6 +6211,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/engine-oniguruma@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "@shikijs/engine-oniguruma@npm:3.13.0"
+  dependencies:
+    "@shikijs/types": "npm:3.13.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/0cd0307028acf0a30fff7de642b84d4600aa33086f88952f1313f9ef56b604e067ebeb2e64f4e9025c06c68dfd6434c2c5da83d385af4792b622e6ad07f7613f
+  languageName: node
+  linkType: hard
+
+"@shikijs/langs@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "@shikijs/langs@npm:3.13.0"
+  dependencies:
+    "@shikijs/types": "npm:3.13.0"
+  checksum: 10c0/3fe59b55b5d1da9784cd93dc2eaae19249c5d218b39ce52c0c802b38894cdedcc55ccf813486a9362be0c97bbc0568a4f7bb2a62bf2ee0edbb2d52852878c8ed
+  languageName: node
+  linkType: hard
+
+"@shikijs/themes@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "@shikijs/themes@npm:3.13.0"
+  dependencies:
+    "@shikijs/types": "npm:3.13.0"
+  checksum: 10c0/b00052267de6f8acf09d01994823234ef4f75285d4c6587f039f5081490462a50ef73defb916add45fec1f469cf0c15ed53e5ada8ca9a48ebc7a243e4a76bbc6
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:3.13.0, @shikijs/types@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "@shikijs/types@npm:3.13.0"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/5f0ceca1dad4f4dfb8c424f1aa78953ace7eb2215d82b863500f1ea023faf55acaa54373f3b59a8ada85f15c304cf658b95eae128c43505855d13607d979a726
+  languageName: node
+  linkType: hard
+
+"@shikijs/vscode-textmate@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "@shikijs/vscode-textmate@npm:10.0.2"
+  checksum: 10c0/36b682d691088ec244de292dc8f91b808f95c89466af421cf84cbab92230f03c8348649c14b3251991b10ce632b0c715e416e992dd5f28ff3221dc2693fd9462
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -7024,6 +7087,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hast@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/hast@npm:3.0.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/3249781a511b38f1d330fd1e3344eed3c4e7ea8eff82e835d35da78e637480d36fad37a78be5a7aed8465d237ad0446abc1150859d0fde395354ea634decf9f7
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
@@ -7206,6 +7278,13 @@ __metadata:
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*":
+  version: 3.0.3
+  resolution: "@types/unist@npm:3.0.3"
+  checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
   languageName: node
   linkType: hard
 
@@ -10633,7 +10712,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.5.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -14465,6 +14544,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "linkify-it@npm:5.0.0"
+  dependencies:
+    uc.micro: "npm:^2.0.0"
+  checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
+  languageName: node
+  linkType: hard
+
 "local-pkg@npm:^1.0.0":
   version: 1.1.1
   resolution: "local-pkg@npm:1.1.1"
@@ -14662,6 +14750,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 10c0/77d7dbb4fbd602aac161e2b50887d8eda28c0fa3b799159cee380fbb311f1e614219126ecbbd2c3a9c685f1720a8109b3c1ca85cc893c39b6c9cc6a62a1d8a8b
+  languageName: node
+  linkType: hard
+
 "lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -14738,6 +14833,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "markdown-it@npm:14.1.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+    entities: "npm:^4.4.0"
+    linkify-it: "npm:^5.0.0"
+    mdurl: "npm:^2.0.0"
+    punycode.js: "npm:^2.3.1"
+    uc.micro: "npm:^2.1.0"
+  bin:
+    markdown-it: bin/markdown-it.mjs
+  checksum: 10c0/9a6bb444181d2db7016a4173ae56a95a62c84d4cbfb6916a399b11d3e6581bf1cc2e4e1d07a2f022ae72c25f56db90fbe1e529fca16fbf9541659dc53480d4b4
+  languageName: node
+  linkType: hard
+
 "marky@npm:^1.2.2":
   version: 1.3.0
   resolution: "marky@npm:1.3.0"
@@ -14756,6 +14867,13 @@ __metadata:
   version: 2.0.14
   resolution: "mdn-data@npm:2.0.14"
   checksum: 10c0/67241f8708c1e665a061d2b042d2d243366e93e5bf1f917693007f6d55111588b952dcbfd3ea9c2d0969fb754aad81b30fdcfdcc24546495fc3b24336b28d4bd
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdurl@npm:2.0.0"
+  checksum: 10c0/633db522272f75ce4788440669137c77540d74a83e9015666a9557a152c02e245b192edc20bc90ae953bbab727503994a53b236b4d9c99bdaee594d0e7dd2ce0
   languageName: node
   linkType: hard
 
@@ -15086,7 +15204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -16412,6 +16530,13 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+  languageName: node
+  linkType: hard
+
+"punycode.js@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "punycode.js@npm:2.3.1"
+  checksum: 10c0/1d12c1c0e06127fa5db56bd7fdf698daf9a78104456a6b67326877afc21feaa821257b171539caedd2f0524027fa38e67b13dd094159c8d70b6d26d2bea4dfdb
   languageName: node
   linkType: hard
 
@@ -19117,6 +19242,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typedoc-plugin-frontmatter@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "typedoc-plugin-frontmatter@npm:1.3.0"
+  dependencies:
+    yaml: "npm:^2.7.0"
+  peerDependencies:
+    typedoc-plugin-markdown: ">=4.5.0"
+  checksum: 10c0/967ee5c38ab64b94489b9001744bbecc1cb6951bb07232caf2f4925f6a4dc0ac53305c4305e34ba10d6fddaab8f939642a2fbf10f1da884d6d6885d370c94cf3
+  languageName: node
+  linkType: hard
+
+"typedoc-plugin-markdown@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "typedoc-plugin-markdown@npm:4.9.0"
+  peerDependencies:
+    typedoc: 0.28.x
+  checksum: 10c0/12040bbff7bc7e4f777d06710e39421f8ebaaf706f4b8075536453f35bc86726c5ce743de0cc9c39ee1bdfc8611b2878a4cf4c83a493e0678fc640dd71fe97fc
+  languageName: node
+  linkType: hard
+
+"typedoc@npm:^0.28.13":
+  version: 0.28.13
+  resolution: "typedoc@npm:0.28.13"
+  dependencies:
+    "@gerrit0/mini-shiki": "npm:^3.12.0"
+    lunr: "npm:^2.3.9"
+    markdown-it: "npm:^14.1.0"
+    minimatch: "npm:^9.0.5"
+    yaml: "npm:^2.8.1"
+  peerDependencies:
+    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
+  bin:
+    typedoc: bin/typedoc
+  checksum: 10c0/f4815cb21a62fadbfeb6f5ad6405d3c819b6bcb20bd1e125c5b1a1a7c7bfabbd9dd67d742f767ce95283e99814a361b86bcc632e9ffa595e51e057778def4d57
+  languageName: node
+  linkType: hard
+
 "typescript-eslint@npm:^8.43.0":
   version: 8.43.0
   resolution: "typescript-eslint@npm:8.43.0"
@@ -19152,6 +19314,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.9.2":
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>":
   version: 5.8.2
   resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=d69c25"
@@ -19172,6 +19344,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>":
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=d69c25"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/66fc07779427a7c3fa97da0cf2e62595eaff2cea4594d45497d294bfa7cb514d164f0b6ce7a5121652cf44c0822af74e29ee579c771c405e002d1f23cf06bfde
+  languageName: node
+  linkType: hard
+
 "ua-parser-js@npm:^0.7.33":
   version: 0.7.40
   resolution: "ua-parser-js@npm:0.7.40"
@@ -19187,6 +19369,13 @@ __metadata:
   bin:
     ua-parser-js: script/cli.js
   checksum: 10c0/2b6ac642c74323957dae142c31f72287f2420c12dced9603d989b96c132b80232779c429b296d7de4012ef8b64e0d8fadc53c639ef06633ce13d785a78b5be6c
+  languageName: node
+  linkType: hard
+
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 10c0/8862eddb412dda76f15db8ad1c640ccc2f47cdf8252a4a30be908d535602c8d33f9855dfcccb8b8837855c1ce1eaa563f7fa7ebe3c98fd0794351aab9b9c55fa
   languageName: node
   linkType: hard
 
@@ -20245,6 +20434,15 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.7.0, yaml@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "yaml@npm:2.8.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
This PR sets up TypeDoc in the repository to generate API documentation for the `react-core` package.

**Why these changes were made:**
- To provide comprehensive, automatically generated API documentation.
- To output documentation in MDX format, making it easily integratable with modern documentation sites (e.g., Docusaurus, Next.js).
- To centralize generated documentation in a top-level `_typedocs` directory.
- To create an easy-to-run script for developers to generate and update documentation.

**How these changes were made:**
- Installed `typedoc` and relevant plugins (`typedoc-plugin-markdown`, `typedoc-plugin-frontmatter`).
- Configured `typedoc.json` to target the `react-core` package, output MDX files to `_typedocs/`, and include frontmatter for static site compatibility.
- Added `docs:generate`, `docs:clean`, and `docs:build` npm scripts to `package.json`.
- Created a `generate-docs.sh` convenience script for a user-friendly documentation generation process.
- Enhanced JSDoc comments for the `useGuide` and `useGuides` hooks in `react-core` to demonstrate rich documentation output.
- Included a `TYPEDOC_SETUP.md` file summarizing the setup and a `_typedocs/README.md` for the generated output.

### Todos
- [ ] None

### Checklist
- [ ] Tests have been added for new features or major refactors to existing features.

### Screenshots or videos
N/A

---
[Slack Thread](https://knocklabs.slack.com/archives/D09430GH3TK/p1758840400132279?thread_ts=1758840400.132279&cid=D09430GH3TK)

<a href="https://cursor.com/background-agent?bcId=bc-40ddb20c-e7dd-4c35-a04a-75ae00cee712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40ddb20c-e7dd-4c35-a04a-75ae00cee712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

