### PR TITLE
chore: changeset to bump react package to a new minor version

### DIFF
--- a/.changeset/fifty-memes-speak.md
+++ b/.changeset/fifty-memes-speak.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": minor
+---
+
+[guides] update selectGuides and useGuides to be subject to throttling by default


### PR DESCRIPTION
### Description

Bumped `react-core` and `client` to new minor versions [here](https://github.com/knocklabs/javascript/pull/811), expecting that would cascade and bump `react` to a new minor version but it did not. 

We want to bring `react` to 0.10.0, so doing it manually here.