### PR TITLE
KnockProvider enabled prop

### DIFF
--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -176,6 +176,11 @@ class Feed {
   }
 
   async markAsSeen(itemOrItems: FeedItemOrItems) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAsSeen - user not authenticated");
+      return { entries: [] };
+    }
+
     const now = new Date().toISOString();
     this.optimisticallyPerformStatusUpdate(
       itemOrItems,
@@ -188,6 +193,11 @@ class Feed {
   }
 
   async markAllAsSeen() {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAllAsSeen - user not authenticated");
+      return { entries: [] };
+    }
+
     // To mark all of the messages as seen we:
     // 1. Optimistically update *everything* we have in the store
     // 2. We decrement the `unseen_count` to zero optimistically
@@ -230,6 +240,11 @@ class Feed {
   }
 
   async markAsUnseen(itemOrItems: FeedItemOrItems) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAsUnseen - user not authenticated");
+      return { entries: [] };
+    }
+
     this.optimisticallyPerformStatusUpdate(
       itemOrItems,
       "unseen",
@@ -241,6 +256,11 @@ class Feed {
   }
 
   async markAsRead(itemOrItems: FeedItemOrItems) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAsRead - user not authenticated");
+      return { entries: [] };
+    }
+
     const now = new Date().toISOString();
     this.optimisticallyPerformStatusUpdate(
       itemOrItems,
@@ -253,6 +273,11 @@ class Feed {
   }
 
   async markAllAsRead() {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAllAsRead - user not authenticated");
+      return { entries: [] };
+    }
+
     // To mark all of the messages as read we:
     // 1. Optimistically update *everything* we have in the store
     // 2. We decrement the `unread_count` to zero optimistically
@@ -295,6 +320,11 @@ class Feed {
   }
 
   async markAsUnread(itemOrItems: FeedItemOrItems) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAsUnread - user not authenticated");
+      return { entries: [] };
+    }
+
     this.optimisticallyPerformStatusUpdate(
       itemOrItems,
       "unread",
@@ -309,6 +339,11 @@ class Feed {
     itemOrItems: FeedItemOrItems,
     metadata?: Record<string, string>,
   ) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAsInteracted - user not authenticated");
+      return { entries: [] };
+    }
+
     const now = new Date().toISOString();
     this.optimisticallyPerformStatusUpdate(
       itemOrItems,
@@ -332,6 +367,11 @@ class Feed {
   TODO: how do we handle rollbacks?
   */
   async markAsArchived(itemOrItems: FeedItemOrItems) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAsArchived - user not authenticated");
+      return { entries: [] };
+    }
+
     const state = this.store.getState();
 
     const shouldOptimisticallyRemoveItems =
@@ -403,6 +443,11 @@ class Feed {
   }
 
   async markAllAsArchived() {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAllAsArchived - user not authenticated");
+      return { entries: [] };
+    }
+
     // Note: there is the potential for a race condition here because the bulk
     // update is an async method, so if a new message comes in during this window before
     // the update has been processed we'll effectively reset the `unseen_count` to be what it was.
@@ -430,6 +475,11 @@ class Feed {
   }
 
   async markAllReadAsArchived() {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAllReadAsArchived - user not authenticated");
+      return { entries: [] };
+    }
+
     // Note: there is the potential for a race condition here because the bulk
     // update is an async method, so if a new message comes in during this window before
     // the update has been processed we'll effectively reset the `unseen_count` to be what it was.
@@ -472,6 +522,11 @@ class Feed {
   }
 
   async markAsUnarchived(itemOrItems: FeedItemOrItems) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping markAsUnarchived - user not authenticated");
+      return { entries: [] };
+    }
+
     const state = this.store.getState();
 
     const items = Array.isArray(itemOrItems) ? itemOrItems : [itemOrItems];
@@ -518,6 +573,11 @@ class Feed {
 
   /* Fetches the feed content, appending it to the store */
   async fetch(options: FetchFeedOptions = {}) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping fetch - user not authenticated");
+      return;
+    }
+
     const { networkStatus, ...state } = this.store.getState();
 
     // If the user is not authenticated, then do nothing
@@ -608,6 +668,11 @@ class Feed {
   }
 
   async fetchNextPage(options: FetchFeedOptions = {}) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Feed] Skipping fetchNextPage - user not authenticated");
