### PR TITLE
chore(react-core): internalize fast-deep-equal (KNO-13810)

### DIFF
--- a/.changeset/internalize-fast-deep-equal-react-core.md
+++ b/.changeset/internalize-fast-deep-equal-react-core.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+Internalize `fast-deep-equal` in `@knocklabs/react-core` with a small inlined deep-equality util and drop the runtime dependency, removing it from consumers' install graphs.

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -50,7 +50,6 @@
     "@knocklabs/client": "workspace:^",
     "@tanstack/react-store": "^0.7.3",
     "date-fns": "^4.0.0",
-    "fast-deep-equal": "^3.1.3",
     "swr": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/react-core/src/modules/core/deepEqual/index.ts
+++ b/packages/react-core/src/modules/core/deepEqual/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Deep structural equality check. Recursively compares primitives, plain
+ * objects, arrays, `Date`, and `RegExp` values. Does not special-case Map/Set.
+ */
+export default function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+
+  if (a && b && typeof a === "object" && typeof b === "object") {
+    const objA = a as Record<string, unknown>;
+    const objB = b as Record<string, unknown>;
+
+    if (objA.constructor !== objB.constructor) return false;
+
+    if (Array.isArray(a) && Array.isArray(b)) {
+      const length = a.length;
+      if (length !== b.length) return false;
+      for (let i = length; i-- !== 0; ) {
+        if (!deepEqual(a[i], b[i])) return false;
+      }
+      return true;
+    }
+
+    if (a.constructor === RegExp) {
+      const reA = a as RegExp;
+      const reB = b as RegExp;
+      return reA.source === reB.source && reA.flags === reB.flags;
+    }
+    if (objA.valueOf !== Object.prototype.valueOf) {
+      return objA.valueOf() === objB.valueOf();
+    }
+    if (objA.toString !== Object.prototype.toString) {
+      return objA.toString() === objB.toString();
+    }
+
+    const keys = Object.keys(objA);
+    const length = keys.length;
+    if (length !== Object.keys(objB).length) return false;
+
+    for (let i = length; i-- !== 0; ) {
+      if (!Object.prototype.hasOwnProperty.call(objB, keys[i]!)) return false;
+    }
+
+    for (let i = length; i-- !== 0; ) {
+      const key = keys[i]!;
+      if (!deepEqual(objA[key], objB[key])) return false;
+    }
+
+    return true;
+  }
+
+  // true if both NaN, false otherwise
+  return a !== a && b !== b;
+}

--- a/packages/react-core/src/modules/core/hooks/useStableOptions.ts
+++ b/packages/react-core/src/modules/core/hooks/useStableOptions.ts
@@ -1,5 +1,6 @@
-import fastDeepEqual from "fast-deep-equal";
 import { useMemo, useRef } from "react";
+
+import deepEqual from "../deepEqual";
 
 export default function useStableOptions<T>(options: T): T {
   const optionsRef = useRef<T>(undefined);
@@ -7,7 +8,7 @@ export default function useStableOptions<T>(options: T): T {
   return useMemo(() => {
     const currentOptions = optionsRef.current;
 
-    if (currentOptions && fastDeepEqual(options, currentOptions)) {
+    if (currentOptions && deepEqual(options, currentOptions)) {
       return currentOptions;
     }
 

--- a/packages/react-core/test/core/deepEqual.test.ts
+++ b/packages/react-core/test/core/deepEqual.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+
+import deepEqual from "../../src/modules/core/deepEqual";
+
+describe("deepEqual", () => {
+  test("treats identical references and equal primitives as equal", () => {
+    const obj = { a: 1 };
+    expect(deepEqual(obj, obj)).toBe(true);
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("a", "a")).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+  });
+
+  test("distinguishes differing primitives", () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("a", "b")).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(0, false)).toBe(false);
+  });
+
+  test("treats NaN as equal to NaN", () => {
+    expect(deepEqual(NaN, NaN)).toBe(true);
+  });
+
+  test("compares nested objects structurally", () => {
+    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true);
+    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 3 } })).toBe(false);
+  });
+
+  test("is independent of object key order", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+
+  test("distinguishes objects with differing key counts", () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  test("compares arrays by length and element", () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(deepEqual([{ a: 1 }], [{ a: 1 }])).toBe(true);
+  });
+
+  test("does not treat an array and an object as equal", () => {
+    expect(deepEqual([], {})).toBe(false);
+  });
+
+  test("compares Date values by time", () => {
+    expect(deepEqual(new Date("2020-01-01"), new Date("2020-01-01"))).toBe(
+      true,
+    );
+    expect(deepEqual(new Date("2020-01-01"), new Date("2021-01-01"))).toBe(
+      false,
+    );
+  });
+
+  test("compares RegExp values by source and flags", () => {
+    expect(deepEqual(/abc/gi, /abc/gi)).toBe(true);
+    expect(deepEqual(/abc/g, /abc/i)).toBe(false);
+    expect(deepEqual(/abc/, /abd/)).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5044,7 +5044,6 @@ __metadata:
     eslint: "npm:^8.56.0"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.5.2"
-    fast-deep-equal: "npm:^3.1.3"
     jsdom: "npm:^29.1.0"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"


### PR DESCRIPTION
### Description

Internalizes `fast-deep-equal` in `@knocklabs/react-core` and drops the runtime dependency. It is reimplemented as a small internal `deepEqual` (the default non-ES6 behavior: recursive comparison of primitives, plain objects, arrays, `Date`, and `RegExp`; no Map/Set special-casing).

**What changed**
- Added `packages/react-core/src/modules/core/deepEqual/` — a dedicated folder containing the `deepEqual` util.
- Repointed the single import in `useStableOptions.ts`.
- Added `packages/react-core/test/core/deepEqual.test.ts` covering primitives, `NaN`, nested objects/arrays, key-order independence, differing key counts, array-vs-object, `Date`, and `RegExp`.
- Dropped `fast-deep-equal` from `packages/react-core/package.json` and updated the lockfile.

`fast-deep-equal` remains in the lockfile only as a transitive dependency of `ajv` — it is no longer a direct dependency of ours.

**Why:** Part of the npm supply chain hardening effort. `@knocklabs/react-core` is published, so dropping the dependency also removes it from every consumer's install graph.

Linear: [KNO-13810](https://linear.app/knock/issue/KNO-13810)

---

**Stack** (bottom → top) — npm supply chain hardening:
1. #1020 — remove `clsx` from `@knocklabs/react`
2. #1021 — internalize `jwt-decode` in `@knocklabs/client`
3. #1022 — internalize `lodash.debounce` in `@knocklabs/react`
4. **#1023 — internalize `fast-deep-equal` in `@knocklabs/react-core`** ◀ this PR

### Checklist
- [x] Tests have been added (`test/core/deepEqual.test.ts`) and `useStableOptions.test.ts` passes against the internalized `deepEqual`.
