### PR TITLE
chore: internalize/remove bundled runtime dependencies

### DIFF
--- a/.changeset/internalize-debounce-react.md
+++ b/.changeset/internalize-debounce-react.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+Internalize `lodash.debounce` in `@knocklabs/react` with a small trailing-edge debounce util and drop the `lodash.debounce` runtime dependency (and its `@types/lodash.debounce` dev dependency).

--- a/.changeset/internalize-debounce-react.md
+++ b/.changeset/internalize-debounce-react.md
@@ -1,5 +1,0 @@
----
-"@knocklabs/react": patch
----
-
-Internalize `lodash.debounce` in `@knocklabs/react` with a small trailing-edge debounce util and drop the `lodash.debounce` runtime dependency (and its `@types/lodash.debounce` dev dependency).

--- a/.changeset/internalize-fast-deep-equal-react-core.md
+++ b/.changeset/internalize-fast-deep-equal-react-core.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-core": patch
+---
+
+Internalize `fast-deep-equal` in `@knocklabs/react-core` with a small inlined deep-equality util and drop the runtime dependency, removing it from consumers' install graphs.

--- a/.changeset/internalize-fast-deep-equal-react-core.md
+++ b/.changeset/internalize-fast-deep-equal-react-core.md
@@ -2,4 +2,4 @@
 "@knocklabs/react-core": patch
 ---
 
-Internalize `fast-deep-equal` in `@knocklabs/react-core` with a small inlined deep-equality util and drop the runtime dependency, removing it from consumers' install graphs.
+Remove the `fast-deep-equal` dependency in favor of an internal `deepEqual` util.

--- a/.changeset/internalize-jwt-decode-client.md
+++ b/.changeset/internalize-jwt-decode-client.md
@@ -2,4 +2,4 @@
 "@knocklabs/client": patch
 ---
 
-Internalize `jwt-decode` in `@knocklabs/client` and drop the runtime dependency. Token decoding now uses a small inlined decoder, removing the package from consumers' install graphs.
+Remove the `jwt-decode` dependency in favor of an internal JWT payload decoder.

--- a/.changeset/internalize-jwt-decode-client.md
+++ b/.changeset/internalize-jwt-decode-client.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+Internalize `jwt-decode` in `@knocklabs/client` and drop the runtime dependency. Token decoding now uses a small inlined decoder, removing the package from consumers' install graphs.

--- a/.changeset/react-internalize-runtime-deps.md
+++ b/.changeset/react-internalize-runtime-deps.md
@@ -2,4 +2,4 @@
 "@knocklabs/react": patch
 ---
 
-Remove the `clsx` and `lodash.debounce` dependencies. Guide components now compose `className` natively, and an internal trailing-edge debounce replaces `lodash.debounce`.
+Remove the `clsx` and `lodash.debounce` dependencies. Guide components compose `className` with a small internal `cx` helper, and an internal trailing-edge debounce replaces `lodash.debounce`.

--- a/.changeset/react-internalize-runtime-deps.md
+++ b/.changeset/react-internalize-runtime-deps.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+Remove the `clsx` and `lodash.debounce` dependencies. Guide components now compose `className` natively, and an internal trailing-edge debounce replaces `lodash.debounce`.

--- a/.changeset/remove-clsx-from-react.md
+++ b/.changeset/remove-clsx-from-react.md
@@ -1,5 +1,0 @@
----
-"@knocklabs/react": patch
----
-
-Remove the `clsx` runtime dependency from `@knocklabs/react`. The guide components now compose `className` natively, dropping `clsx` from the package's install graph.

--- a/.changeset/remove-clsx-from-react.md
+++ b/.changeset/remove-clsx-from-react.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react": patch
+---
+
+Remove the `clsx` runtime dependency from `@knocklabs/react`. The guide components now compose `className` natively, dropping `clsx` from the package's install graph.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -75,7 +75,6 @@
     "axios": "^1.15.1",
     "axios-retry": "^4.5.0",
     "eventemitter2": "^6.4.5",
-    "jwt-decode": "^4.0.0",
     "nanoid": "^3.3.12",
     "phoenix": "1.8.5",
     "urlpattern-polyfill": "^10.0.0"

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { GenericData } from "@knocklabs/types";
-import { JwtPayload } from "jwt-decode";
 
+import { JwtPayload } from "./jwt";
 import Knock from "./knock";
 
 export type LogLevel = "debug";

--- a/packages/client/src/jwt/index.ts
+++ b/packages/client/src/jwt/index.ts
@@ -3,7 +3,7 @@
  * it as JSON. This does not verify the token signature.
  */
 