+      return;
+    }
+
     // Attempts to fetch the next page of results (if we have any)
     const { pageInfo } = this.store.getState();
 

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -340,7 +340,9 @@ class Feed {
     metadata?: Record<string, string>,
   ) {
     if (!this.knock.isAuthenticated()) {
-      this.knock.log("[Feed] Skipping markAsInteracted - user not authenticated");
+      this.knock.log(
+        "[Feed] Skipping markAsInteracted - user not authenticated",
+      );
       return { entries: [] };
     }
 
@@ -444,7 +446,9 @@ class Feed {
 
   async markAllAsArchived() {
     if (!this.knock.isAuthenticated()) {
-      this.knock.log("[Feed] Skipping markAllAsArchived - user not authenticated");
+      this.knock.log(
+        "[Feed] Skipping markAllAsArchived - user not authenticated",
+      );
       return { entries: [] };
     }
 
@@ -476,7 +480,9 @@ class Feed {
 
   async markAllReadAsArchived() {
     if (!this.knock.isAuthenticated()) {
-      this.knock.log("[Feed] Skipping markAllReadAsArchived - user not authenticated");
+      this.knock.log(
+        "[Feed] Skipping markAllReadAsArchived - user not authenticated",
+      );
       return { entries: [] };
     }
 
@@ -523,7 +529,9 @@ class Feed {
 
   async markAsUnarchived(itemOrItems: FeedItemOrItems) {
     if (!this.knock.isAuthenticated()) {
-      this.knock.log("[Feed] Skipping markAsUnarchived - user not authenticated");
+      this.knock.log(
+        "[Feed] Skipping markAsUnarchived - user not authenticated",
+      );
       return { entries: [] };
     }
 

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -350,7 +350,14 @@ export class KnockGuideClient {
 
   async fetch(opts?: { filters?: QueryFilterParams }) {
     this.knock.log("[Guide] .fetch");
-    this.knock.failIfNotAuthenticated();
+
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Guide] Skipping fetch - user not authenticated");
+      return {
+        status: "error" as const,
+        error: new Error("Not authenticated"),
+      };
+    }
 
     const queryParams = this.buildQueryParams(opts?.filters);
     const queryKey = this.formatQueryKey(queryParams);
@@ -400,7 +407,12 @@ export class KnockGuideClient {
 
   subscribe() {
     if (!this.socket) return;
-    this.knock.failIfNotAuthenticated();
+
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Guide] Skipping subscribe - user not authenticated");
+      return;
+    }
+
     this.knock.log("[Guide] Subscribing to real time updates");
 
     // Ensure a live socket connection if not yet connected.
@@ -846,6 +858,11 @@ export class KnockGuideClient {
   async markAsSeen(guide: GuideData, step: GuideStepData) {
     if (step.message.seen_at) return;
 
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log("[Guide] Skipping markAsSeen - user not authenticated");
+      return;
+    }
+
     this.knock.log(
       `[Guide] Marking as seen (Guide key: ${guide.key}, Step ref:${step.ref})`,
     );
@@ -874,6 +891,13 @@ export class KnockGuideClient {
     step: GuideStepData,
     metadata?: GenericData,
   ) {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log(
+        "[Guide] Skipping markAsInteracted - user not authenticated",
+      );
+      return;
+    }
+
     this.knock.log(
       `[Guide] Marking as interacted (Guide key: ${guide.key}; Step ref:${step.ref})`,
     );
@@ -900,6 +924,13 @@ export class KnockGuideClient {
 
   async markAsArchived(guide: GuideData, step: GuideStepData) {
     if (step.message.archived_at) return;
+
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log(
+        "[Guide] Skipping markAsArchived - user not authenticated",
+      );
+      return;
+    }
 
     this.knock.log(
       `[Guide] Marking as archived (Guide key: ${guide.key}, Step ref:${step.ref})`,

--- a/packages/client/src/clients/messages/index.ts
+++ b/packages/client/src/clients/messages/index.ts
@@ -30,6 +30,13 @@ class MessageClient {
     status: MessageEngagementStatus,
     options?: UpdateMessageStatusOptions,
   ): Promise<Message> {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log(
+        "[Messages] Skipping updateStatus - user not authenticated",
+      );
+      throw new Error("Not authenticated");
+    }
+
     // Metadata is only required for the "interacted" status
     const payload =
       status === "interacted" && options
@@ -49,6 +56,13 @@ class MessageClient {
     messageId: string,
     status: Exclude<MessageEngagementStatus, "interacted">,
   ): Promise<Message> {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log(
+        "[Messages] Skipping removeStatus - user not authenticated",
+      );
+      throw new Error("Not authenticated");
+    }
+
     const result = await this.knock.client().makeRequest({
       method: "DELETE",
       url: `/v1/messages/${messageId}/${status}`,
@@ -62,6 +76,13 @@ class MessageClient {
     status: MessageEngagementStatus | "unseen" | "unread" | "unarchived",
     options?: UpdateMessageStatusOptions,
   ): Promise<Message[]> {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log(
+        "[Messages] Skipping batchUpdateStatuses - user not authenticated",
+      );
+      return [];
+    }
+
     // Metadata is only required for the "interacted" status
     const additionalPayload =
       status === "interacted" && options ? { metadata: options.metadata } : {};
@@ -80,6 +101,13 @@ class MessageClient {
     status,
     options,
   }: BulkUpdateMessagesInChannelProperties): Promise<BulkOperation> {
+    if (!this.knock.isAuthenticated()) {
+      this.knock.log(
+        "[Messages] Skipping bulkUpdateAllStatusesInChannel - user not authenticated",
+      );
+      throw new Error("Not authenticated");
+    }
+
     const result = await this.knock.client().makeRequest({
       method: "POST",
       url: `/v1/channels/${channelId}/messages/bulk/${status}`,

--- a/packages/client/src/clients/ms-teams/index.ts
+++ b/packages/client/src/clients/ms-teams/index.ts
@@ -113,7 +113,7 @@ class MsTeamsClient {
       this.instance.log(
         "[MS Teams] Skipping revokeAccessToken - user not authenticated",
       );
-      return { status: "success" };
+      return { status: "not_connected" };
     }
 
     const result = await this.instance.client().makeRequest({

--- a/packages/client/src/clients/ms-teams/index.ts
+++ b/packages/client/src/clients/ms-teams/index.ts
@@ -18,6 +18,13 @@ class MsTeamsClient {
   }
 
   async authCheck({ tenant: tenantId, knockChannelId }: AuthCheckInput) {
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[MS Teams] Skipping authCheck - user not authenticated",
+      );
+      return { status: "not_connected" };
+    }
+
     const result = await this.instance.client().makeRequest({
       method: "GET",
       url: `/v1/providers/ms-teams/${knockChannelId}/auth_check`,
@@ -36,6 +43,13 @@ class MsTeamsClient {
   async getTeams(
     input: GetMsTeamsTeamsInput,
   ): Promise<GetMsTeamsTeamsResponse> {
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[MS Teams] Skipping getTeams - user not authenticated",
+      );
+      return { ms_teams_teams: [], skip_token: null };
+    }
+
     const { knockChannelId, tenant: tenantId } = input;
     const queryOptions = input.queryOptions || {};
 
@@ -62,6 +76,13 @@ class MsTeamsClient {
   async getChannels(
     input: GetMsTeamsChannelsInput,
   ): Promise<GetMsTeamsChannelsResponse> {
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[MS Teams] Skipping getChannels - user not authenticated",
+      );
+      return { ms_teams_channels: [] };
+    }
+
     const { knockChannelId, teamId, tenant: tenantId } = input;
     const queryOptions = input.queryOptions || {};
 
@@ -88,6 +109,13 @@ class MsTeamsClient {
     tenant: tenantId,
     knockChannelId,
   }: RevokeAccessTokenInput) {
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[MS Teams] Skipping revokeAccessToken - user not authenticated",
+      );
+      return { status: "success" };
+    }
+
     const result = await this.instance.client().makeRequest({
       method: "PUT",
       url: `/v1/providers/ms-teams/${knockChannelId}/revoke_access`,

--- a/packages/client/src/clients/slack/index.ts
+++ b/packages/client/src/clients/slack/index.ts
@@ -73,7 +73,7 @@ class SlackClient {
       this.instance.log(
         "[Slack] Skipping revokeAccessToken - user not authenticated",
       );
-      return { status: "success" };
+      return { status: "not_connected" };
     }
 
     const result = await this.instance.client().makeRequest({

--- a/packages/client/src/clients/slack/index.ts
+++ b/packages/client/src/clients/slack/index.ts
@@ -13,6 +13,11 @@ class SlackClient {
   }
 
   async authCheck({ tenant, knockChannelId }: AuthCheckInput) {
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log("[Slack] Skipping authCheck - user not authenticated");
+      return { status: "not_connected" };
+    }
+
     const result = await this.instance.client().makeRequest({
       method: "GET",
       url: `/v1/providers/slack/${knockChannelId}/auth_check`,
@@ -31,6 +36,13 @@ class SlackClient {
   async getChannels(
     input: GetSlackChannelsInput,
   ): Promise<GetSlackChannelsResponse> {
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[Slack] Skipping getChannels - user not authenticated",
+      );
+      return { slack_channels: [], next_cursor: null };
+    }
+
     const { knockChannelId, tenant } = input;
     const queryOptions = input.queryOptions || {};
 
@@ -57,6 +69,13 @@ class SlackClient {
   }
 
   async revokeAccessToken({ tenant, knockChannelId }: RevokeAccessTokenInput) {
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[Slack] Skipping revokeAccessToken - user not authenticated",
+      );
+      return { status: "success" };
+    }
+
     const result = await this.instance.client().makeRequest({
       method: "PUT",
       url: `/v1/providers/slack/${knockChannelId}/revoke_access`,

--- a/packages/client/src/clients/users/index.ts
+++ b/packages/client/src/clients/users/index.ts
@@ -89,7 +89,12 @@ class UserClient {
   }
 
   async getChannelData<T = GenericData>(params: GetChannelDataInput) {
-    this.instance.failIfNotAuthenticated();
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[User] Skipping getChannelData - user not authenticated",
+      );
+      throw new Error("Not authenticated");
+    }
 
     const result = await this.instance.client().makeRequest({
       method: "GET",
@@ -103,7 +108,12 @@ class UserClient {
     channelId,
     channelData,
   }: SetChannelDataInput) {
-    this.instance.failIfNotAuthenticated();
+    if (!this.instance.isAuthenticated()) {
+      this.instance.log(
+        "[User] Skipping setChannelData - user not authenticated",
+      );
+      throw new Error("Not authenticated");
+    }
 
     const result = await this.instance.client().makeRequest({
       method: "PUT",

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -165,6 +165,25 @@ class Knock {
     return checkUserToken ? !!(this.userId && this.userToken) : !!this.userId;
   }
 
+  /*
+    Resets the authentication state and tears down any active connections.
+    This is useful when you want to clear the current user session without destroying the Knock instance.
+  */
+  resetAuthentication() {
+    this.log("Resetting authentication state");
+    
+    // Teardown any active feeds and connections
+    this.feeds.teardownInstances();
+    this.teardown();
+    
+    // Clear authentication state
+    this.userId = undefined;
+    this.userToken = undefined;
+    
+    // Reinitialize the API client without credentials
+    this.apiClient = this.createApiClient();
+  }
+
   // Used to teardown any connected instances
   teardown() {
     if (this.tokenExpirationTimer) {

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -171,15 +171,15 @@ class Knock {
   */
   resetAuthentication() {
     this.log("Resetting authentication state");
-    
+
     // Teardown any active feeds and connections
     this.feeds.teardownInstances();
     this.teardown();
-    
+
     // Clear authentication state
     this.userId = undefined;
     this.userToken = undefined;
-    
+
     // Reinitialize the API client without credentials
     this.apiClient = this.createApiClient();
   }

--- a/packages/client/test/clients/feed/feed.test.ts
+++ b/packages/client/test/clients/feed/feed.test.ts
@@ -21,6 +21,16 @@ describe("Feed", () => {
     };
   };
 
+  const getUnauthenticatedTestSetup = () => {
+    const { knock, mockApiClient } = createMockKnock();
+    // Don't authenticate - leave knock unauthenticated
+    return {
+      knock,
+      mockApiClient,
+      cleanup: () => vi.clearAllMocks(),
+    };
+  };
+
   describe("Basic Feed Tests", () => {
     test("can create a feed client", () => {
       const { knock, cleanup } = getTestSetup();
@@ -1577,6 +1587,232 @@ describe("Feed", () => {
         const result = await feed.markAsSeen(feedItem);
 
         expect(result).toEqual([updatedItem]);
+      } finally {
+        cleanup();
+      }
+    });
+  });
+
+  describe("Authentication Guards", () => {
+    test("fetch skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+
+        const logSpy = vi.spyOn(knock, "log");
+
+        await feed.fetch();
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping fetch - user not authenticated",
+        );
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("markAsSeen skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+        const feedItem = createUnreadFeedItem();
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await feed.markAsSeen(feedItem);
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping markAsSeen - user not authenticated",
+        );
+        expect(result).toEqual({ entries: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("markAllAsSeen skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await feed.markAllAsSeen();
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping markAllAsSeen - user not authenticated",
+        );
+        expect(result).toEqual({ entries: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("markAsRead skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+        const feedItem = createUnreadFeedItem();
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await feed.markAsRead(feedItem);
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping markAsRead - user not authenticated",
+        );
+        expect(result).toEqual({ entries: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("markAllAsRead skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await feed.markAllAsRead();
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping markAllAsRead - user not authenticated",
+        );
+        expect(result).toEqual({ entries: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("markAsArchived skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+        const feedItem = createUnreadFeedItem();
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await feed.markAsArchived(feedItem);
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping markAsArchived - user not authenticated",
+        );
+        expect(result).toEqual({ entries: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("markAllAsArchived skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await feed.markAllAsArchived();
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping markAllAsArchived - user not authenticated",
+        );
+        expect(result).toEqual({ entries: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("markAsInteracted skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          undefined,
+        );
+        const feedItem = createUnreadFeedItem();
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await feed.markAsInteracted(feedItem);
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] Skipping markAsInteracted - user not authenticated",
+        );
+        expect(result).toEqual({ entries: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("listenForUpdates skips websocket connection when not authenticated", () => {
+      const { knock, cleanup } = getUnauthenticatedTestSetup();
+
+      try {
+        const mockSocketManager = {
+          join: vi.fn(),
+        } as unknown as FeedSocketManager;
+
+        const feed = new Feed(
+          knock,
+          "01234567-89ab-cdef-0123-456789abcdef",
+          {},
+          mockSocketManager,
+        );
+
+        const logSpy = vi.spyOn(knock, "log");
+
+        feed.listenForUpdates();
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Feed] User is not authenticated, skipping listening for updates",
+        );
+        expect(mockSocketManager.join).not.toHaveBeenCalled();
       } finally {
         cleanup();
       }

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -3059,4 +3059,142 @@ describe("KnockGuideClient", () => {
       );
     });
   });
+
+  describe("Authentication Guards", () => {
+    test("fetch skips API call when not authenticated", async () => {
+      const unauthKnock = {
+        ...mockKnock,
+        isAuthenticated: vi.fn(() => false),
+      };
+
+      const client = new KnockGuideClient(unauthKnock, channelId);
+      const logSpy = vi.spyOn(unauthKnock, "log");
+
+      const result = await client.fetch();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        "[Guide] Skipping fetch - user not authenticated",
+      );
+      expect(result).toEqual({
+        status: "error",
+        error: new Error("Not authenticated"),
+      });
+      expect(mockKnock.user.getGuides).not.toHaveBeenCalled();
+    });
+
+    test("subscribe skips websocket when not authenticated", () => {
+      const testSocket = {
+        channel: vi.fn(),
+        connect: vi.fn(),
+        isConnected: vi.fn(() => false),
+      };
+
+      const unauthKnock = {
+        ...mockKnock,
+        isAuthenticated: vi.fn(() => false),
+        client: () => ({ socket: testSocket }),
+      };
+
+      const logSpy = vi.spyOn(unauthKnock, "log");
+      const client = new KnockGuideClient(unauthKnock, channelId);
+
+      client.subscribe();
+
+      // Check that the skip message was logged
+      expect(logSpy).toHaveBeenCalledWith(
+        "[Guide] Skipping subscribe - user not authenticated",
+      );
+      expect(testSocket.channel).not.toHaveBeenCalled();
+    });
+
+    test("markAsSeen skips API call when not authenticated", async () => {
+      const unauthKnock = {
+        ...mockKnock,
+        isAuthenticated: vi.fn(() => false),
+      };
+
+      const mockGuide = {
+        key: "test-guide",
+        steps: [
+          {
+            ref: "step-1",
+            message: { id: "msg_1", seen_at: null },
+            content: {},
+          },
+        ],
+      };
+
+      const client = new KnockGuideClient(unauthKnock, channelId);
+      const logSpy = vi.spyOn(unauthKnock, "log");
+
+      const result = await client.markAsSeen(mockGuide, mockGuide.steps[0]);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        "[Guide] Skipping markAsSeen - user not authenticated",
+      );
+      expect(result).toBeUndefined();
+      expect(mockKnock.user.markGuideStepAs).not.toHaveBeenCalled();
+    });
+
+    test("markAsInteracted skips API call when not authenticated", async () => {
+      const unauthKnock = {
+        ...mockKnock,
+        isAuthenticated: vi.fn(() => false),
+      };
+
+      const mockGuide = {
+        key: "test-guide",
+        steps: [
+          {
+            ref: "step-1",
+            message: { id: "msg_1", interacted_at: null },
+            content: {},
+          },
+        ],
+      };
+
+      const client = new KnockGuideClient(unauthKnock, channelId);
+      const logSpy = vi.spyOn(unauthKnock, "log");
+
+      const result = await client.markAsInteracted(
+        mockGuide,
+        mockGuide.steps[0],
+      );
+
+      expect(logSpy).toHaveBeenCalledWith(
+        "[Guide] Skipping markAsInteracted - user not authenticated",
+      );
+      expect(result).toBeUndefined();
+      expect(mockKnock.user.markGuideStepAs).not.toHaveBeenCalled();
+    });
+
+    test("markAsArchived skips API call when not authenticated", async () => {
+      const unauthKnock = {
+        ...mockKnock,
+        isAuthenticated: vi.fn(() => false),
+      };
+
+      const mockGuide = {
+        key: "test-guide",
+        steps: [
+          {
+            ref: "step-1",
+            message: { id: "msg_1", archived_at: null },
+            content: {},
+          },
+        ],
+      };
+
+      const client = new KnockGuideClient(unauthKnock, channelId);
+      const logSpy = vi.spyOn(unauthKnock, "log");
+
+      const result = await client.markAsArchived(mockGuide, mockGuide.steps[0]);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        "[Guide] Skipping markAsArchived - user not authenticated",
+      );
+      expect(result).toBeUndefined();
+      expect(mockKnock.user.markGuideStepAs).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -271,7 +271,7 @@ describe("KnockGuideClient", () => {
 
       await client.fetch();
 
-      expect(mockKnock.failIfNotAuthenticated).toHaveBeenCalled();
+      expect(mockKnock.isAuthenticated).toHaveBeenCalled();
       expect(mockKnock.user.getGuides).toHaveBeenCalledWith(
         channelId,
         expect.objectContaining({
@@ -288,7 +288,7 @@ describe("KnockGuideClient", () => {
       const client = new KnockGuideClient(mockKnock, channelId);
       await client.fetch();
 
-      expect(mockKnock.failIfNotAuthenticated).toHaveBeenCalled();
+      expect(mockKnock.isAuthenticated).toHaveBeenCalled();
       expect(mockStore.setState).toHaveBeenCalledWith(expect.any(Function));
 
       // Get the last setState call and execute its function
@@ -343,7 +343,7 @@ describe("KnockGuideClient", () => {
       );
       client.subscribe();
 
-      expect(mockKnock.failIfNotAuthenticated).toHaveBeenCalled();
+      expect(mockKnock.isAuthenticated).toHaveBeenCalled();
       expect(mockSocket.channel).toHaveBeenCalledWith(
         `guides:${channelId}`,
         expect.objectContaining({
@@ -3050,7 +3050,7 @@ describe("KnockGuideClient", () => {
 
       await client.fetch({ filters: { type: "tooltip" } });
 
-      expect(mockKnock.failIfNotAuthenticated).toHaveBeenCalled();
+      expect(mockKnock.isAuthenticated).toHaveBeenCalled();
       expect(mockKnock.user.getGuides).toHaveBeenCalledWith(
         channelId,
         expect.objectContaining({

--- a/packages/client/test/clients/messages/messages.test.ts
+++ b/packages/client/test/clients/messages/messages.test.ts
@@ -747,4 +747,98 @@ describe("MessageClient", () => {
       );
     });
   });
+
+  describe("Authentication Guards", () => {
+    const getUnauthenticatedSetup = () => {
+      const { knock, mockApiClient } = createMockKnock();
+      // Don't authenticate
+      return { knock, mockApiClient, cleanup: () => vi.clearAllMocks() };
+    };
+
+    test("updateStatus skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MessageClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        await expect(client.updateStatus("msg_123", "read")).rejects.toThrow(
+          "Not authenticated",
+        );
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Messages] Skipping updateStatus - user not authenticated",
+        );
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("removeStatus skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MessageClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        await expect(client.removeStatus("msg_123", "seen")).rejects.toThrow(
+          "Not authenticated",
+        );
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Messages] Skipping removeStatus - user not authenticated",
+        );
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("batchUpdateStatuses skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MessageClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.batchUpdateStatuses(
+          ["msg_1", "msg_2"],
+          "read",
+        );
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Messages] Skipping batchUpdateStatuses - user not authenticated",
+        );
+        expect(result).toEqual([]);
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("bulkUpdateAllStatusesInChannel skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MessageClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        await expect(
+          client.bulkUpdateAllStatusesInChannel({
+            channelId: "channel_123",
+            status: "read",
+            options: {},
+          }),
+        ).rejects.toThrow("Not authenticated");
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Messages] Skipping bulkUpdateAllStatusesInChannel - user not authenticated",
+        );
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+  });
 });

--- a/packages/client/test/clients/ms-teams/ms-teams.test.ts
+++ b/packages/client/test/clients/ms-teams/ms-teams.test.ts
@@ -720,7 +720,7 @@ describe("Microsoft Teams Client", () => {
         expect(logSpy).toHaveBeenCalledWith(
           "[MS Teams] Skipping revokeAccessToken - user not authenticated",
         );
-        expect(result).toEqual({ status: "success" });
+        expect(result).toEqual({ status: "not_connected" });
         expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
       } finally {
         cleanup();

--- a/packages/client/test/clients/ms-teams/ms-teams.test.ts
+++ b/packages/client/test/clients/ms-teams/ms-teams.test.ts
@@ -630,4 +630,101 @@ describe("Microsoft Teams Client", () => {
       }
     });
   });
+
+  describe("Authentication Guards", () => {
+    const getUnauthenticatedSetup = () => {
+      const { knock, mockApiClient } = createMockKnock();
+      // Don't authenticate
+      return { knock, mockApiClient, cleanup: () => vi.clearAllMocks() };
+    };
+
+    test("authCheck skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MsTeamsClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.authCheck({
+          tenant: "tenant_123",
+          knockChannelId: "channel_123",
+        });
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[MS Teams] Skipping authCheck - user not authenticated",
+        );
+        expect(result).toEqual({ status: "not_connected" });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("getTeams skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MsTeamsClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.getTeams({
+          tenant: "tenant_123",
+          knockChannelId: "channel_123",
+        });
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[MS Teams] Skipping getTeams - user not authenticated",
+        );
+        expect(result).toEqual({ ms_teams_teams: [], skip_token: null });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("getChannels skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MsTeamsClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.getChannels({
+          tenant: "tenant_123",
+          knockChannelId: "channel_123",
+          teamId: "team_123",
+        });
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[MS Teams] Skipping getChannels - user not authenticated",
+        );
+        expect(result).toEqual({ ms_teams_channels: [] });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("revokeAccessToken skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new MsTeamsClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.revokeAccessToken({
+          tenant: "tenant_123",
+          knockChannelId: "channel_123",
+        });
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[MS Teams] Skipping revokeAccessToken - user not authenticated",
+        );
+        expect(result).toEqual({ status: "success" });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+  });
 });

--- a/packages/client/test/clients/slack/slack.test.ts
+++ b/packages/client/test/clients/slack/slack.test.ts
@@ -510,4 +510,78 @@ describe("Slack Client", () => {
       }
     });
   });
+
+  describe("Authentication Guards", () => {
+    const getUnauthenticatedSetup = () => {
+      const { knock, mockApiClient } = createMockKnock();
+      // Don't authenticate
+      return { knock, mockApiClient, cleanup: () => vi.clearAllMocks() };
+    };
+
+    test("authCheck skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new SlackClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.authCheck({
+          tenant: "tenant_123",
+          knockChannelId: "channel_123",
+        });
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Slack] Skipping authCheck - user not authenticated",
+        );
+        expect(result).toEqual({ status: "not_connected" });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("getChannels skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new SlackClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.getChannels({
+          tenant: "tenant_123",
+          knockChannelId: "channel_123",
+        });
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Slack] Skipping getChannels - user not authenticated",
+        );
+        expect(result).toEqual({ slack_channels: [], next_cursor: null });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("revokeAccessToken skips API call when not authenticated", async () => {
+      const { knock, mockApiClient, cleanup } = getUnauthenticatedSetup();
+
+      try {
+        const client = new SlackClient(knock);
+        const logSpy = vi.spyOn(knock, "log");
+
+        const result = await client.revokeAccessToken({
+          tenant: "tenant_123",
+          knockChannelId: "channel_123",
+        });
+
+        expect(logSpy).toHaveBeenCalledWith(
+          "[Slack] Skipping revokeAccessToken - user not authenticated",
+        );
+        expect(result).toEqual({ status: "success" });
+        expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
+      } finally {
+        cleanup();
+      }
+    });
+  });
 });

--- a/packages/client/test/clients/slack/slack.test.ts
+++ b/packages/client/test/clients/slack/slack.test.ts
@@ -577,7 +577,7 @@ describe("Slack Client", () => {
         expect(logSpy).toHaveBeenCalledWith(
           "[Slack] Skipping revokeAccessToken - user not authenticated",
         );
-        expect(result).toEqual({ status: "success" });
+        expect(result).toEqual({ status: "not_connected" });
         expect(mockApiClient.makeRequest).not.toHaveBeenCalled();
       } finally {
         cleanup();

--- a/packages/client/test/clients/users/users.test.ts
+++ b/packages/client/test/clients/users/users.test.ts
@@ -612,15 +612,11 @@ describe("User Client", () => {
 
         await expect(
           client.getChannelData({ channelId: "test" }),
-        ).rejects.toThrow(
-          "Not authenticated. Please call `authenticate` first.",
-        );
+        ).rejects.toThrow("Not authenticated");
 
         await expect(
           client.setChannelData({ channelId: "test", channelData: {} }),
-        ).rejects.toThrow(
-          "Not authenticated. Please call `authenticate` first.",
-        );
+        ).rejects.toThrow("Not authenticated");
       });
 
       test("handles channel data operation errors", async () => {

--- a/packages/client/test/knock.test.ts
+++ b/packages/client/test/knock.test.ts
@@ -772,4 +772,58 @@ describe("Knock Client", () => {
       expect(knock.isAuthenticated(true)).toBe(true);
     });
   });
+
+  describe("resetAuthentication", () => {
+    test("clears userId and userToken", () => {
+      const knock = new Knock("pk_test_12345");
+
+      knock.authenticate("user_123", "token_456");
+      expect(knock.isAuthenticated()).toBe(true);
+      expect(knock.userId).toBe("user_123");
+      expect(knock.userToken).toBe("token_456");
+
+      knock.resetAuthentication();
+
+      expect(knock.isAuthenticated()).toBe(false);
+      expect(knock.userId).toBeUndefined();
+      expect(knock.userToken).toBeUndefined();
+    });
+
+    test("tears down feed instances", () => {
+      const knock = new Knock("pk_test_12345");
+      knock.authenticate("user_123", "token_456");
+
+      const teardownSpy = vi.spyOn(knock.feeds, "teardownInstances");
+
+      knock.resetAuthentication();
+
+      expect(teardownSpy).toHaveBeenCalled();
+    });
+
+    test("calls teardown to clean up connections", () => {
+      const knock = new Knock("pk_test_12345");
+      knock.authenticate("user_123", "token_456");
+
+      const teardownSpy = vi.spyOn(knock, "teardown");
+
+      knock.resetAuthentication();
+
+      expect(teardownSpy).toHaveBeenCalled();
+    });
+
+    test("can re-authenticate after reset", () => {
+      const knock = new Knock("pk_test_12345");
+
+      knock.authenticate("user_123", "token_456");
+      expect(knock.userId).toBe("user_123");
+
+      knock.resetAuthentication();
+      expect(knock.isAuthenticated()).toBe(false);
+
+      knock.authenticate("user_456", "token_789");
+      expect(knock.isAuthenticated()).toBe(true);
+      expect(knock.userId).toBe("user_456");
+      expect(knock.userToken).toBe("token_789");
+    });
+  });
 });

--- a/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
+++ b/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
@@ -208,6 +208,13 @@ const InternalKnockExpoPushNotificationProvider: React.FC<
         return;
       }
 
+      if (!knockClient.isAuthenticated()) {
+        knockClient.log(
+          "[Knock] Skipping status update - user not authenticated",
+        );
+        return;
+      }
+
       return knockClient.messages.updateStatus(messageId, status);
     },
     [knockClient],
@@ -219,7 +226,7 @@ const InternalKnockExpoPushNotificationProvider: React.FC<
         customNotificationHandler ?? defaultNotificationHandler,
     });
 
-    if (autoRegister) {
+    if (autoRegister && knockClient.isAuthenticated()) {
       registerForPushNotifications()
         .then((token) => {
           if (token) {
@@ -241,6 +248,10 @@ const InternalKnockExpoPushNotificationProvider: React.FC<
             _error,
           );
         });
+    } else if (autoRegister && !knockClient.isAuthenticated()) {
+      knockClient.log(
+        "[Knock] Skipping auto-register - user not authenticated",
+      );
     }
 
     const notificationReceivedSubscription =

--- a/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
+++ b/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
@@ -288,6 +288,7 @@ const InternalKnockExpoPushNotificationProvider: React.FC<
     autoRegister,
     knockExpoChannelId,
     knockClient,
+    knockClient.userId, // Track userId to detect authentication state changes
   ]);
 
   return (

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -111,7 +111,8 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
       if (enabled && userIdOrUserWithProperties) {
         knock.authenticate(userIdOrUserWithProperties, userToken, {
           onUserTokenExpiring: authenticateOptions.onUserTokenExpiring,
-          timeBeforeExpirationInMs: authenticateOptions.timeBeforeExpirationInMs,
+          timeBeforeExpirationInMs:
+            authenticateOptions.timeBeforeExpirationInMs,
           identificationStrategy: authenticateOptions.identificationStrategy,
         });
       }
@@ -157,7 +158,8 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
       ) {
         knockClient.authenticate(userIdOrUserWithProperties, userToken, {
           onUserTokenExpiring: authenticateOptions.onUserTokenExpiring,
-          timeBeforeExpirationInMs: authenticateOptions.timeBeforeExpirationInMs,
+          timeBeforeExpirationInMs:
+            authenticateOptions.timeBeforeExpirationInMs,
           identificationStrategy: authenticateOptions.identificationStrategy,
         });
       }

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -133,8 +133,7 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
       // Note: authenticate() handles re-auth internally if userId/userToken changed
       knockClient.authenticate(userIdOrUserWithProperties, userToken, {
         onUserTokenExpiring: authenticateOptions.onUserTokenExpiring,
-        timeBeforeExpirationInMs:
-          authenticateOptions.timeBeforeExpirationInMs,
+        timeBeforeExpirationInMs: authenticateOptions.timeBeforeExpirationInMs,
         identificationStrategy: authenticateOptions.identificationStrategy,
       });
       setForceUpdate((n) => n + 1);

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -26,6 +26,13 @@ export type KnockProviderProps = {
   i18n?: I18nContent;
   logLevel?: LogLevel;
   branch?: string;
+  /**
+   * Controls whether the KnockProvider should authenticate and initialize the Knock client.
+   * When set to false, the provider will skip authentication and just render children.
+   * This is useful for preventing auth errors when user credentials are not yet available.
+   * @default true
+   */
+  enabled?: boolean;
 } & (
   | {
       /**
@@ -55,7 +62,11 @@ export type KnockProviderProps = {
     }
 );
 
-export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
+const AuthenticatedKnockProvider: React.FC<
+  PropsWithChildren<
+    Omit<KnockProviderProps, "enabled"> & { enabled: true | undefined }
+  >
+> = ({
   apiKey,
   host,
   logLevel,
@@ -101,6 +112,23 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
     <KnockContext.Provider value={{ knock }}>
       <KnockI18nProvider i18n={i18n}>{children}</KnockI18nProvider>
     </KnockContext.Provider>
+  );
+};
+
+export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
+  enabled = true,
+  children,
+  ...props
+}) => {
+  // When disabled, skip authentication and just render children
+  if (!enabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <AuthenticatedKnockProvider enabled={enabled} {...props}>
+      {children}
+    </AuthenticatedKnockProvider>
   );
 };
 

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -118,15 +118,16 @@ const AuthenticatedKnockProvider: React.FC<
 export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
   enabled = true,
   children,
+  i18n,
   ...props
 }) => {
-  // When disabled, skip authentication and just render children
+  // When disabled, skip authentication but still provide i18n context
   if (!enabled) {
-    return <>{children}</>;
+    return <KnockI18nProvider i18n={i18n}>{children}</KnockI18nProvider>;
   }
 
   return (
-    <AuthenticatedKnockProvider enabled={enabled} {...props}>
+    <AuthenticatedKnockProvider enabled={enabled} i18n={i18n} {...props}>
       {children}
     </AuthenticatedKnockProvider>
   );

--- a/packages/react-core/src/modules/core/context/KnockProvider.tsx
+++ b/packages/react-core/src/modules/core/context/KnockProvider.tsx
@@ -97,34 +97,14 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
     ],
   );
 
-  // Create and manage Knock client instance
-  const [forceUpdate, setForceUpdate] = React.useState(0);
-  const knockClient = React.useMemo(
-    () => {
-      const knock = new Knock(apiKey ?? "", {
-        host: authenticateOptions.host,
-        logLevel: authenticateOptions.logLevel,
-        branch: authenticateOptions.branch,
-      });
-
-      // Authenticate synchronously on creation if enabled
-      if (enabled && userIdOrUserWithProperties) {
-        knock.authenticate(userIdOrUserWithProperties, userToken, {
-          onUserTokenExpiring: authenticateOptions.onUserTokenExpiring,
-          timeBeforeExpirationInMs:
-            authenticateOptions.timeBeforeExpirationInMs,
-          identificationStrategy: authenticateOptions.identificationStrategy,
-        });
-      }
-
-      return knock;
-    },
-    // We intentionally omit enabled, userIdOrUserWithProperties, and userToken
-    // to reuse the same instance when these change. Auth state changes are handled
-    // in the effect below via resetAuthentication()/authenticate() calls.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [apiKey, authenticateOptions, forceUpdate],
-  );
+  // Create Knock client instance (without authentication)
+  const knockClient = React.useMemo(() => {
+    return new Knock(apiKey ?? "", {
+      host: authenticateOptions.host,
+      logLevel: authenticateOptions.logLevel,
+      branch: authenticateOptions.branch,
+    });
+  }, [apiKey, authenticateOptions]);
 
   // Handle authentication state based on enabled prop
   React.useEffect(() => {
@@ -136,11 +116,9 @@ export const KnockProvider: React.FC<PropsWithChildren<KnockProviderProps>> = ({
         timeBeforeExpirationInMs: authenticateOptions.timeBeforeExpirationInMs,
         identificationStrategy: authenticateOptions.identificationStrategy,
       });
-      setForceUpdate((n) => n + 1);
     } else if (!enabled && knockClient.isAuthenticated()) {
       // When disabled, reset authentication if currently authenticated
       knockClient.resetAuthentication();
-      setForceUpdate((n) => n + 1);
     }
   }, [
     enabled,

--- a/packages/react-core/test/core/KnockProvider.test.tsx
+++ b/packages/react-core/test/core/KnockProvider.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createMockKnock } from "../../../client/test/test-utils/mocks";
-import { KnockProvider, useKnockClient } from "../../src";
+import { KnockProvider, useKnockClient, useTranslations } from "../../src";
 
 const TEST_BRANCH_SLUG = "lorem-ipsum-dolor-branch";
 
@@ -490,6 +490,33 @@ describe("KnockProvider", () => {
       // Now context should not be available
       expect(getByTestId("error-msg")).toHaveTextContent(
         "No context available",
+      );
+    });
+
+    test("i18n context is still available when enabled is false", () => {
+      const TestChild = () => {
+        const { t, locale } = useTranslations();
+        return (
+          <div data-testid="i18n-test">
+            Locale: {locale}, Translation: {t("archiveNotification")}
+          </div>
+        );
+      };
+
+      const { getByTestId } = render(
+        <KnockProvider
+          apiKey="test_api_key"
+          user={{ id: "test_user_id" }}
+          enabled={false}
+        >
+          <TestChild />
+        </KnockProvider>,
+      );
+
+      // i18n should still work (with default locale and translations)
+      expect(getByTestId("i18n-test")).toHaveTextContent("Locale: en");
+      expect(getByTestId("i18n-test")).toHaveTextContent(
+        "Translation: Archive this notification",
       );
     });
   });

--- a/packages/react-native/src/modules/push/KnockPushNotificationProvider.tsx
+++ b/packages/react-native/src/modules/push/KnockPushNotificationProvider.tsx
@@ -45,6 +45,13 @@ export const KnockPushNotificationProvider: React.FC<
   // Acts like an upsert. Inserts or updates
   const registerPushTokenToChannel = useCallback(
     async (token: string, channelId: string): Promise<ChannelData | void> => {
+      if (!knockClient.isAuthenticated()) {
+        knockClient.log(
+          "[Knock] Skipping registerPushTokenToChannel - user not authenticated",
+        );
+        return;
+      }
+
       const newDevice: Device = {
         token,
         locale: Intl.DateTimeFormat().resolvedOptions().locale,
@@ -81,6 +88,13 @@ export const KnockPushNotificationProvider: React.FC<
 
   const unregisterPushTokenFromChannel = useCallback(
     async (token: string, channelId: string): Promise<ChannelData | void> => {
+      if (!knockClient.isAuthenticated()) {
+        knockClient.log(
+          "[Knock] Skipping unregisterPushTokenFromChannel - user not authenticated",
+        );
+        return;
+      }
+
       return knockClient.user
         .getChannelData({ channelId: channelId })
         .then((result: ChannelData) => {


### PR DESCRIPTION
### Description
Adds an `enabled` prop to `KnockProvider` to control whether the provider should authenticate and initialize the Knock client.

This change addresses the problem where `KnockProvider` would always attempt authentication on mount, even with `undefined` `userId`/`userToken`, leading to boilerplate conditional rendering or auth errors.

The `enabled` prop (defaulting to `true`) allows users to conditionally skip authentication by setting `enabled={false}`, similar to patterns in other popular React libraries. This removes the need for wrapper components and prevents unnecessary API calls in unauthenticated states.

The implementation refactors `KnockProvider` into two components: an outer `KnockProvider` handling the `enabled` logic and an inner `AuthenticatedKnockProvider` responsible for the actual client initialization and authentication. This ensures React hook rules are followed while providing the desired functionality.

### Checklist
- [x] Tests have been added for new features or major refactors to existing features.

---
Linear Issue: [KNO-10561](https://linear.app/knock/issue/KNO-10561/feature-request-add-enabled-prop-to-knockprovider)

<a href="https://cursor.com/background-agent?bcId=bc-1018ec53-94f2-414a-991f-b22004ff4353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1018ec53-94f2-414a-991f-b22004ff4353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

