### PR TITLE
chore: handle (re)subscribe in guide toolbar V2 when entering/exiting

### DIFF
--- a/.changeset/tangy-tools-cross.md
+++ b/.changeset/tangy-tools-cross.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+---
+
+[Guides] Only re-subscribe per listenForUpdates when exiting debugging in guide toolbar v2

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -629,7 +629,6 @@ export class KnockGuideClient {
         `[Guide] Start debugging, refetching guides and resubscribing to the websocket channel`,
       );
       this.fetch({ force: true });
-      this.subscribe();
     }
   }
 
@@ -653,8 +652,6 @@ export class KnockGuideClient {
         `[Guide] Stop debugging, refetching guides and resubscribing to the websocket channel`,
       );
       this.fetch({ force: true });
-      // TODO: Manage (re)subscribe/unsubscribe in V2 rather than here.
-      this.subscribe();
     }
   }
 

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -654,7 +654,11 @@ export class KnockGuideClient {
         `[Guide] Stop debugging, refetching guides and resubscribing to the websocket channel`,
       );
       this.fetch({ force: true });
-      opts?.listenForUpdates ? this.subscribe() : this.unsubscribe();
+      if (opts?.listenForUpdates) {
+        this.subscribe();
+      } else {
+        this.unsubscribe();
+      }
     }
   }
 

--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -629,10 +629,12 @@ export class KnockGuideClient {
         `[Guide] Start debugging, refetching guides and resubscribing to the websocket channel`,
       );
       this.fetch({ force: true });
+      // Always subscribe while debugging.
+      this.subscribe();
     }
   }
 
