### PR TITLE
set up minimum package age 7 days for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@knocklabs/*"
+        - "@telegraph/*"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
### Description
- Adds `cooldown: default-days: 7` to the npm dependabot entry so version bump PRs wait until a release is at least 7 days old.
- Excludes `@knocklabs/*` and `@telegraph/*` so first-party packages still update immediately.
- Mirrors the policy from knocklabs/control#8356.

