### PR TITLE
chore(ci): pin actions to SHAs and restrict default workflow permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,9 +18,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
@@ -44,13 +47,13 @@ jobs:
         run: yarn test:ci
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: knocklabs/javascript
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Checkout the PR branch for package.json analysis and committing.
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ steps.pr.outputs.ref }}
           token: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }}
@@ -55,14 +55,14 @@ jobs:
       # This ensures we never execute code from an untrusted PR branch
       # when triggered via workflow_dispatch.
       - name: Checkout trusted script from main
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
           sparse-checkout: .github/scripts
           path: .trusted
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
 

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -3,13 +3,16 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Install and build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
           cache: yarn
@@ -20,7 +23,7 @@ jobs:
       - name: Build packages
         run: yarn build:packages
       - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v8
+        uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e # 8.2.1
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-integration-tests:
     strategy:
@@ -17,9 +20,9 @@ jobs:
       INTEGRATION_KNOCK_FEED_ID: ${{ secrets.INTEGRATION_KNOCK_FEED_ID }}
     steps:
       - name: Checkout Latest
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
           cache: "yarn"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # Checkout the repository with full history and tag data so that
       # Changesets can generate changelogs and tag new releases appropriately.
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -44,7 +44,7 @@ jobs:
       # Set up Node.js using the version specified in package.json,
       # and cache Yarn dependencies for faster installs.
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           registry-url: "https://registry.npmjs.org"
           node-version-file: "package.json"
@@ -115,7 +115,7 @@ jobs:
       # Create a versioning PR if changeset files exist, or publish packages
       # to npm if version bump commits have already been merged into the branch.
       - name: Create release PR or publish
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           commit: "chore(repo): version packages for ${{ steps.release-type.outputs.release-type }}"
           title: "chore(repo): version packages for ${{ steps.release-type.outputs.release-type }}"


### PR DESCRIPTION
### Description

Defense-in-depth hardening for the GitHub Actions setup, prompted by a review of the [TanStack npm supply-chain compromise postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem). Closes [KNO-13133](https://linear.app/knock/issue/KNO-13133/harden-github-actions-against-supply-chain-attacks-tanstack-style).

The repo is **not** vulnerable to the specific TanStack chain — we use neither `pull_request_target` nor OIDC trusted publishing, and `NPM_TOKEN` is only referenced in `release.yml` which runs on `push` to protected branches. This PR closes the two residual gaps the review surfaced.

**1. Pin every `uses:` reference to a commit SHA (with version comment).**
Tag-pinning means an action publisher compromise would execute attacker code with whatever permissions the surrounding job has — including `release.yml` where `NPM_TOKEN` is live. SHA pinning is the [GitHub-recommended](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) standard.

| Action | Pinned SHA | Version |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `codecov/codecov-action` | `75cd11691c0faa626561e295848008c8a7dddffe` | v5.5.4 |
| `codecov/test-results-action` | `0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3` | v1.2.1 |
| `expo/expo-github-action` | `c7b66a9c327a43a8fa7c0158e7f30d6040d2481e` | 8.2.1 |
| `changesets/action` | `63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b` | v1.8.0 |

**2. Add `permissions: contents: read` at workflow level** on the PR-triggered workflows (`cicd.yml`, `expo.yml`, `integration.yml`) so `GITHUB_TOKEN` defaults to read-only. Any job that needs more must opt in explicitly.

Skipped:
- `dependabot-changeset.yml` — already has its own explicit `permissions:` block
- `release.yml` — needs write access for `changesets/action`; runs only on push to protected branches


### Checklist
- [x] Format check passes (`yarn format:check`)
- [ ] PR CI passes on this branch (will verify after open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)