### PR TITLE
chore: use new guide engagement update endpoints w/o message_id param

### DIFF
--- a/.changeset/neat-rooms-leave.md
+++ b/.changeset/neat-rooms-leave.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+chore: use the new guide engagement update endpoints w/o message_id param

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -978,7 +978,6 @@ export class KnockGuideClient {
     step: GuideStepData,
   ) {
     return {
-      message_id: step.message.id,
       channel_id: guide.channel_id,
       guide_key: guide.key,
       guide_id: guide.id,

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -8,7 +8,6 @@ import { GenericData } from "@knocklabs/types";
 export type Any = any;
 
 export interface StepMessageState {
-  id: string;
   seen_at: string | null;
   read_at: string | null;
   interacted_at: string | null;
@@ -83,7 +82,6 @@ export type GetGuidesResponse = {
 
 export type GuideEngagementEventBaseParams = {
   // Base params required for all engagement update events
-  message_id: string;
   channel_id: string;
   guide_key: string;
   guide_id: string;

--- a/packages/client/src/clients/users/index.ts
+++ b/packages/client/src/clients/users/index.ts
@@ -130,7 +130,7 @@ class UserClient {
   ) {
     const result = await this.instance.client().makeRequest({
       method: "PUT",
-      url: `${guidesApiRootPath(this.instance.userId)}/messages/${params.message_id}/${status}`,
+      url: `${guidesApiRootPath(this.instance.userId)}/messages/${status}`,
       data: params,
     });
 

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -580,7 +580,6 @@ describe("KnockGuideClient", () => {
       await client.markAsSeen(mockGuide, mockStep);
 
       expect(mockKnock.user.markGuideStepAs).toHaveBeenCalledWith("seen", {
-        message_id: "msg_123",
         channel_id: channelId,
         guide_key: "test_guide",
         guide_id: "guide_123",
@@ -613,7 +612,6 @@ describe("KnockGuideClient", () => {
       expect(mockKnock.user.markGuideStepAs).toHaveBeenCalledWith(
         "interacted",
         {
-          message_id: "msg_123",
           channel_id: channelId,
           guide_key: "test_guide",
           guide_id: "guide_123",
@@ -643,7 +641,6 @@ describe("KnockGuideClient", () => {
       await client.markAsArchived(mockGuide, mockStep);
 
       expect(mockKnock.user.markGuideStepAs).toHaveBeenCalledWith("archived", {
-        message_id: "msg_123",
         channel_id: channelId,
         guide_key: "test_guide",
         guide_id: "guide_123",
@@ -699,7 +696,6 @@ describe("KnockGuideClient", () => {
       await client.markAsArchived(unthrottledGuide, freshMockStep);
 
       expect(mockKnock.user.markGuideStepAs).toHaveBeenCalledWith("archived", {
-        message_id: "msg_123",
         channel_id: channelId,
         guide_key: "test_guide",
         guide_id: "guide_123",
@@ -2632,7 +2628,6 @@ describe("KnockGuideClient", () => {
       );
 
       expect(result).toEqual({
-        message_id: "msg_123",
         channel_id: channelId,
         guide_key: "test_guide",
         guide_id: "guide_123",

--- a/packages/client/test/clients/users/users.test.ts
+++ b/packages/client/test/clients/users/users.test.ts
@@ -733,7 +733,6 @@ describe("User Client", () => {
 
         const client = new UserClient(knock);
         const params = {
-          message_id: "message_123",
           channel_id: "channel_123",
           guide_key: "welcome_guide",
           guide_id: "guide_123",
@@ -743,7 +742,7 @@ describe("User Client", () => {
 
         expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
           method: "PUT",
-          url: "/v1/users/user_123/guides/messages/message_123/seen",
+          url: "/v1/users/user_123/guides/messages/seen",
           data: params,
         });
         expect(result).toEqual(mockResponse);
@@ -766,7 +765,6 @@ describe("User Client", () => {
 
         const client = new UserClient(knock);
         const params = {
-          message_id: "message_456",
           channel_id: "channel_456",
           guide_key: "tutorial_guide",
           guide_id: "guide_456",
@@ -777,7 +775,7 @@ describe("User Client", () => {
 
         expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
           method: "PUT",
-          url: "/v1/users/user_123/guides/messages/message_456/interacted",
+          url: "/v1/users/user_123/guides/messages/interacted",
           data: params,
         });
         expect(result).toEqual(mockResponse);
@@ -800,7 +798,6 @@ describe("User Client", () => {
 
         const client = new UserClient(knock);
         const params = {
-          message_id: "message_789",
           channel_id: "channel_789",
           guide_key: "advanced_guide",
           guide_id: "guide_789",
@@ -810,7 +807,7 @@ describe("User Client", () => {
 
         expect(mockApiClient.makeRequest).toHaveBeenCalledWith({
           method: "PUT",
-          url: "/v1/users/user_123/guides/messages/message_789/archived",
+          url: "/v1/users/user_123/guides/messages/archived",
           data: params,
         });
         expect(result).toEqual(mockResponse);
@@ -846,7 +843,6 @@ describe("User Client", () => {
 
           await expect(
             client.markGuideStepAs(scenario.status, {
-              message_id: "test_message",
               channel_id: "test_channel",
               guide_key: "test_guide",
               guide_id: "test_guide_id",
@@ -925,7 +921,6 @@ describe("User Client", () => {
 
       await expect(
         knock.user.markGuideStepAs("seen", {
-          message_id: "guide_123",
           guide_key: "onboarding_guide",
           guide_id: "guide_456",
           guide_step_ref: "step_1",


### PR DESCRIPTION
### Description
As part of the partitioned messages work, we changed when we generated ksuid's for guide messages and now we no longer use the `message_id` path param in the engagement status update endpoints for guide messages. 

In [this PR](https://github.com/knocklabs/switchboard/pull/4666/files#diff-201fabf4973d057813897e18733aa4d4a4827b88326792b0be9dcdaa7eba5f39R220-R222) we've added the new endpoints without a message_id param. 

Now this PR updates the guide client to use the new endpoints, and remove references to `message_id`. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch guide engagement update calls to new endpoints that omit message_id, removing message_id from request params/types and updating tests accordingly.
> 
> - **Guides client**:
>   - Update `buildEngagementEventBaseParams` to omit `message_id`.
> - **Users client API**:
>   - Change `markGuideStepAs` URL to `.../guides/messages/{status}` (remove `message_id` path segment).
> - **Types**:
>   - Remove `message_id` from `GuideEngagementEventBaseParams`.
>   - Remove `id` from `StepMessageState`.
> - **Tests**:
>   - Adjust guide and user client tests to stop passing `message_id` and expect new URLs.
> - **Changeset**:
>   - Patch release for `@knocklabs/client` describing endpoint change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a71e62edc5c1c0e9f7cfadf34177e8692a68767f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->