### PR TITLE
refactor(guide): rename stage results keys to byKey and byType

### DIFF
--- a/packages/client/src/clients/guide/client.ts
+++ b/packages/client/src/clients/guide/client.ts
@@ -868,14 +868,14 @@ export class KnockGuideClient {
     if (!this.stage || this.stage.status === "closed") return;
 
     // Deep merge to accumulate the results.
-    const queriedByKey = this.stage.results.key || {};
+    const queriedByKey = this.stage.results.byKey || {};
     if (filters.key) {
       queriedByKey[filters.key] = {
         ...(queriedByKey[filters.key] || {}),
         ...{ [limit]: result },
       };
     }
-    const queriedByType = this.stage.results.type || {};
+    const queriedByType = this.stage.results.byType || {};
     if (filters.type) {
       queriedByType[filters.type] = {
         ...(queriedByType[filters.type] || {}),
@@ -885,7 +885,7 @@ export class KnockGuideClient {
 
     this.stage = {
       ...this.stage,
-      results: { key: queriedByKey, type: queriedByType },
+      results: { byKey: queriedByKey, byType: queriedByType },
     };
   }
 

--- a/packages/client/src/clients/guide/types.ts
+++ b/packages/client/src/clients/guide/types.ts
@@ -296,8 +296,8 @@ type SelectionResultByLimit = {
 };
 
 type RecordedSelectionResults = {
-  key?: Record<KnockGuide["key"], SelectionResultByLimit>;
-  type?: Record<KnockGuide["type"], SelectionResultByLimit>;
+  byKey?: Record<KnockGuide["key"], SelectionResultByLimit>;
+  byType?: Record<KnockGuide["type"], SelectionResultByLimit>;
 };
 
 export type GroupStage = {

--- a/packages/client/test/clients/guide/guide.test.ts
+++ b/packages/client/test/clients/guide/guide.test.ts
@@ -4152,11 +4152,11 @@ describe("KnockGuideClient", () => {
       const stage = client.getStage();
       expect(stage).toBeDefined();
       expect(stage!.status).toBe("open");
-      expect(stage!.results.key).toBeDefined();
-      expect(stage!.results.key!["onboarding"]).toBeDefined();
-      expect(stage!.results.key!["onboarding"]!.one).toBeDefined();
-      expect(stage!.results.key!["onboarding"]!.one!.metadata).toBeDefined();
-      expect(stage!.results.key!["onboarding"]!.one!.metadata!.limit).toBe(
+      expect(stage!.results.byKey).toBeDefined();
+      expect(stage!.results.byKey!["onboarding"]).toBeDefined();
+      expect(stage!.results.byKey!["onboarding"]!.one).toBeDefined();
+      expect(stage!.results.byKey!["onboarding"]!.one!.metadata).toBeDefined();
+      expect(stage!.results.byKey!["onboarding"]!.one!.metadata!.limit).toBe(
         "one",
       );
     });
@@ -4181,9 +4181,9 @@ describe("KnockGuideClient", () => {
 
       const stage = client.getStage();
       expect(stage).toBeDefined();
-      expect(stage!.results.type).toBeDefined();
-      expect(stage!.results.type!["card"]).toBeDefined();
-      expect(stage!.results.type!["card"]!.one).toBeDefined();
+      expect(stage!.results.byType).toBeDefined();
+      expect(stage!.results.byType!["card"]).toBeDefined();
+      expect(stage!.results.byType!["card"]!.one).toBeDefined();
     });
 
     test("does not record when not debugging", () => {
@@ -4248,8 +4248,8 @@ describe("KnockGuideClient", () => {
       client.selectGuide(stateWithGuides, { type: "banner" });
 
       const stage = client.getStage();
-      expect(stage!.results.key!["onboarding"].one).toBeDefined();
-      expect(stage!.results.type!["banner"].one).toBeDefined();
+      expect(stage!.results.byKey!["onboarding"].one).toBeDefined();
+      expect(stage!.results.byType!["banner"].one).toBeDefined();
     });
 
     test("selectGuides records result with 'all' limit", () => {
@@ -4272,14 +4272,14 @@ describe("KnockGuideClient", () => {
       client.selectGuides(stateWithGuides, { type: "card" });
 
       const stage = client.getStage();
-      expect(stage!.results.type).toBeDefined();
-      expect(stage!.results.type!["card"]).toBeDefined();
-      expect(stage!.results.type!["card"]!.all).toBeDefined();
-      expect(stage!.results.type!["card"]!.all!.metadata!.limit).toBe("all");
+      expect(stage!.results.byType).toBeDefined();
+      expect(stage!.results.byType!["card"]).toBeDefined();
+      expect(stage!.results.byType!["card"]!.all).toBeDefined();
+      expect(stage!.results.byType!["card"]!.all!.metadata!.limit).toBe("all");
 
       // selectGuides calls selectGuide internally with recordSelectQuery: false,
       // so the "one" limit should NOT be recorded for the same type filter.
-      expect(stage!.results.type!["card"]!.one).toBeUndefined();
+      expect(stage!.results.byType!["card"]!.one).toBeUndefined();
     });
 
     test("does not record when stage is closed", () => {
@@ -4344,8 +4344,8 @@ describe("KnockGuideClient", () => {
       client.selectGuide(stateWithGuides, { key: "onboarding" });
 
       const stage = client.getStage();
-      expect(stage!.results.key).toBeDefined();
-      expect(stage!.results.key!["onboarding"]).toBeDefined();
+      expect(stage!.results.byKey).toBeDefined();
+      expect(stage!.results.byKey!["onboarding"]).toBeDefined();
     });
   });
 

--- a/packages/react/src/modules/guide/components/Toolbar/V2/useInspectGuideClientStore.ts
+++ b/packages/react/src/modules/guide/components/Toolbar/V2/useInspectGuideClientStore.ts
@@ -59,8 +59,8 @@ type SelectionResultByLimit = {
   all?: KnockGuideSelectionResult;
 };
 type SelectionResultByQuery = {
-  key?: SelectionResultByLimit;
-  type?: SelectionResultByLimit;
+  byKey?: SelectionResultByLimit;
+  byType?: SelectionResultByLimit;
 };
 type SelectableStatusPresent = {
   status: "returned" | "throttled" | "queried";
@@ -157,8 +157,8 @@ const inferSelectByKeyReturnStatus = (
   query: SelectionResultByQuery,
 ): SelectableStatusPresent["status"] => {
   const includeThrottled =
-    !!query.key?.one?.metadata?.opts?.includeThrottled ||
-    !!query.key?.all?.metadata?.opts?.includeThrottled;
+    !!query.byKey?.one?.metadata?.opts?.includeThrottled ||
+    !!query.byKey?.all?.metadata?.opts?.includeThrottled;
 
   // If unthrottled, then it should always be returned.
   if (guide.bypass_global_group_limit) {
@@ -185,9 +185,10 @@ const inferSelectOneByTypeReturnStatus = (
   stage: KnockGuideClientGroupStage,
   query: SelectionResultByQuery,
 ): SelectableStatusPresent["status"] => {
-  const includeThrottled = !!query.type?.one?.metadata?.opts?.includeThrottled;
+  const includeThrottled =
+    !!query.byType?.one?.metadata?.opts?.includeThrottled;
 
-  const result = query.type!.one!;
+  const result = query.byType!.one!;
   if (result.size === 0) {
     return "queried";
   }
@@ -229,7 +230,7 @@ const inferSelectAllByTypeReturnStatus = (
   stage: KnockGuideClientGroupStage,
   query: SelectionResultByQuery,
 ): SelectableStatusPresent["status"] => {
-  const result = query.type!.all!;
+  const result = query.byType!.all!;
   if (result.size === 0) {
     return "queried";
   }
@@ -241,7 +242,8 @@ const inferSelectAllByTypeReturnStatus = (
   const guidesByKey: Record<KnockGuide["key"], KnockGuide> = byKey(guides);
 
   // If includeThrottled given, then expect all selected guides to be returned.
-  const includeThrottled = !!query.type?.all?.metadata?.opts?.includeThrottled;
+  const includeThrottled =
+    !!query.byType?.all?.metadata?.opts?.includeThrottled;
   if (includeThrottled) {
     return guidesByKey[guide.key] ? "returned" : "queried";
   }
@@ -270,14 +272,14 @@ const inferSelectReturnStatus = (
 ) => {
   // Querying by key can only return up to a max of one guide, regardless of
   // useGuide or useGuides, and should take precedence in status designation.
-  if (query.key) {
+  if (query.byKey) {
     return inferSelectByKeyReturnStatus(guide, snapshot, stage, query);
   }
 
-  if (query.type?.all) {
+  if (query.byType?.all) {
     return inferSelectAllByTypeReturnStatus(guide, snapshot, stage, query);
   }
-  if (query.type?.one) {
+  if (query.byType?.one) {
     return inferSelectOneByTypeReturnStatus(guide, snapshot, stage, query);
   }
 
@@ -295,11 +297,11 @@ const toSelectableStatus = (
   }
 
   const query = {
-    key: (stage.results.key || {})[guide.key],
-    type: (stage.results.type || {})[guide.type],
+    byKey: (stage.results.byKey || {})[guide.key],
+    byType: (stage.results.byType || {})[guide.type],
   };
 
-  const queried = Boolean(query.key || query.type);
+  const queried = Boolean(query.byKey || query.byType);
   if (!queried) {
     // No present query in the current location can select this guide.
     return { status: undefined };

--- a/packages/react/test/guide/Toolbar/V2/useInspectGuideClientStore.test.ts
+++ b/packages/react/test/guide/Toolbar/V2/useInspectGuideClientStore.test.ts
@@ -538,7 +538,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1" });
@@ -609,7 +609,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1", active: true });
@@ -672,7 +672,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1" });
@@ -693,7 +693,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       mockCheckStateIfThrottled.mockReturnValue(true);
@@ -717,7 +717,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: {
+          byKey: {
             g1: {
               one: makeSelectionResult([], { includeThrottled: true }),
             },
@@ -742,7 +742,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other_guide",
         timeoutId: null,
         results: {
-          key: {
+          byKey: {
             g1: { one: makeSelectionResult() },
             other_guide: { one: makeSelectionResult() },
           },
@@ -767,7 +767,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other_guide",
         timeoutId: null,
         results: {
-          key: {
+          byKey: {
             g1: { one: makeSelectionResult() },
             other_guide: { one: makeSelectionResult() },
           },
@@ -795,7 +795,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other_guide",
         timeoutId: null,
         results: {
-          key: { other_guide: { one: makeSelectionResult() } },
+          byKey: { other_guide: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1" });
@@ -818,7 +818,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([[0, { key: "g1" }]]),
             },
@@ -848,7 +848,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([
                 [0, { key: "higher_priority_guide" }],
@@ -875,7 +875,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([]),
             },
@@ -904,7 +904,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([[0, { key: "g1" }]]),
             },
@@ -930,7 +930,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([[0, { key: "g1" }]]),
             },
@@ -956,7 +956,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([[0, { key: "g1" }]], {
                 includeThrottled: true,
@@ -983,7 +983,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other_guide",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([[0, { key: "g1" }]]),
             },
@@ -1008,7 +1008,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([[0, { key: "g1" }]]),
             },
@@ -1033,7 +1033,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([]),
             },
@@ -1058,7 +1058,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([
                 [0, { key: "g1", bypass_global_group_limit: true }],
@@ -1090,7 +1090,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([[0, { key: "g1" }]]),
             },
@@ -1120,7 +1120,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([[0, { key: "g1" }]]),
             },
@@ -1150,7 +1150,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([
                 [0, { key: "first", bypass_global_group_limit: true }],
@@ -1183,7 +1183,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([
                 [0, { key: "first", bypass_global_group_limit: true }],
@@ -1216,7 +1216,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "first",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([
                 [0, { key: "first", bypass_global_group_limit: false }],
@@ -1244,7 +1244,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([
                 [0, { key: "first", bypass_global_group_limit: false }],
@@ -1272,7 +1272,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult(
                 [
@@ -1303,7 +1303,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult(
                 [[0, { key: "other" }]],
@@ -1331,7 +1331,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "other",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([
                 [0, { key: "first", bypass_global_group_limit: true }],
@@ -1358,7 +1358,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "first",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {
               all: makeSelectionResult([
                 [0, { key: "first", bypass_global_group_limit: false }],
@@ -1385,7 +1385,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          type: {
+          byType: {
             banner: {},
           },
         },
@@ -1409,10 +1409,10 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: {
+          byKey: {
             g1: { one: makeSelectionResult() },
           },
-          type: {
+          byType: {
             banner: {
               one: makeSelectionResult([[0, { key: "other" }]]),
             },
@@ -1453,7 +1453,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       mockCheckActivatable.mockReturnValue(false);
@@ -1477,7 +1477,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: {
+          byKey: {
             g1: { one: makeSelectionResult() },
           },
         },
@@ -1568,7 +1568,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1" });
@@ -1623,7 +1623,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1" });
@@ -1654,7 +1654,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1" });
@@ -1681,7 +1681,7 @@ describe("useInspectGuideClientStore", () => {
         resolved: "g1",
         timeoutId: null,
         results: {
-          key: { g1: { one: makeSelectionResult() } },
+          byKey: { g1: { one: makeSelectionResult() } },
         },
       };
       const guide = makeGuide({ key: "g1" });


### PR DESCRIPTION
### Description

Renames the `key` and `type` fields in `RecordedSelectionResults` to `byKey` and `byType` respectively for clarity. No other functional changes, just something that I realized would be good to re-name after introducing it initially.

```
type RecordedSelectionResults = {
  byKey?: Record<KnockGuide["key"], SelectionResultByLimit>;
  byType?: Record<KnockGuide["type"], SelectionResultByLimit>;
};
```

