### PR TITLE
fix: allow an undefined user id to be passed

### DIFF
--- a/.changeset/swift-papayas-design.md
+++ b/.changeset/swift-papayas-design.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+fix: ensure that user.id can be undefined

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -239,7 +239,7 @@ class Knock {
       return userIdOrUserWithProperties.id;
     }
 
-    throw new Error("`user` object must contain an `id` property");
+    return undefined;
   }
 }
 

--- a/packages/client/test/knock.test.ts
+++ b/packages/client/test/knock.test.ts
@@ -185,14 +185,6 @@ describe("Knock Client", () => {
 
       expect(identify).toHaveBeenCalledWith({ name: "John Doe" });
     });
-
-    test("throws error when user object does not contain an `id` property", () => {
-      const knock = new Knock("pk_test_12345");
-      // @ts-expect-error - we want to test the error case
-      expect(() => knock.authenticate({ name: "John Doe" })).toThrowError(
-        "`user` object must contain an `id` property",
-      );
-    });
   });
 
   describe("Inline identification strategy", () => {

--- a/packages/client/test/knock.test.ts
+++ b/packages/client/test/knock.test.ts
@@ -185,6 +185,16 @@ describe("Knock Client", () => {
 
       expect(identify).toHaveBeenCalledWith({ name: "John Doe" });
     });
+
+    test("does not identify user when user object does not contain an `id` property", () => {
+      const knock = new Knock("pk_test_12345");
+      const identify = vi.spyOn(knock.user, "identify");
+
+      // @ts-expect-error - we want to test the error case
+      knock.authenticate({ name: "John Doe" });
+
+      expect(identify).not.toHaveBeenCalled();
+    });
   });
 
   describe("Inline identification strategy", () => {


### PR DESCRIPTION
### Description

Stop throwing if there's an undefined user ID

KNO-9977

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop throwing when `user.id` is absent; return `undefined` and avoid inline identification.
> 
> - **Client**:
>   - `getUserId` now returns `undefined` when `user.id` is missing instead of throwing.
>   - `authenticate` effectively skips inline identification when no `id` is provided in the user object.
> - **Tests**:
>   - Update test to assert no identification occurs when user object lacks `id` (no error thrown).
> - **Changeset**:
>   - Patch release for `@knocklabs/client` noting the fix for optional `user.id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7144bd6741d009fcfc4e86b3d580c27fc563fabf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->