### PR TITLE
fix: add a changeset for client and react to pick up #959

### DIFF
--- a/.changeset/rename-stage-results-keys.md
+++ b/.changeset/rename-stage-results-keys.md
@@ -1,0 +1,6 @@
+---
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+---
+
+[Guides] Rename stage results keys to `byKey` and `byType`


### PR DESCRIPTION
### Description

Adds a changeset that should've been included in #959, so that the `@knocklabs/client` package can be bumped and the `@knocklabs/react` package uses the updated package and picks up the latest changes in the client package.
