### PR TITLE
fix: handle missing features in feed settings response

### DIFF
--- a/.changeset/fix-feed-settings-features.md
+++ b/.changeset/fix-feed-settings-features.md
@@ -1,0 +1,7 @@
+---
+"@knocklabs/react-core": patch
+"@knocklabs/react": patch
+"@knocklabs/react-native": patch
+---
+
+Handle missing `features` in feed settings responses to prevent crashes on partial API responses.

--- a/packages/react-core/src/modules/feed/hooks/useFeedSettings.ts
+++ b/packages/react-core/src/modules/feed/hooks/useFeedSettings.ts
@@ -11,7 +11,7 @@ function useFeedSettings(feedClient: Feed): {
   settings: FeedSettings | null;
   loading: boolean;
 } {
-  const [settings, setSettings] = useState(null);
+  const [settings, setSettings] = useState<FeedSettings | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   // TODO: consider moving this into the feed client and into the feed store state when
@@ -29,7 +29,13 @@ function useFeedSettings(feedClient: Feed): {
       });
 
       if (!response.error) {
-        setSettings(response.body);
+        setSettings({
+          features: {
+            branding_required: Boolean(
+              response.body?.features?.branding_required,
+            ),
+          },
+        });
       }
 
       setIsLoading(false);

--- a/packages/react-core/src/modules/feed/hooks/useFeedSettings.ts
+++ b/packages/react-core/src/modules/feed/hooks/useFeedSettings.ts
@@ -28,11 +28,16 @@ function useFeedSettings(feedClient: Feed): {
         url: feedSettingsPath,
       });
 
-      if (!response.error) {
+      // Only trust a genuine success whose body actually contains the settings
+      // payload. On flaky connections a captive portal or proxy can return a
+      // 200 with a body that isn't the feed settings object; treat that as
+      // "unknown" (leave settings null) rather than fabricating a default that
+      // would silently suppress branding when it is required.
+      if (response.statusCode === "ok" && response.body?.features) {
         setSettings({
           features: {
             branding_required: Boolean(
-              response.body?.features?.branding_required,
+              response.body.features.branding_required,
             ),
           },
         });

--- a/packages/react-core/test/feed/useFeedSettings.test.ts
+++ b/packages/react-core/test/feed/useFeedSettings.test.ts
@@ -56,9 +56,12 @@ describe("useFeedSettings", () => {
     expect(result.current.settings).toBeNull();
   });
 
-  it("handles partial settings response by defaulting features", async () => {
+  it("leaves settings null when a success response is missing the features payload", async () => {
     const { feed, mockApiClient } = createMockFeed("feed_123");
 
+    // A degraded connection (captive portal / proxy) can return a 200 whose
+    // body is not the feed settings object. We must not fabricate a default
+    // from it, which would silently suppress branding when it is required.
     mockNetworkSuccess(mockApiClient, {});
 
     const { result } = renderHook(() =>
@@ -69,10 +72,6 @@ describe("useFeedSettings", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.settings).toEqual({
-      features: {
-        branding_required: false,
-      },
-    });
+    expect(result.current.settings).toBeNull();
   });
 });

--- a/packages/react-core/test/feed/useFeedSettings.test.ts
+++ b/packages/react-core/test/feed/useFeedSettings.test.ts
@@ -55,4 +55,24 @@ describe("useFeedSettings", () => {
 
     expect(result.current.settings).toBeNull();
   });
+
+  it("handles partial settings response by defaulting features", async () => {
+    const { feed, mockApiClient } = createMockFeed("feed_123");
+
+    mockNetworkSuccess(mockApiClient, {});
+
+    const { result } = renderHook(() =>
+      useFeedSettings(feed as unknown as Feed),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.settings).toEqual({
+      features: {
+        branding_required: false,
+      },
+    });
+  });
 });

--- a/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
+++ b/packages/react-native/src/modules/feed/components/NotificationFeedComponents/NotificationFeed.tsx
@@ -160,7 +160,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
         onEndReached={onEndReached}
         onEndReachedThreshold={0.5}
       />
-      {settings?.features.branding_required && (
+      {settings?.features?.branding_required && (
         <View style={styles.branding}>
           <PoweredByKnockIcon />
         </View>

--- a/packages/react/src/modules/feed/components/NotificationFeed/NotificationFeed.tsx
+++ b/packages/react/src/modules/feed/components/NotificationFeed/NotificationFeed.tsx
@@ -154,7 +154,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
         {!requestInFlight && noItems && EmptyComponent}
       </div>
 
-      {settings?.features.branding_required && (
+      {settings?.features?.branding_required && (
         <div className="rnf-notification-feed__knock-branding">
           <a href={poweredByKnockUrl} target="_blank">
             {t("poweredBy") || "Powered by Knock"}


### PR DESCRIPTION
### Description

Fixes #1018

Users on flaky networks can receive a successful (200) response from the feed settings endpoint with a partial or empty body (e.g. missing the `features` object). The SDK then crashed with:

`TypeError: can't access property "branding_required", v.features is undefined`

This PR:

- Normalizes feed settings in `useFeedSettings` so `features.branding_required` always defaults safely when missing
- Adds optional chaining on `features` in both web and React Native `NotificationFeed` components
- Adds a unit test for the partial-settings response case

### Todos

None.

### Checklist

- [x] Tests have been added for new features or major refactors to existing features.

### Test plan

- [x] `yarn test` — `useFeedSettings` tests pass (including new partial response case)
- [x] `yarn workspace @knocklabs/react-core type:check` passes
- [x] `yarn workspace @knocklabs/react-core lint` passes
- [x] `yarn workspace @knocklabs/react lint` passes
- [x] `yarn workspace @knocklabs/react-native lint` passes
