### PR TITLE
chore: cache the last settled annotated guides in guide toolbar

### DIFF
--- a/.changeset/curly-jeans-hug.md
+++ b/.changeset/curly-jeans-hug.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+[Guide] Skip re-rendering in transient state in guide toolbar

--- a/packages/react/src/modules/guide/components/Toolbar/V2/useInspectGuideClientStore.ts
+++ b/packages/react/src/modules/guide/components/Toolbar/V2/useInspectGuideClientStore.ts
@@ -9,6 +9,7 @@ import {
   checkStateIfThrottled,
 } from "@knocklabs/client";
 import { useGuideContext, useStore } from "@knocklabs/react-core";
+import * as React from "react";
 
 import { FOCUS_ERRORS } from "./helpers";
 
@@ -443,6 +444,12 @@ export const useInspectGuideClientStore = (
     };
   });
 
+  // Cache of the last settled orderedGuides, used to keep the toolbar stable
+  // while the group stage is transiently cleared or re-opening.
+  const orderedGuidesRef = React.useRef<
+    (AnnotatedGuide | UncommittedGuide)[] | undefined
+  >(undefined);
+
   // Not in debugging session, so noop.
   if (!snapshot.debug?.debugging) {
     return undefined;
@@ -470,16 +477,31 @@ export const useInspectGuideClientStore = (
 
   const groupStage = client.getStage();
 
-  // Annotate guides for various eligibility, activation and query statuses
-  // that are useful for debugging purposes.
-  const orderedGuides = defaultGroup.display_sequence.map((guideKey, index) => {
-    const guide = snapshot.guides[guideKey];
-    if (!guide) {
-      return newUncommittedGuide(guideKey, index);
-    }
+  // The stage is transient while it is undefined (just cleared) or "open"
+  // (new stage with empty results); during these windows the computed
+  // selectable status collapses to undefined for every guide. "closed" and
+  // "patch" both preserve results, so we treat them as settled.
+  const isTransient = !groupStage || groupStage.status === "open";
 
-    return annotateGuide(guide, index, snapshot, groupStage);
-  });
+  // Annotate guides for various eligibility, activation and query statuses
+  // that are useful for debugging purposes. Serve the last settled result
+  // during transient windows to avoid flashing status dots.
+  let orderedGuides: (AnnotatedGuide | UncommittedGuide)[];
+  if (isTransient && orderedGuidesRef.current) {
+    orderedGuides = orderedGuidesRef.current;
+  } else {
+    orderedGuides = defaultGroup.display_sequence.map((guideKey, index) => {
+      const guide = snapshot.guides[guideKey];
+      if (!guide) {
+        return newUncommittedGuide(guideKey, index);
+      }
+      return annotateGuide(guide, index, snapshot, groupStage);
+    });
+
+    if (!isTransient) {
+      orderedGuidesRef.current = orderedGuides;
+    }
+  }
 
   // Check if the focused guide actually exists and is selectable on the page.
   const focusedGuideKey = Object.keys(runConfig.focusedGuideKeys || {})[0];

--- a/packages/react/test/guide/Toolbar/V2/useInspectGuideClientStore.test.ts
+++ b/packages/react/test/guide/Toolbar/V2/useInspectGuideClientStore.test.ts
@@ -1718,4 +1718,139 @@ describe("useInspectGuideClientStore", () => {
       expect(result.guides).toHaveLength(1);
     });
   });