-export interface JwtPayload {
+export type JwtPayload = {
   iss?: string;
   sub?: string;
   aud?: string | string[];
@@ -11,46 +11,47 @@ export interface JwtPayload {
   nbf?: number;
   iat?: number;
   jti?: string;
-}
+};
 
 export class InvalidTokenError extends Error {}
 InvalidTokenError.prototype.name = "InvalidTokenError";
 
-function b64DecodeUnicode(str: string): string {
+const b64DecodeUnicode = (str: string): string => {
   return decodeURIComponent(
     atob(str).replace(/(.)/g, (char) => {
-      let code = char.charCodeAt(0).toString(16).toUpperCase();
-      if (code.length < 2) {
-        code = "0" + code;
-      }
-      return "%" + code;
+      const code = char.charCodeAt(0).toString(16).toUpperCase();
+      return "%" + code.padStart(2, "0");
     }),
   );
-}
+};
 
-function base64UrlDecode(str: string): string {
-  let output = str.replace(/-/g, "+").replace(/_/g, "/");
-  switch (output.length % 4) {
-    case 0:
-      break;
-    case 2:
-      output += "==";
-      break;
-    case 3:
-      output += "=";
-      break;
-    default:
-      throw new Error("base64 string is not of the correct length");
+const base64UrlDecode = (str: string): string => {
+  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const remainder = base64.length % 4;
+  if (remainder === 1) {
+    throw new Error("base64 string is not of the correct length");
   }
+  const padded = base64 + "=".repeat((4 - remainder) % 4);
 
   try {
-    return b64DecodeUnicode(output);
+    return b64DecodeUnicode(padded);
   } catch {
-    return atob(output);
+    return atob(padded);
   }
-}
+};
 
-export function jwtDecode<T = JwtPayload>(token: string): T {
+const decodePayloadSegment = (part: string): string => {
+  try {
+    return base64UrlDecode(part);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new InvalidTokenError(
+      `Invalid token specified: invalid base64 for part #2 (${message})`,
+    );
+  }
+};
+
+export const jwtDecode = <T = JwtPayload>(token: string): T => {
   if (typeof token !== "string") {
     throw new InvalidTokenError("Invalid token specified: must be a string");
   }
@@ -62,15 +63,7 @@ export function jwtDecode<T = JwtPayload>(token: string): T {
     throw new InvalidTokenError("Invalid token specified: missing part #2");
   }
 
-  let decoded: string;
-  try {
-    decoded = base64UrlDecode(part);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    throw new InvalidTokenError(
-      `Invalid token specified: invalid base64 for part #2 (${message})`,
-    );
-  }
+  const decoded = decodePayloadSegment(part);
 
   try {
     return JSON.parse(decoded) as T;
@@ -80,4 +73,4 @@ export function jwtDecode<T = JwtPayload>(token: string): T {
       `Invalid token specified: invalid json for part #2 (${message})`,
     );
   }
-}
+};

--- a/packages/client/src/jwt/index.ts
+++ b/packages/client/src/jwt/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Decodes a JWT payload by base64url-decoding the second segment and parsing
+ * it as JSON. This does not verify the token signature.
+ */
+
+export interface JwtPayload {
+  iss?: string;
+  sub?: string;
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  jti?: string;
+}
+
+export class InvalidTokenError extends Error {}
+InvalidTokenError.prototype.name = "InvalidTokenError";
+
+function b64DecodeUnicode(str: string): string {
+  return decodeURIComponent(
+    atob(str).replace(/(.)/g, (char) => {
+      let code = char.charCodeAt(0).toString(16).toUpperCase();
+      if (code.length < 2) {
+        code = "0" + code;
+      }
+      return "%" + code;
+    }),
+  );
+}
+
+function base64UrlDecode(str: string): string {
+  let output = str.replace(/-/g, "+").replace(/_/g, "/");
+  switch (output.length % 4) {
+    case 0:
+      break;
+    case 2:
+      output += "==";
+      break;
+    case 3:
+      output += "=";
+      break;
+    default:
+      throw new Error("base64 string is not of the correct length");
+  }
+
+  try {
+    return b64DecodeUnicode(output);
+  } catch {
+    return atob(output);
+  }
+}
+
+export function jwtDecode<T = JwtPayload>(token: string): T {
+  if (typeof token !== "string") {
+    throw new InvalidTokenError("Invalid token specified: must be a string");
+  }
+
+  // The payload is the second segment of the JWT (header.payload.signature).
+  const part = token.split(".")[1];
+
+  if (typeof part !== "string") {
+    throw new InvalidTokenError("Invalid token specified: missing part #2");
+  }
+
+  let decoded: string;
+  try {
+    decoded = base64UrlDecode(part);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new InvalidTokenError(
+      `Invalid token specified: invalid base64 for part #2 (${message})`,
+    );
+  }
+
+  try {
+    return JSON.parse(decoded) as T;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new InvalidTokenError(
+      `Invalid token specified: invalid json for part #2 (${message})`,
+    );
+  }
+}

--- a/packages/client/src/knock.ts
+++ b/packages/client/src/knock.ts
@@ -1,5 +1,3 @@
-import { jwtDecode } from "jwt-decode";
-
 import ApiClient from "./api";
 import FeedClient from "./clients/feed";
 import MessageClient from "./clients/messages";
@@ -16,6 +14,7 @@ import {
   UserIdOrUserWithProperties,
   UserTokenExpiringCallback,
 } from "./interfaces";
+import { jwtDecode } from "./jwt";
 
 const DEFAULT_HOST = "https://api.knock.app";
 

--- a/packages/client/test/jwt.test.ts
+++ b/packages/client/test/jwt.test.ts
@@ -4,13 +4,13 @@ import { InvalidTokenError, jwtDecode } from "../src/jwt";
 
 // Builds a JWT-shaped string for the given payload. Only the payload segment
 // is meaningful to `jwtDecode`; the header and signature are placeholders.
-function encodeToken(payload: Record<string, unknown>): string {
+const encodeToken = (payload: Record<string, unknown>): string => {
   const header = Buffer.from(
     JSON.stringify({ alg: "HS256", typ: "JWT" }),
   ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   return `${header}.${body}.signature`;
-}
+};
 
 describe("jwtDecode", () => {
   test("decodes standard registered claims", () => {
@@ -43,13 +43,14 @@ describe("jwtDecode", () => {
     expect(decoded.name).toBe("José Ünïcode 🚀");
   });
 
-  test("decodes base64url payloads regardless of length (padding)", () => {
-    // Vary payload length to exercise each `length % 4` padding branch.
-    for (const id of ["a", "ab", "abc", "abcd"]) {
+  // Vary payload length to exercise each `length % 4` padding branch.
+  test.each(["a", "ab", "abc", "abcd"])(
+    "decodes a base64url payload of length %s (padding)",
+    (id) => {
       const decoded = jwtDecode<{ id: string }>(encodeToken({ id }));
       expect(decoded.id).toBe(id);
-    }
-  });
+    },
+  );
 
   test("throws InvalidTokenError when the token is not a string", () => {
     // @ts-expect-error - exercising the runtime guard against non-string input

--- a/packages/client/test/jwt.test.ts
+++ b/packages/client/test/jwt.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+
+import { InvalidTokenError, jwtDecode } from "../src/jwt";
+
+// Builds a JWT-shaped string for the given payload. Only the payload segment
+// is meaningful to `jwtDecode`; the header and signature are placeholders.
+function encodeToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.signature`;
+}
+
+describe("jwtDecode", () => {
+  test("decodes standard registered claims", () => {
+    const token = encodeToken({
+      sub: "user_123",
+      exp: 9999999999,
+      iat: 1516239022,
+    });
+
+    const decoded = jwtDecode(token);
+
+    expect(decoded.sub).toBe("user_123");
+    expect(decoded.exp).toBe(9999999999);
+    expect(decoded.iat).toBe(1516239022);
+  });
+
+  test("decodes custom claims via a type parameter", () => {
+    const token = encodeToken({ sub: "user_123", role: "admin" });
+
+    const decoded = jwtDecode<{ sub: string; role: string }>(token);
+
+    expect(decoded).toEqual({ sub: "user_123", role: "admin" });
+  });
+
+  test("decodes payloads containing unicode characters", () => {
+    const token = encodeToken({ name: "José Ünïcode 🚀" });
+
+    const decoded = jwtDecode<{ name: string }>(token);
+
+    expect(decoded.name).toBe("José Ünïcode 🚀");
+  });
+
+  test("decodes base64url payloads regardless of length (padding)", () => {
+    // Vary payload length to exercise each `length % 4` padding branch.
+    for (const id of ["a", "ab", "abc", "abcd"]) {
+      const decoded = jwtDecode<{ id: string }>(encodeToken({ id }));
+      expect(decoded.id).toBe(id);
+    }
+  });
+
+  test("throws InvalidTokenError when the token is not a string", () => {
+    // @ts-expect-error - exercising the runtime guard against non-string input
+    expect(() => jwtDecode(undefined)).toThrow(InvalidTokenError);
+  });
+
+  test("throws InvalidTokenError when the payload segment is missing", () => {
+    expect(() => jwtDecode("only-one-segment")).toThrow(InvalidTokenError);
+  });
+
+  test("throws InvalidTokenError when the payload is not valid JSON", () => {
+    const notJson = Buffer.from("not json").toString("base64url");
+
+    expect(() => jwtDecode(`header.${notJson}.signature`)).toThrow(
+      InvalidTokenError,
+    );
+  });
+});

--- a/packages/client/test/jwt.test.ts
+++ b/packages/client/test/jwt.test.ts
@@ -68,4 +68,17 @@ describe("jwtDecode", () => {
       InvalidTokenError,
     );
   });
+
+  test("throws InvalidTokenError when the payload has an invalid base64 length", () => {
+    // A 5-character segment can never be valid base64 (length % 4 === 1).
+    expect(() => jwtDecode("header.abcde.signature")).toThrow(
+      InvalidTokenError,
+    );
+  });
+
+  test("falls back to raw base64 for payloads that are not valid UTF-8", () => {
+    // "_w" base64url-decodes to the byte 0xFF (invalid UTF-8), so the decoder
+    // falls back to atob; the decoded value is not valid JSON, so it throws.
+    expect(() => jwtDecode("header._w.signature")).toThrow(InvalidTokenError);
+  });
 });

--- a/packages/client/test/knock.test.ts
+++ b/packages/client/test/knock.test.ts
@@ -1,15 +1,15 @@
-import { jwtDecode } from "jwt-decode";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { jwtDecode } from "../src/jwt";
 import Knock from "../src/knock";
 
 import { authenticateKnock, createMockKnock } from "./test-utils/mocks";
 
 const TEST_BRANCH_SLUG = "lorem-ipsum-dolor-branch";
 
-// ✅ Mock the named export `jwtDecode` from the "jwt-decode" module.
+// ✅ Mock the named export `jwtDecode` from the internal jwt module.
 // It will always return a decoded token with an `exp` 61 seconds in the future.
-vi.mock("jwt-decode", () => ({
+vi.mock("../src/jwt", () => ({
   jwtDecode: vi.fn(() => ({
     exp: Math.floor(Date.now() / 1000) + 61,
   })),

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -50,7 +50,6 @@
     "@knocklabs/client": "workspace:^",
     "@tanstack/react-store": "^0.7.3",
     "date-fns": "^4.0.0",
-    "fast-deep-equal": "^3.1.3",
     "swr": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/react-core/src/modules/core/deepEqual/index.ts
+++ b/packages/react-core/src/modules/core/deepEqual/index.ts
@@ -2,7 +2,7 @@
  * Deep structural equality check. Recursively compares primitives, plain
  * objects, arrays, `Date`, and `RegExp` values. Does not special-case Map/Set.
  */
-export default function deepEqual(a: unknown, b: unknown): boolean {
+export const deepEqual = (a: unknown, b: unknown): boolean => {
   if (a === b) return true;
 
   if (a && b && typeof a === "object" && typeof b === "object") {
@@ -12,12 +12,9 @@ export default function deepEqual(a: unknown, b: unknown): boolean {
     if (objA.constructor !== objB.constructor) return false;
 
     if (Array.isArray(a) && Array.isArray(b)) {
-      const length = a.length;
-      if (length !== b.length) return false;
-      for (let i = length; i-- !== 0; ) {
-        if (!deepEqual(a[i], b[i])) return false;
-      }
-      return true;
+      return (
+        a.length === b.length && a.every((value, i) => deepEqual(value, b[i]))
+      );
     }
 
     if (a.constructor === RegExp) {
@@ -33,21 +30,15 @@ export default function deepEqual(a: unknown, b: unknown): boolean {
     }
 
     const keys = Object.keys(objA);
-    const length = keys.length;
-    if (length !== Object.keys(objB).length) return false;
+    if (keys.length !== Object.keys(objB).length) return false;
 
-    for (let i = length; i-- !== 0; ) {
-      if (!Object.prototype.hasOwnProperty.call(objB, keys[i]!)) return false;
-    }
-
-    for (let i = length; i-- !== 0; ) {
-      const key = keys[i]!;
-      if (!deepEqual(objA[key], objB[key])) return false;
-    }
-
-    return true;
+    return keys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(objB, key) &&
+        deepEqual(objA[key], objB[key]),
+    );
   }
 
   // true if both NaN, false otherwise
   return a !== a && b !== b;
-}
+};

--- a/packages/react-core/src/modules/core/deepEqual/index.ts
+++ b/packages/react-core/src/modules/core/deepEqual/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Deep structural equality check. Recursively compares primitives, plain
+ * objects, arrays, `Date`, and `RegExp` values. Does not special-case Map/Set.
+ */
+export default function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+
+  if (a && b && typeof a === "object" && typeof b === "object") {
+    const objA = a as Record<string, unknown>;
+    const objB = b as Record<string, unknown>;
+
+    if (objA.constructor !== objB.constructor) return false;
+
+    if (Array.isArray(a) && Array.isArray(b)) {
+      const length = a.length;
+      if (length !== b.length) return false;
+      for (let i = length; i-- !== 0; ) {
+        if (!deepEqual(a[i], b[i])) return false;
+      }
+      return true;
+    }
+
+    if (a.constructor === RegExp) {
+      const reA = a as RegExp;
+      const reB = b as RegExp;
+      return reA.source === reB.source && reA.flags === reB.flags;
+    }
+    if (objA.valueOf !== Object.prototype.valueOf) {
+      return objA.valueOf() === objB.valueOf();
+    }
+    if (objA.toString !== Object.prototype.toString) {
+      return objA.toString() === objB.toString();
+    }
+
+    const keys = Object.keys(objA);
+    const length = keys.length;
+    if (length !== Object.keys(objB).length) return false;
+
+    for (let i = length; i-- !== 0; ) {
+      if (!Object.prototype.hasOwnProperty.call(objB, keys[i]!)) return false;
+    }
+
+    for (let i = length; i-- !== 0; ) {
+      const key = keys[i]!;
+      if (!deepEqual(objA[key], objB[key])) return false;
+    }
+
+    return true;
+  }
+
+  // true if both NaN, false otherwise
+  return a !== a && b !== b;
+}

--- a/packages/react-core/src/modules/core/hooks/useStableOptions.ts
+++ b/packages/react-core/src/modules/core/hooks/useStableOptions.ts
@@ -1,6 +1,6 @@
 import { useMemo, useRef } from "react";
 
-import deepEqual from "../deepEqual";
+import { deepEqual } from "../deepEqual";
 
 export default function useStableOptions<T>(options: T): T {
   const optionsRef = useRef<T>(undefined);

--- a/packages/react-core/src/modules/core/hooks/useStableOptions.ts
+++ b/packages/react-core/src/modules/core/hooks/useStableOptions.ts
@@ -1,5 +1,6 @@
-import fastDeepEqual from "fast-deep-equal";
 import { useMemo, useRef } from "react";
+
+import deepEqual from "../deepEqual";
 
 export default function useStableOptions<T>(options: T): T {
   const optionsRef = useRef<T>(undefined);
@@ -7,7 +8,7 @@ export default function useStableOptions<T>(options: T): T {
   return useMemo(() => {
     const currentOptions = optionsRef.current;
 
-    if (currentOptions && fastDeepEqual(options, currentOptions)) {
+    if (currentOptions && deepEqual(options, currentOptions)) {
       return currentOptions;
     }
 

--- a/packages/react-core/test/core/deepEqual.test.ts
+++ b/packages/react-core/test/core/deepEqual.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import deepEqual from "../../src/modules/core/deepEqual";
+import { deepEqual } from "../../src/modules/core/deepEqual";
 
 describe("deepEqual", () => {
   test("treats identical references and equal primitives as equal", () => {

--- a/packages/react-core/test/core/deepEqual.test.ts
+++ b/packages/react-core/test/core/deepEqual.test.ts
@@ -62,4 +62,11 @@ describe("deepEqual", () => {
     expect(deepEqual(/abc/g, /abc/i)).toBe(false);
     expect(deepEqual(/abc/, /abd/)).toBe(false);
   });
+
+  test("compares objects with a custom toString but default valueOf", () => {
+    const tag = (label: string) => ({ toString: () => label });
+
+    expect(deepEqual(tag("x"), tag("x"))).toBe(true);
+    expect(deepEqual(tag("x"), tag("y"))).toBe(false);
+  });
 });

--- a/packages/react-core/test/core/deepEqual.test.ts
+++ b/packages/react-core/test/core/deepEqual.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+
+import deepEqual from "../../src/modules/core/deepEqual";
+
+describe("deepEqual", () => {
+  test("treats identical references and equal primitives as equal", () => {
+    const obj = { a: 1 };
+    expect(deepEqual(obj, obj)).toBe(true);
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("a", "a")).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+  });
+
+  test("distinguishes differing primitives", () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("a", "b")).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(0, false)).toBe(false);
+  });
+
+  test("treats NaN as equal to NaN", () => {
+    expect(deepEqual(NaN, NaN)).toBe(true);
+  });
+
+  test("compares nested objects structurally", () => {
+    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true);
+    expect(deepEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 3 } })).toBe(false);
+  });
+
+  test("is independent of object key order", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+
+  test("distinguishes objects with differing key counts", () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  test("compares arrays by length and element", () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(deepEqual([{ a: 1 }], [{ a: 1 }])).toBe(true);
+  });
+
+  test("does not treat an array and an object as equal", () => {
+    expect(deepEqual([], {})).toBe(false);
+  });
+
+  test("compares Date values by time", () => {
+    expect(deepEqual(new Date("2020-01-01"), new Date("2020-01-01"))).toBe(
+      true,
+    );
+    expect(deepEqual(new Date("2020-01-01"), new Date("2021-01-01"))).toBe(
+      false,
+    );
+  });
+
+  test("compares RegExp values by source and flags", () => {
+    expect(deepEqual(/abc/gi, /abc/gi)).toBe(true);
+    expect(deepEqual(/abc/g, /abc/i)).toBe(false);
+    expect(deepEqual(/abc/, /abd/)).toBe(false);
+  });
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -88,7 +88,6 @@
     "@telegraph/tokens": ">=0.2.0",
     "@telegraph/tooltip": ">=0.2.2",
     "@telegraph/typography": ">=0.4.0",
-    "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.544.0"
   },
   "devDependencies": {
@@ -98,7 +97,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/eslint-plugin-jsx-a11y": "^6",
-    "@types/lodash.debounce": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.1.6",
     "@typescript-eslint/eslint-plugin": "^8.59.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -88,7 +88,6 @@
     "@telegraph/tokens": ">=0.2.0",
     "@telegraph/tooltip": ">=0.2.2",
     "@telegraph/typography": ">=0.4.0",
-    "clsx": "^2.1.1",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.544.0"
   },

--- a/packages/react/src/modules/core/cx/index.ts
+++ b/packages/react/src/modules/core/cx/index.ts
@@ -1,0 +1,9 @@
+type ClassValue = string | false | null | undefined;
+
+/**
+ * Joins truthy class names into a space-separated string, e.g.
+ * `cx("knock-guide-banner", className)`. Falsy values are dropped, so
+ * conditional modifiers work too: `cx("btn", isActive && "btn--active")`.
+ */
+export const cx = (...classes: ClassValue[]): string =>
+  classes.filter((value): value is string => Boolean(value)).join(" ");

--- a/packages/react/src/modules/core/debounce/index.ts
+++ b/packages/react/src/modules/core/debounce/index.ts
@@ -1,0 +1,35 @@
+type DebouncedFunction<TArgs extends unknown[]> = {
+  (...args: TArgs): void;
+  cancel: () => void;
+};
+
+/**
+ * Minimal trailing-edge debounce, replacing `lodash.debounce` for our single
+ * use case (no `leading`/`maxWait` options). Invokes `func` once `wait`
+ * milliseconds have elapsed since the last call.
+ */
+export const debounce = <TArgs extends unknown[]>(
+  func: (...args: TArgs) => void,
+  wait = 0,
+): DebouncedFunction<TArgs> => {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const debounced = (...args: TArgs) => {
+    if (timeout !== null) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      timeout = null;
+      func(...args);
+    }, wait);
+  };
+
+  debounced.cancel = () => {
+    if (timeout !== null) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
+
+  return debounced;
+};

--- a/packages/react/src/modules/core/hooks/useOnBottomScroll.ts
+++ b/packages/react/src/modules/core/hooks/useOnBottomScroll.ts
@@ -1,5 +1,6 @@
-import debounce from "lodash.debounce";
 import { RefObject, useCallback, useEffect, useMemo } from "react";
+
+import { debounce } from "../debounce";
 
 type OnBottomScrollOptions = {
   ref: RefObject<HTMLDivElement | null>;

--- a/packages/react/src/modules/guide/components/Banner/Banner.tsx
+++ b/packages/react/src/modules/guide/components/Banner/Banner.tsx
@@ -1,5 +1,4 @@
 import { ColorMode, useGuide } from "@knocklabs/react-core";
-import clsx from "clsx";
 import React from "react";
 
 import { maybeNavigateToUrlWithDelay } from "../helpers";
@@ -13,7 +12,10 @@ const Root: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-banner", className)} {...props}>
+    <div
+      className={["knock-guide-banner", className].filter(Boolean).join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -24,7 +26,12 @@ const Content: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-banner__message", className)} {...props}>
+    <div
+      className={["knock-guide-banner__message", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -35,7 +42,12 @@ const Title: React.FC<
   { title: string } & React.ComponentPropsWithRef<"div">
 > = ({ title, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-banner__title", className)} {...props}>
+    <div
+      className={["knock-guide-banner__title", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {title}
     </div>
   );
@@ -49,7 +61,9 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
 }) => {
   return (
     <div
-      className={clsx("knock-guide-banner__body", className)}
+      className={["knock-guide-banner__body", className]
+        .filter(Boolean)
+        .join(" ")}
       dangerouslySetInnerHTML={{ __html: body }}
       {...props}
     />
@@ -61,7 +75,12 @@ const Actions: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-banner__actions", className)} {...props}>
+    <div
+      className={["knock-guide-banner__actions", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -73,7 +92,9 @@ const PrimaryButton: React.FC<
 > = ({ text, action, className, ...props }) => {
   return (
     <button
-      className={clsx("knock-guide-banner__action", className)}
+      className={["knock-guide-banner__action", className]
+        .filter(Boolean)
+        .join(" ")}
       {...props}
     >
       {text}
@@ -87,10 +108,12 @@ const SecondaryButton: React.FC<
 > = ({ text, action, className, ...props }) => {
   return (
     <button
-      className={clsx(
+      className={[
         "knock-guide-banner__action knock-guide-banner__action--secondary",
         className,
-      )}
+      ]
+        .filter(Boolean)
+        .join(" ")}
       {...props}
     >
       {text}
@@ -104,7 +127,12 @@ const DismissButton: React.FC<React.ComponentPropsWithRef<"button">> = ({
   ...props
 }) => {
   return (
-    <button className={clsx("knock-guide-banner__close", className)} {...props}>
+    <button
+      className={["knock-guide-banner__close", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="18"

--- a/packages/react/src/modules/guide/components/Banner/Banner.tsx
+++ b/packages/react/src/modules/guide/components/Banner/Banner.tsx
@@ -1,6 +1,7 @@
 import { ColorMode, useGuide } from "@knocklabs/react-core";
 import React from "react";
 
+import { cx } from "../../../core/cx";
 import { maybeNavigateToUrlWithDelay } from "../helpers";
 import { ButtonContent, TargetButton, TargetButtonWithGuide } from "../types";
 
@@ -12,10 +13,7 @@ const Root: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-banner", className].filter(Boolean).join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-banner", className)} {...props}>
       {children}
     </div>
   );
@@ -26,12 +24,7 @@ const Content: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-banner__message", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-banner__message", className)} {...props}>
       {children}
     </div>
   );
@@ -42,12 +35,7 @@ const Title: React.FC<
   { title: string } & React.ComponentPropsWithRef<"div">
 > = ({ title, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-banner__title", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-banner__title", className)} {...props}>
       {title}
     </div>
   );
@@ -61,9 +49,7 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
 }) => {
   return (
     <div
-      className={["knock-guide-banner__body", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={cx("knock-guide-banner__body", className)}
       dangerouslySetInnerHTML={{ __html: body }}
       {...props}
     />
@@ -75,12 +61,7 @@ const Actions: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-banner__actions", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-banner__actions", className)} {...props}>
       {children}
     </div>
   );
@@ -91,12 +72,7 @@ const PrimaryButton: React.FC<
   ButtonContent & React.ComponentPropsWithRef<"button">
 > = ({ text, action, className, ...props }) => {
   return (
-    <button
-      className={["knock-guide-banner__action", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <button className={cx("knock-guide-banner__action", className)} {...props}>
       {text}
     </button>
   );
@@ -108,12 +84,10 @@ const SecondaryButton: React.FC<
 > = ({ text, action, className, ...props }) => {
   return (
     <button
-      className={[
+      className={cx(
         "knock-guide-banner__action knock-guide-banner__action--secondary",
         className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
+      )}
       {...props}
     >
       {text}
@@ -127,12 +101,7 @@ const DismissButton: React.FC<React.ComponentPropsWithRef<"button">> = ({
   ...props
 }) => {
   return (
-    <button
-      className={["knock-guide-banner__close", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <button className={cx("knock-guide-banner__close", className)} {...props}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="18"

--- a/packages/react/src/modules/guide/components/Card/Card.tsx
+++ b/packages/react/src/modules/guide/components/Card/Card.tsx
@@ -1,5 +1,4 @@
 import { ColorMode, useGuide } from "@knocklabs/react-core";
-import clsx from "clsx";
 import React from "react";
 
 import { isValidHttpUrl, maybeNavigateToUrlWithDelay } from "../helpers";
@@ -20,7 +19,10 @@ const Root: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-card", className)} {...props}>
+    <div
+      className={["knock-guide-card", className].filter(Boolean).join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -31,7 +33,12 @@ const Content: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-card__message", className)} {...props}>
+    <div
+      className={["knock-guide-card__message", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -42,7 +49,12 @@ const Header: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-card__header", className)} {...props}>
+    <div
+      className={["knock-guide-card__header", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -53,7 +65,12 @@ const Headline: React.FC<
   { headline: string } & React.ComponentPropsWithRef<"div">
 > = ({ headline, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-card__headline", className)} {...props}>
+    <div
+      className={["knock-guide-card__headline", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {headline}
     </div>
   );
@@ -64,7 +81,12 @@ const Title: React.FC<
   { title: string } & React.ComponentPropsWithRef<"div">
 > = ({ title, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-card__title", className)} {...props}>
+    <div
+      className={["knock-guide-card__title", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {title}
     </div>
   );
@@ -78,7 +100,9 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
 }) => {
   return (
     <div
-      className={clsx("knock-guide-card__body", className)}
+      className={["knock-guide-card__body", className]
+        .filter(Boolean)
+        .join(" ")}
       dangerouslySetInnerHTML={{ __html: body }}
       {...props}
     />
@@ -91,7 +115,7 @@ const Img: React.FC<
 > = ({ children, className, alt, ...props }) => {
   return (
     <img
-      className={clsx("knock-guide-card__img", className)}
+      className={["knock-guide-card__img", className].filter(Boolean).join(" ")}
       alt={alt || ""}
       {...props}
     >
@@ -105,7 +129,12 @@ const Actions: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-card__actions", className)} {...props}>
+    <div
+      className={["knock-guide-card__actions", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -116,7 +145,12 @@ const PrimaryButton: React.FC<
   ButtonContent & React.ComponentPropsWithRef<"button">
 > = ({ text, action, className, ...props }) => {
   return (
-    <button className={clsx("knock-guide-card__action", className)} {...props}>
+    <button
+      className={["knock-guide-card__action", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {text}
     </button>
   );
@@ -128,10 +162,12 @@ const SecondaryButton: React.FC<
 > = ({ text, action, className, ...props }) => {
   return (
     <button
-      className={clsx(
+      className={[
         "knock-guide-card__action knock-guide-card__action--secondary",
         className,
-      )}
+      ]
+        .filter(Boolean)
+        .join(" ")}
       {...props}
     >
       {text}
@@ -145,7 +181,12 @@ const DismissButton: React.FC<React.ComponentPropsWithRef<"button">> = ({
   ...props
 }) => {
   return (
-    <button className={clsx("knock-guide-card__close", className)} {...props}>
+    <button
+      className={["knock-guide-card__close", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="18"

--- a/packages/react/src/modules/guide/components/Card/Card.tsx
+++ b/packages/react/src/modules/guide/components/Card/Card.tsx
@@ -1,6 +1,7 @@
 import { ColorMode, useGuide } from "@knocklabs/react-core";
 import React from "react";
 
+import { cx } from "../../../core/cx";
 import { isValidHttpUrl, maybeNavigateToUrlWithDelay } from "../helpers";
 import {
   ButtonContent,
@@ -19,10 +20,7 @@ const Root: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-card", className].filter(Boolean).join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-card", className)} {...props}>
       {children}
     </div>
   );
@@ -33,12 +31,7 @@ const Content: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-card__message", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-card__message", className)} {...props}>
       {children}
     </div>
   );
@@ -49,12 +42,7 @@ const Header: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-card__header", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-card__header", className)} {...props}>
       {children}
     </div>
   );
@@ -65,12 +53,7 @@ const Headline: React.FC<
   { headline: string } & React.ComponentPropsWithRef<"div">
 > = ({ headline, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-card__headline", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-card__headline", className)} {...props}>
       {headline}
     </div>
   );
@@ -81,12 +64,7 @@ const Title: React.FC<
   { title: string } & React.ComponentPropsWithRef<"div">
 > = ({ title, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-card__title", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-card__title", className)} {...props}>
       {title}
     </div>
   );
@@ -100,9 +78,7 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
 }) => {
   return (
     <div
-      className={["knock-guide-card__body", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={cx("knock-guide-card__body", className)}
       dangerouslySetInnerHTML={{ __html: body }}
       {...props}
     />
@@ -115,7 +91,7 @@ const Img: React.FC<
 > = ({ children, className, alt, ...props }) => {
   return (
     <img
-      className={["knock-guide-card__img", className].filter(Boolean).join(" ")}
+      className={cx("knock-guide-card__img", className)}
       alt={alt || ""}
       {...props}
     >
@@ -129,12 +105,7 @@ const Actions: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-card__actions", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-card__actions", className)} {...props}>
       {children}
     </div>
   );
@@ -145,12 +116,7 @@ const PrimaryButton: React.FC<
   ButtonContent & React.ComponentPropsWithRef<"button">
 > = ({ text, action, className, ...props }) => {
   return (
-    <button
-      className={["knock-guide-card__action", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <button className={cx("knock-guide-card__action", className)} {...props}>
       {text}
     </button>
   );
@@ -162,12 +128,10 @@ const SecondaryButton: React.FC<
 > = ({ text, action, className, ...props }) => {
   return (
     <button
-      className={[
+      className={cx(
         "knock-guide-card__action knock-guide-card__action--secondary",
         className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
+      )}
       {...props}
     >
       {text}
@@ -181,12 +145,7 @@ const DismissButton: React.FC<React.ComponentPropsWithRef<"button">> = ({
   ...props
 }) => {
   return (
-    <button
-      className={["knock-guide-card__close", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <button className={cx("knock-guide-card__close", className)} {...props}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="18"

--- a/packages/react/src/modules/guide/components/Modal/Modal.tsx
+++ b/packages/react/src/modules/guide/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import { ColorMode, useGuide } from "@knocklabs/react-core";
 import * as Dialog from "@radix-ui/react-dialog";
 import React from "react";
 
+import { cx } from "../../../core/cx";
 import { isValidHttpUrl, maybeNavigateToUrlWithDelay } from "../helpers";
 import {
   ButtonContent,
@@ -39,9 +40,7 @@ const Overlay = React.forwardRef<OverlayRef, OverlayProps>(
   ({ className, ...props }, forwardedRef) => {
     return (
       <Dialog.Overlay
-        className={["knock-guide-modal__overlay", className]
-          .filter(Boolean)
-          .join(" ")}
+        className={cx("knock-guide-modal__overlay", className)}
         ref={forwardedRef}
         {...props}
       />
@@ -58,7 +57,7 @@ const Content = React.forwardRef<ContentRef, ContentProps>(
   ({ children, className, ...props }, forwardedRef) => {
     return (
       <Dialog.Content
-        className={["knock-guide-modal", className].filter(Boolean).join(" ")}
+        className={cx("knock-guide-modal", className)}
         ref={forwardedRef}
         {...props}
       >
@@ -73,12 +72,7 @@ const Header: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-modal__header", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-modal__header", className)} {...props}>
       {children}
     </div>
   );
@@ -93,9 +87,7 @@ type TitleProps = React.ComponentPropsWithoutRef<typeof Dialog.Title> &
 const Title = ({ title, className, ...props }: TitleProps) => {
   return (
     <Dialog.Title
-      className={["knock-guide-modal__title", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={cx("knock-guide-modal__title", className)}
       {...props}
     >
       {title}
@@ -111,9 +103,7 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
 }) => {
   return (
     <Dialog.Description
-      className={["knock-guide-modal__body", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={cx("knock-guide-modal__body", className)}
       dangerouslySetInnerHTML={{ __html: body }}
       {...props}
     />
@@ -126,9 +116,7 @@ const Img: React.FC<
 > = ({ children, className, alt, ...props }) => {
   return (
     <img
-      className={["knock-guide-modal__img", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={cx("knock-guide-modal__img", className)}
       alt={alt || ""}
       {...props}
     >
@@ -142,12 +130,7 @@ const Actions: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div
-      className={["knock-guide-modal__actions", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <div className={cx("knock-guide-modal__actions", className)} {...props}>
       {children}
     </div>
   );
@@ -158,12 +141,7 @@ const PrimaryButton: React.FC<
   ButtonContent & React.ComponentPropsWithRef<"button">
 > = ({ text, action, className, ...props }) => {
   return (
-    <button
-      className={["knock-guide-modal__action", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
+    <button className={cx("knock-guide-modal__action", className)} {...props}>
       {text}
     </button>
   );
@@ -175,12 +153,10 @@ const SecondaryButton: React.FC<
 > = ({ text, action, className, ...props }) => {
   return (
     <button
-      className={[
+      className={cx(
         "knock-guide-modal__action knock-guide-modal__action--secondary",
         className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
+      )}
       {...props}
     >
       {text}
@@ -195,9 +171,7 @@ type CloseProps = React.ComponentPropsWithoutRef<typeof Dialog.Close> &
 const Close = ({ className, ...props }: CloseProps) => {
   return (
     <Dialog.Close
-      className={["knock-guide-modal__close", className]
-        .filter(Boolean)
-        .join(" ")}
+      className={cx("knock-guide-modal__close", className)}
       {...props}
     >
       <svg

--- a/packages/react/src/modules/guide/components/Modal/Modal.tsx
+++ b/packages/react/src/modules/guide/components/Modal/Modal.tsx
@@ -1,6 +1,5 @@
 import { ColorMode, useGuide } from "@knocklabs/react-core";
 import * as Dialog from "@radix-ui/react-dialog";
-import clsx from "clsx";
 import React from "react";
 
 import { isValidHttpUrl, maybeNavigateToUrlWithDelay } from "../helpers";
@@ -40,7 +39,9 @@ const Overlay = React.forwardRef<OverlayRef, OverlayProps>(
   ({ className, ...props }, forwardedRef) => {
     return (
       <Dialog.Overlay
-        className={clsx("knock-guide-modal__overlay", className)}
+        className={["knock-guide-modal__overlay", className]
+          .filter(Boolean)
+          .join(" ")}
         ref={forwardedRef}
         {...props}
       />
@@ -57,7 +58,7 @@ const Content = React.forwardRef<ContentRef, ContentProps>(
   ({ children, className, ...props }, forwardedRef) => {
     return (
       <Dialog.Content
-        className={clsx("knock-guide-modal", className)}
+        className={["knock-guide-modal", className].filter(Boolean).join(" ")}
         ref={forwardedRef}
         {...props}
       >
@@ -72,7 +73,12 @@ const Header: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-modal__header", className)} {...props}>
+    <div
+      className={["knock-guide-modal__header", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -87,7 +93,9 @@ type TitleProps = React.ComponentPropsWithoutRef<typeof Dialog.Title> &
 const Title = ({ title, className, ...props }: TitleProps) => {
   return (
     <Dialog.Title
-      className={clsx("knock-guide-modal__title", className)}
+      className={["knock-guide-modal__title", className]
+        .filter(Boolean)
+        .join(" ")}
       {...props}
     >
       {title}
@@ -103,7 +111,9 @@ const Body: React.FC<{ body: string } & React.ComponentPropsWithRef<"div">> = ({
 }) => {
   return (
     <Dialog.Description
-      className={clsx("knock-guide-modal__body", className)}
+      className={["knock-guide-modal__body", className]
+        .filter(Boolean)
+        .join(" ")}
       dangerouslySetInnerHTML={{ __html: body }}
       {...props}
     />
@@ -116,7 +126,9 @@ const Img: React.FC<
 > = ({ children, className, alt, ...props }) => {
   return (
     <img
-      className={clsx("knock-guide-modal__img", className)}
+      className={["knock-guide-modal__img", className]
+        .filter(Boolean)
+        .join(" ")}
       alt={alt || ""}
       {...props}
     >
@@ -130,7 +142,12 @@ const Actions: React.FC<
   React.PropsWithChildren<React.ComponentPropsWithRef<"div">>
 > = ({ children, className, ...props }) => {
   return (
-    <div className={clsx("knock-guide-modal__actions", className)} {...props}>
+    <div
+      className={["knock-guide-modal__actions", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -141,7 +158,12 @@ const PrimaryButton: React.FC<
   ButtonContent & React.ComponentPropsWithRef<"button">
 > = ({ text, action, className, ...props }) => {
   return (
-    <button className={clsx("knock-guide-modal__action", className)} {...props}>
+    <button
+      className={["knock-guide-modal__action", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    >
       {text}
     </button>
   );
@@ -153,10 +175,12 @@ const SecondaryButton: React.FC<
 > = ({ text, action, className, ...props }) => {
   return (
     <button
-      className={clsx(
+      className={[
         "knock-guide-modal__action knock-guide-modal__action--secondary",
         className,
-      )}
+      ]
+        .filter(Boolean)
+        .join(" ")}
       {...props}
     >
       {text}
@@ -171,7 +195,9 @@ type CloseProps = React.ComponentPropsWithoutRef<typeof Dialog.Close> &
 const Close = ({ className, ...props }: CloseProps) => {
   return (
     <Dialog.Close
-      className={clsx("knock-guide-modal__close", className)}
+      className={["knock-guide-modal__close", className]
+        .filter(Boolean)
+        .join(" ")}
       {...props}
     >
       <svg

--- a/packages/react/test/core/cx.test.ts
+++ b/packages/react/test/core/cx.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+
+import { cx } from "../../src/modules/core/cx";
+
+describe("cx", () => {
+  test("joins multiple class names with a space", () => {
+    expect(cx("a", "b", "c")).toBe("a b c");
+  });
+
+  test("merges a base class with an optional className prop", () => {
+    expect(cx("knock-guide-banner", undefined)).toBe("knock-guide-banner");
+    expect(cx("knock-guide-banner", "custom")).toBe(
+      "knock-guide-banner custom",
+    );
+  });
+
+  test("drops falsy values", () => {
+    expect(cx("a", undefined, "b", null, false, "")).toBe("a b");
+  });
+
+  test("supports conditional modifier classes", () => {
+    const isActive = true;
+    const isDisabled = false;
+    expect(
+      cx("btn", isActive && "btn--active", isDisabled && "btn--disabled"),
+    ).toBe("btn btn--active");
+  });
+
+  test("returns an empty string when given no truthy values", () => {
+    expect(cx(undefined, null, false)).toBe("");
+  });
+});

--- a/packages/react/test/core/debounce.test.ts
+++ b/packages/react/test/core/debounce.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { debounce } from "../../src/modules/core/debounce";
+
+describe("debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("does not invoke the function before the wait elapses", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 200);
+
+    debounced();
+    vi.advanceTimersByTime(199);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("invokes the function once after the wait elapses", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 200);
+
+    debounced();
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("coalesces rapid calls into a single trailing invocation", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 200);
+
+    debounced();
+    vi.advanceTimersByTime(100);
+    debounced();
+    vi.advanceTimersByTime(100);
+    debounced();
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("invokes with the arguments from the most recent call", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 200);
+
+    debounced("first");
+    debounced("second");
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("second");
+  });
+
+  test("cancel() prevents a pending invocation", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 200);
+
+    debounced();
+    debounced.cancel();
+    vi.advanceTimersByTime(200);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("allows a new invocation after the previous one fires", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 200);
+
+    debounced();
+    vi.advanceTimersByTime(200);
+    debounced();
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react/test/core/useOnBottomScroll.test.tsx
+++ b/packages/react/test/core/useOnBottomScroll.test.tsx
@@ -5,12 +5,10 @@ import { describe, expect, test, vi } from "vitest";
 import useOnBottomScroll from "../../src/modules/core/hooks/useOnBottomScroll";
 import { renderWithProviders } from "../test-utils";
 
-// Mock debounce so callback executes immediately
-vi.mock("lodash.debounce", () => {
-  return {
-    default: (fn: unknown) => fn,
-  };
-});
+// Mock debounce so the callback executes immediately
+vi.mock("../../src/modules/core/debounce", () => ({
+  debounce: (fn: () => void) => fn,
+}));
 
 describe("useOnBottomScroll", () => {
   function TestComponent({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5122,7 +5122,6 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/react": "npm:^16.3.2"
     "@types/eslint-plugin-jsx-a11y": "npm:^6"
-    "@types/lodash.debounce": "npm:^4.0.9"
     "@types/react": "npm:^19.2.14"
     "@types/react-dom": "npm:^19.1.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.59.4"
@@ -5134,7 +5133,6 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.5.2"
     jsdom: "npm:^29.1.0"
-    lodash.debounce: "npm:^4.0.8"
     lucide-react: "npm:^0.544.0"
     next: "npm:15.3.6"
     react: "npm:^19.2.5"
@@ -8329,22 +8327,6 @@ __metadata:
     "@types/ms": "npm:*"
     "@types/node": "npm:*"
   checksum: 10c0/0688ac8fb75f809201cb7e18a12b9d80ce539cb9dd27e1b01e11807cb1a337059e899b8ee3abc3f2c9417f02e363a3069d9eab9ef9724b1da1f0e10713514f94
-  languageName: node
-  linkType: hard
-
-"@types/lodash.debounce@npm:^4.0.9":
-  version: 4.0.9
-  resolution: "@types/lodash.debounce@npm:4.0.9"
-  dependencies:
-    "@types/lodash": "npm:*"
-  checksum: 10c0/9fbb24e5e52616faf60ba5c82d8c6517f4b86fc6e9ab353b4c56c0760f63d9bf53af3f2d8f6c37efa48090359fb96dba1087d497758511f6c40677002191d042
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:*":
-  version: 4.17.16
-  resolution: "@types/lodash@npm:4.17.16"
-  checksum: 10c0/cf017901b8ab1d7aabc86d5189d9288f4f99f19a75caf020c0e2c77b8d4cead4db0d0b842d009b029339f92399f49f34377dd7c2721053388f251778b4c23534
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5044,7 +5044,6 @@ __metadata:
     eslint: "npm:^8.56.0"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-react-refresh: "npm:^0.5.2"
-    fast-deep-equal: "npm:^3.1.3"
     jsdom: "npm:^29.1.0"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5130,7 +5130,6 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.59.4"
     "@vitejs/plugin-react": "npm:^4.5.1"
     babel-plugin-react-require: "npm:^4.0.3"
-    clsx: "npm:^2.1.1"
     eslint: "npm:^8.56.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react-hooks: "npm:^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4870,7 +4870,6 @@ __metadata:
     eslint: "npm:^8.56.0"
     eventemitter2: "npm:^6.4.5"
     jsonwebtoken: "npm:^9.0.3"
-    jwt-decode: "npm:^4.0.0"
     nanoid: "npm:^3.3.12"
     phoenix: "npm:1.8.5"
     prettier: "npm:^3.5.3"
@@ -15798,13 +15797,6 @@ __metadata:
     jwa: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/6be1ed93023aef570ccc5ea8d162b065840f3ef12f0d1bb3114cade844de7a357d5dc558201d9a65101e70885a6fa56b17462f520e6b0d426195510618a154d0
-  languageName: node
-  linkType: hard
-
-"jwt-decode@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jwt-decode@npm:4.0.0"
-  checksum: 10c0/de75bbf89220746c388cf6a7b71e56080437b77d2edb29bae1c2155048b02c6b8c59a3e5e8d6ccdfd54f0b8bda25226e491a4f1b55ac5f8da04cfbadec4e546c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Combines four small "npm supply chain hardening" changes — each dropping a third-party runtime dependency from a published package — into one PR. Each is an independent, behavior-preserving change with its own commit, changeset, and tests. Dropping these direct dependencies also removes them from consumers' install graphs once the packages publish.

#### 1. Remove `clsx` from `@knocklabs/react` — [KNO-13814](https://linear.app/knock/issue/KNO-13814)

Every call site was the simple `clsx("static-class", className)` pattern. All ~29 sites across the guide components (`Banner`, `Card`, `Modal`) now use a small internal `cx` helper in its own `packages/react/src/modules/core/cx/` folder — `cx("knock-guide-banner", className)` — replacing the `clsx` runtime dependency with one line of our own code. `clsx` remains in the lockfile only as a transitive dep of the `@telegraph/*` packages.

#### 2. Internalize `jwt-decode` in `@knocklabs/client` — [KNO-13812](https://linear.app/knock/issue/KNO-13812)

The decoder (base64url-decode the payload + `JSON.parse`, no signature verification) now lives in its own `packages/client/src/jwt/` folder. Imports and the test mock are repointed; `jwt-decode` is fully removed from the lockfile. Covered by `test/jwt.test.ts`.

#### 3. Internalize `lodash.debounce` in `@knocklabs/react` — [KNO-13811](https://linear.app/knock/issue/KNO-13811)

The single call site uses default (trailing-edge) options, so a minimal `debounce` now lives in its own `packages/react/src/modules/core/debounce/` folder. Drops both `lodash.debounce` and `@types/lodash.debounce`. Covered by `test/core/debounce.test.ts`.

#### 4. Internalize `fast-deep-equal` in `@knocklabs/react-core` — [KNO-13810](https://linear.app/knock/issue/KNO-13810)

Reimplemented as `deepEqual` in its own `packages/react-core/src/modules/core/deepEqual/` folder (default non-ES6 behavior: primitives, plain objects, arrays, `Date`, `RegExp`). Covered by `test/core/deepEqual.test.ts`.
