### PR TITLE
chore: harden Yarn install scripts in the JS SDK

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,11 @@
+# Disable package build (install/postinstall) scripts by default. Install
+# scripts are the primary execution vector for npm supply-chain attacks, so we
+# deny them globally and allow-list only the packages that genuinely need to
+# compile or download a binary at install time. The allow-list lives in the
+# `dependenciesMeta` field of the root package.json (`built: true` per package);
+# Yarn 4 does not recognize `dependenciesMeta` as a .yarnrc.yml setting.
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.9.1.cjs

--- a/package.json
+++ b/package.json
@@ -40,6 +40,20 @@
       "INTERNAL_MISMATCH"
     ]
   },
+  "dependenciesMeta": {
+    "@swc/core": {
+      "built": true
+    },
+    "esbuild": {
+      "built": true
+    },
+    "sharp": {
+      "built": true
+    },
+    "unrs-resolver": {
+      "built": true
+    }
+  },
   "devDependencies": {
     "@changesets/cli": "^2.29.2",
     "@knocklabs/eslint-config": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5005,6 +5005,15 @@ __metadata:
     prettier: "npm:^3.5.3"
     turbo: "npm:^2.5.8"
     vitest: "npm:^3.2.4"
+  dependenciesMeta:
+    "@swc/core":
+      built: true
+    esbuild:
+      built: true
+    sharp:
+      built: true
+    unrs-resolver:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Hardens Yarn install-script execution in the monorepo to reduce supply-chain attack surface. Closes [KNO-13806](https://linear.app/knock/issue/KNO-13806/harden-yarn-install-scripts-in-the-js-sdk-disable-by-default-allow).

**Why.** Install/postinstall scripts are the primary execution vector for the recent wave of npm supply-chain attacks — Shai-Hulud and the nx, chalk, and debug compromises all ran their payloads through a postinstall script. The root `.yarnrc.yml` had no script hardening, so any installed package could run arbitrary code at install time, in CI and on contributor machines. As a published SDK, a compromised install step here would also flow out to every downstream consumer.

**What & how.**
- **`.yarnrc.yml`** → `enableScripts: false`: deny all dependency build scripts by default.
- **`package.json`** → a `dependenciesMeta` allow-list re-enables (`built: true`) only the packages that genuinely need to compile or download a binary at install time:
  - `@swc/core`, `esbuild` — build toolchain (required for `build:packages`)
  - `sharp` — native image processing (Next.js examples)
  - `unrs-resolver` — native module resolver behind `eslint-import-resolver-typescript` (required for `lint`)

`dependenciesMeta` lives in the manifest, **not** `.yarnrc.yml` — Yarn 4.9.1 does not recognize it as a yarnrc setting (verified via `yarn config` + the docs). The lockfile change is just Yarn recording that allow-list against the root workspace.

**Re-derived the allow-list from a fresh install** rather than trusting the proposed list. A clean install surfaced one extra package with an install script: **`msgpackr-extract`** (pulled in transitively by `@expo/metro-config`). It's left **denied** — it's example/dev tooling only, ships its native binary via a prebuilt-binary optional dependency (`@msgpackr-extract/msgpackr-extract-*`), and falls back to pure JS, so its postinstall doesn't need to run. That's the more-hardened choice and is explicitly sanctioned by the ticket ("only needed by examples or tooling … can stay denied").

**Verification — Yarn 4.9.1, all green locally:**
- Confirmed the open question from the ticket: `built: true` acts as an **allow-list override** of a global `enableScripts: false` (re-enables only the listed packages), not purely a deny-list.
- Fresh `yarn install` and `yarn install --immutable` (what CI runs): exactly the 4 allow-listed packages build; `msgpackr-extract` is denied with a warning (`YN0004`), not an error; no install errors; `yarn.lock` stays consistent under `--immutable`.
- Workspace lifecycle scripts are unaffected — the root `postinstall: manypkg check` still runs.
- `yarn format:check`, `yarn build:packages`, `yarn type:check`, `yarn lint`, and `yarn test` (74 files / 878 tests) all pass.

### Checklist
- [x] No tests added — config-only change to monorepo install tooling; no published package code changes (and therefore no changeset).