+
+  // ----- Stability across transient stage transitions -----
+  //
+  // The group stage is cleared and re-opened on Focus toggles, navigation,
+  // etc. During the order-resolution window, selectable would collapse to
+  // undefined for every guide, causing the status dots to flicker. The hook
+  // caches the last settled orderedGuides and serves it while the stage is
+  // transient (undefined or "open") to keep the toolbar view stable.
+
+  describe("stability across transient stage transitions", () => {
+    const closedStage = {
+      status: "closed" as const,
+      ordered: ["g1"],
+      resolved: "g1",
+      timeoutId: null,
+      results: { byKey: { g1: { one: makeSelectionResult() } } },
+    };
+
+    test("serves the last settled result when stage becomes undefined", () => {
+      mockGroupStage = closedStage;
+      const guide = makeGuide({ key: "g1" });
+      setSnapshot({
+        guideGroups: [makeGuideGroup(["g1"])],
+        guides: { g1: guide },
+      });
+
+      const { result, rerender } = renderHook(() =>
+        useInspectGuideClientStore(defaultRunConfig),
+      );
+      const firstResult = expectOk(result.current);
+      expect(
+        (firstResult.guides[0] as AnnotatedGuide).annotation.selectable.status,
+      ).toBe("returned");
+
+      // Simulate stage being cleared (e.g. after setDebug / setLocation).
+      mockGroupStage = undefined;
+      rerender();
+
+      const secondResult = expectOk(result.current);
+      expect(
+        (secondResult.guides[0] as AnnotatedGuide).annotation.selectable.status,
+      ).toBe("returned");
+      expect(secondResult.guides).toBe(firstResult.guides);
+    });
+
+    test("serves the last settled result when a new stage is 'open'", () => {
+      mockGroupStage = closedStage;
+      const guide = makeGuide({ key: "g1" });
+      setSnapshot({
+        guideGroups: [makeGuideGroup(["g1"])],
+        guides: { g1: guide },
+      });
+
+      const { result, rerender } = renderHook(() =>
+        useInspectGuideClientStore(defaultRunConfig),
+      );
+      const firstResult = expectOk(result.current);
+
+      // A new stage opens with empty results before resolving later.
+      mockGroupStage = {
+        status: "open",
+        ordered: [],
+        results: {},
+        timeoutId: null,
+      };
+      rerender();
+
+      const secondResult = expectOk(result.current);
+      expect(
+        (secondResult.guides[0] as AnnotatedGuide).annotation.selectable.status,
+      ).toBe("returned");
+      expect(secondResult.guides).toBe(firstResult.guides);
+    });
+
+    test("falls back to fresh (transient) result on first render with no prior settled stage", () => {
+      mockGroupStage = undefined;
+      const guide = makeGuide({ key: "g1" });
+      setSnapshot({
+        guideGroups: [makeGuideGroup(["g1"])],
+        guides: { g1: guide },
+      });
+
+      const result = expectOk(renderInspect());
+      // No cache yet — transient selectable status is shown as-is.
+      expect(
+        (result.guides[0] as AnnotatedGuide).annotation.selectable.status,
+      ).toBeUndefined();
+    });
+
+    test("refreshes cache when the stage settles again with different results", () => {
+      mockGroupStage = closedStage;
+      const guide = makeGuide({ key: "g1" });
+      setSnapshot({
+        guideGroups: [makeGuideGroup(["g1"])],
+        guides: { g1: guide },
+      });
+
+      const { result, rerender } = renderHook(() =>
+        useInspectGuideClientStore(defaultRunConfig),
+      );
+      expect(
+        (expectOk(result.current).guides[0] as AnnotatedGuide).annotation
+          .selectable.status,
+      ).toBe("returned");
+
+      // Transient window — serves cached "returned".
+      mockGroupStage = undefined;
+      rerender();
+      expect(
+        (expectOk(result.current).guides[0] as AnnotatedGuide).annotation
+          .selectable.status,
+      ).toBe("returned");
+
+      // Stage closes again with a different resolved guide — cache must
+      // refresh so the toolbar reflects the new state.
+      mockGroupStage = {
+        status: "closed",
+        ordered: ["g1", "other"],
+        resolved: "other",
+        timeoutId: null,
+        results: {
+          byKey: {
+            g1: { one: makeSelectionResult() },
+            other: { one: makeSelectionResult() },
+          },
+        },
+      };
+      rerender();
+
+      expect(
+        (expectOk(result.current).guides[0] as AnnotatedGuide).annotation
+          .selectable.status,
+      ).toBe("queried");
+    });
+  });
 });


### PR DESCRIPTION
### Description

This aims to address the "flickers" seen with the query status dots when navigating or moving focus, by caching the annotated guides and only re-annotating (and re-rendering in toolbar bar) when the guide client's group state resolution settles. This allows the toolbar to skip re-rendering during a transient/interim state in the guide client.