-  unsetDebug() {
+  unsetDebug(opts?: { listenForUpdates?: boolean }) {
     this.knock.log("[Guide] .unsetDebug()");
     const shouldRefetch = this.store.state.debug?.debugging;
 
@@ -652,6 +654,7 @@ export class KnockGuideClient {
         `[Guide] Stop debugging, refetching guides and resubscribing to the websocket channel`,
       );
       this.fetch({ force: true });
+      opts?.listenForUpdates ? this.subscribe() : this.unsubscribe();
     }
   }
 

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -4856,7 +4856,7 @@ describe("KnockGuideClient", () => {
 
       expect(client.store.state.debug).toBe(undefined);
 
-      // calls fetch when existing debugging
+      // calls fetch when exiting debugging
       expect(fetchSpy).toHaveBeenCalled();
     });
 

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -4714,9 +4714,9 @@ describe("KnockGuideClient", () => {
 
       expect(client.store.state.debug!.debugging!).toBe(true);
 
-      // calls fetch when not already debugging; subscribe is managed by V2 toolbar
+      // calls fetch and subscribe when not already debugging
       expect(fetchSpy).toHaveBeenCalled();
-      expect(subscribeSpy).not.toHaveBeenCalled();
+      expect(subscribeSpy).toHaveBeenCalled();
     });
 
     test("sets debug state with provided options", () => {

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -4851,17 +4851,13 @@ describe("KnockGuideClient", () => {
       const fetchSpy = vi
         .spyOn(client, "fetch")
         .mockImplementation(() => Promise.resolve({ status: "ok" }));
-      const subscribeSpy = vi
-        .spyOn(client, "subscribe")
-        .mockImplementation(() => {});
 
       client.unsetDebug();
 
       expect(client.store.state.debug).toBe(undefined);
 
-      // calls fetch when was debugging; subscribe is managed by V2 toolbar
+      // calls fetch when existing debugging
       expect(fetchSpy).toHaveBeenCalled();
-      expect(subscribeSpy).not.toHaveBeenCalled();
     });
 
     test("does not call fetch and subscribe when was not debugging", () => {

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -4714,9 +4714,9 @@ describe("KnockGuideClient", () => {
 
       expect(client.store.state.debug!.debugging!).toBe(true);
 
-      // calls fetch and subscribe when not already debugging
+      // calls fetch when not already debugging; subscribe is managed by V2 toolbar
       expect(fetchSpy).toHaveBeenCalled();
-      expect(subscribeSpy).toHaveBeenCalled();
+      expect(subscribeSpy).not.toHaveBeenCalled();
     });
 
     test("sets debug state with provided options", () => {
@@ -4859,9 +4859,9 @@ describe("KnockGuideClient", () => {
 
       expect(client.store.state.debug).toBe(undefined);
 
-      // calls fetch and subscribe when was debugging
+      // calls fetch when was debugging; subscribe is managed by V2 toolbar
       expect(fetchSpy).toHaveBeenCalled();
-      expect(subscribeSpy).toHaveBeenCalled();
+      expect(subscribeSpy).not.toHaveBeenCalled();
     });
 
     test("does not call fetch and subscribe when was not debugging", () => {

--- a/packages/react-core/test/guide/KnockGuideProvider.test.tsx
+++ b/packages/react-core/test/guide/KnockGuideProvider.test.tsx
@@ -78,6 +78,20 @@ describe("KnockGuideProvider", () => {
     expect(subscribeMock).toHaveBeenCalled();
   });
 
+  it("does not subscribe when listenForUpdates is false", () => {
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+      React.createElement(
+        KnockGuideProvider,
+        { channelId: "feed", readyToTarget: true, listenForUpdates: false },
+        children,
+      );
+
+    renderHook(() => useGuideContext(), { wrapper });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
   it("defers fetch/subscribe to toolbar v2 when toolbar is visible", () => {
     getToolbarRunConfigFromUrlMock.mockReturnValue({ isVisible: true });
 

--- a/packages/react/src/modules/guide/components/Toolbar/V2/V2.tsx
+++ b/packages/react/src/modules/guide/components/Toolbar/V2/V2.tsx
@@ -87,9 +87,10 @@ const filterGuides = (
 
 type Props = {
   readyToTarget: boolean;
+  listenForUpdates: boolean;
 };
 
-export const V2 = ({ readyToTarget }: Props) => {
+export const V2 = ({ readyToTarget, listenForUpdates }: Props) => {
   const { client } = useGuideContext();
 
   const [displayOption, setDisplayOption] =
@@ -111,8 +112,16 @@ export const V2 = ({ readyToTarget }: Props) => {
   React.useEffect(() => {
     const { isVisible = false, focusedGuideKeys = {} } = runConfig || {};
     const isDebugging = client.store.state.debug?.debugging;
+
+    const stopDebug = () => {
+      client.unsetDebug();
+      listenForUpdates ? client.subscribe() : client.unsubscribe();
+    };
+
+    // Always subscribe while debugging.
     if (isVisible && !isDebugging && readyToTarget) {
       client.setDebug({ focusedGuideKeys });
+      client.subscribe();
 
       // If focused, switch to all guides so you can see in the list.
       if (Object.keys(focusedGuideKeys).length > 0) {
@@ -120,10 +129,12 @@ export const V2 = ({ readyToTarget }: Props) => {
       }
     }
 
-    return () => {
-      client.unsetDebug();
-    };
-  }, [readyToTarget, runConfig, client, setDisplayOption]);
+    if (!isVisible && isDebugging) {
+      stopDebug();
+    }
+
+    return () => stopDebug();
+  }, [readyToTarget, listenForUpdates, runConfig, client, setDisplayOption]);
 
   // Toggle collapsed state with Ctrl + .
   React.useEffect(() => {
@@ -351,7 +362,6 @@ export const V2 = ({ readyToTarget }: Props) => {
                   leadingIcon={{ icon: LogOut, alt: "Exit" }}
                   onClick={() => {
                     setRunConfig((curr) => ({ ...curr, isVisible: false }));
-                    client.unsetDebug();
                   }}
                 >
                   Exit

--- a/packages/react/src/modules/guide/components/Toolbar/V2/V2.tsx
+++ b/packages/react/src/modules/guide/components/Toolbar/V2/V2.tsx
@@ -113,15 +113,8 @@ export const V2 = ({ readyToTarget, listenForUpdates }: Props) => {
     const { isVisible = false, focusedGuideKeys = {} } = runConfig || {};
     const isDebugging = client.store.state.debug?.debugging;
 
-    const stopDebug = () => {
-      client.unsetDebug();
-      listenForUpdates ? client.subscribe() : client.unsubscribe();
-    };
-
-    // Always subscribe while debugging.
     if (isVisible && !isDebugging && readyToTarget) {
       client.setDebug({ focusedGuideKeys });
-      client.subscribe();
 
       // If focused, switch to all guides so you can see in the list.
       if (Object.keys(focusedGuideKeys).length > 0) {
@@ -130,10 +123,14 @@ export const V2 = ({ readyToTarget, listenForUpdates }: Props) => {
     }
 
     if (!isVisible && isDebugging) {
-      stopDebug();
+      client.unsetDebug({ listenForUpdates });
     }
 
-    return () => stopDebug();
+    return () => {
+      if (isDebugging) {
+        client.unsetDebug({ listenForUpdates });
+      }
+    };
   }, [readyToTarget, listenForUpdates, runConfig, client, setDisplayOption]);
 
   // Toggle collapsed state with Ctrl + .

--- a/packages/react/src/modules/guide/components/Toolbar/V2/V2.tsx
+++ b/packages/react/src/modules/guide/components/Toolbar/V2/V2.tsx
@@ -127,7 +127,7 @@ export const V2 = ({ readyToTarget, listenForUpdates }: Props) => {
     }
 
     return () => {
-      if (isDebugging) {
+      if (client.store.state.debug?.debugging) {
         client.unsetDebug({ listenForUpdates });
       }
     };

--- a/packages/react/src/modules/guide/providers/KnockGuideProvider.tsx
+++ b/packages/react/src/modules/guide/providers/KnockGuideProvider.tsx
@@ -17,18 +17,23 @@ export const KnockGuideProvider: React.FC<React.PropsWithChildren<Props>> = ({
   children,
   toolbar = "v2",
   readyToTarget,
+  listenForUpdates = true,
   ...props
 }) => {
   return (
     <KnockGuideProviderCore
       {...props}
       readyToTarget={readyToTarget}
+      listenForUpdates={listenForUpdates}
       // For backward compatibility with toolbar v1. Remove once v2 ships.
       trackDebugParams={toolbar === "v1"}
     >
       {children}
       {toolbar === "v2" ? (
-        <ToolbarV2 readyToTarget={readyToTarget} />
+        <ToolbarV2
+          readyToTarget={readyToTarget}
+          listenForUpdates={listenForUpdates}
+        />
       ) : (
         <ToolbarV1 />
       )}


### PR DESCRIPTION
### Description

One small follow up to #942, we now pass down the `listenForUpdates` from `KnockGuideProvider` also and use it to decide whether to re-subscribe when exiting from debugging in the guide toolbar V2.

