### PR TITLE
feat(react): wire up @telegraph/style-engine PostCSS plugin and remove toggle CSS workaround

### DIFF
--- a/.changeset/telegraph-style-engine-wire-up.md
+++ b/.changeset/telegraph-style-engine-wire-up.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+Wire up @telegraph/style-engine PostCSS plugin in the Vite config and remove the manual @import workaround for @telegraph/toggle CSS.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -95,6 +95,7 @@
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
     "@tanstack/react-router": "1.134.12",
+    "@telegraph/style-engine": "^0.3.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/eslint-plugin-jsx-a11y": "^6",

--- a/packages/react/src/modules/guide/components/Toolbar/styles.css
+++ b/packages/react/src/modules/guide/components/Toolbar/styles.css
@@ -1,6 +1,3 @@
-/* TODO(KNO-12330): Include manually for now until telegraph style engine is
-* able to compile automatically with components in the monorepo setup */
-@import "@telegraph/toggle/default.css";
 @telegraph tokens;
 @telegraph components;
 

--- a/packages/react/vite.config.mts
+++ b/packages/react/vite.config.mts
@@ -1,12 +1,16 @@
 /// <reference types="vitest" />
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 import react from "@vitejs/plugin-react";
+import { createRequire } from "module";
 import path from "path";
 import execute from "rollup-plugin-execute";
 import preserveDirectives from "rollup-preserve-directives";
 import { LibraryFormats, defineConfig, loadEnv } from "vite";
 import dts from "vite-plugin-dts";
 import noBundlePlugin from "vite-plugin-no-bundle";
+
+const require = createRequire(import.meta.url);
+const styleEnginePlugin = require("@telegraph/style-engine/postcss");
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -16,6 +20,11 @@ export default defineConfig(({ mode }) => {
   const formats: LibraryFormats[] = CJS ? ["cjs"] : ["es"];
 
   return {
+    css: {
+      postcss: {
+        plugins: [styleEnginePlugin()],
+      },
+    },
     plugins: [
       react({
         jsxRuntime: "classic",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4663,6 +4663,7 @@ __metadata:
     "@telegraph/layout": "npm:^0.5.0"
     "@telegraph/segmented-control": "npm:^0.2.2"
     "@telegraph/select": "npm:^0.0.86"
+    "@telegraph/style-engine": "npm:^0.3.2"
     "@telegraph/tag": "npm:^0.1.4"
     "@telegraph/toggle": "npm:0.1.1"
     "@telegraph/tokens": "npm:^0.1.4"
@@ -7541,6 +7542,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@telegraph/style-engine@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@telegraph/style-engine@npm:0.3.2"
+  dependencies:
+    "@telegraph/tokens": "npm:^0.2.0"
+    postcss: "npm:^8.5.6"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  checksum: 10c0/14bc97ebc98cba9ce5ed6680a266c141191240d6670c2568c35fd38468a396d5b9c6b79152e8b070ffd3f018cb499dfd4f1bb4833725c1cf88ab82eeb88c9bdb
+  languageName: node
+  linkType: hard
+
 "@telegraph/tag@npm:^0.1.4":
   version: 0.1.4
   resolution: "@telegraph/tag@npm:0.1.4"
@@ -7610,6 +7624,15 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
   checksum: 10c0/0c4355816b5b5291e84c5c96dba142326c0df866ea353c9c3de9fb6a1274985cfd29455bdbb8e39fde5458ef127da49bfd4e02a93673cfcb0ccc40f364f16a1a
+  languageName: node
+  linkType: hard
+
+"@telegraph/tokens@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@telegraph/tokens@npm:0.2.0"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10c0/96db93d0ed5ae9581446894028b04bde31691b64fe3d027d0824aa949ea21a7054ea798924c20737987705c249f1939482a58ed5ac8a686813765974d1311b1e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Wires up the `@telegraph/style-engine` PostCSS plugin into `packages/react` and removes the manual CSS workaround that was put in place by KNO-12330.

**What changed:**
- Added `@telegraph/style-engine@^0.3.2` as a `devDependency` in `packages/react/package.json`.
- Wired the plugin directly into `vite.config.mts` via `css.postcss.plugins` using `createRequire` (required because Vite 5 bundles `postcss-load-config` v2 internally, which doesn't support `postcss.config.json` or `.js` correctly).
- Removed the `/* TODO(KNO-12330) */` comment and the manual `@import "@telegraph/toggle/default.css"` from `packages/react/src/modules/guide/components/Toolbar/styles.css` — toggle CSS is now injected automatically by `@telegraph/style-engine` when it processes `@telegraph components`.

**Why:** The style-engine fix from KNO-12330 was published. The manual `@import` was always a temporary workaround; this PR cleans it up.

### How we tested

Built the `@knocklabs/react` package locally (`yarn build` from repo root) and verified the output:

- `dist/index.css` is **62,736 bytes** — matching the expected size from the ticket.
- Toggle CSS selectors are present in the output (`[data-tgph-toggle-switch]`, `[data-tgph-toggle-input]`, `[data-tgph-toggle-checked=true]`, `[data-tgph-toggle-icon]`, `[data-tgph-toggle-label]`, `[data-tgph-toggle-disabled=true]`, `[data-tgph-toggle-checked=false]` — 12 total matches).
- No manual `@import "@telegraph/toggle/default.css"` in the built output.
- `@telegraph tokens` and `@telegraph components` directives are fully processed and absent from the output.
