### PR TITLE
chore(KNO-11276): remove link to RN example from Expo example README

### DIFF
--- a/examples/expo-example/README.md
+++ b/examples/expo-example/README.md
@@ -2,8 +2,6 @@
 
 This example app uses [Knock](https://knock.app) to power in-app notifications. It uses the [Knock Expo SDK](../../packages/expo) and [Expo](https://docs.expo.dev/).
 
-> Not using Expo? See our [Knock + React Native example app](../react-native-example/README.md).
-
 ## Running locally
 
 1. Install dependencies from the root of the monorepo.


### PR DESCRIPTION
### Description

This PR removes a broken link from the Expo example app README. The vanilla React Native example app was removed from this repository.

### Checklist

- [X] Tests have been added for new features or major refactors to existing features.
