### PR TITLE
chore: include package.json in package exports maps

### DIFF
--- a/.changeset/expose-package-json-exports.md
+++ b/.changeset/expose-package-json-exports.md
@@ -1,0 +1,9 @@
+---
+"@knocklabs/client": patch
+"@knocklabs/react": patch
+"@knocklabs/react-core": patch
+"@knocklabs/react-native": patch
+"@knocklabs/expo": patch
+---
+
+Expose `./package.json` in each package's `exports` map. This restores the ability for tooling (bundlers, test mockers such as Storybook/Vitest, and version checks) to resolve the package manifest, which the `exports` field otherwise blocks.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,6 +11,7 @@
   "typings": "dist/types/index.d.ts",
   "react-native": "./src/index.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/types/index.d.ts",
       "react-native": "./src/index.ts",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -9,6 +9,7 @@
   "typings": "dist/types/index.d.ts",
   "react-native": "./src/index.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -10,6 +10,7 @@
   "typings": "dist/types/index.d.ts",
   "react-native": "./src/index.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/types/index.d.ts",
       "react-native": "./src/index.ts",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -9,6 +9,7 @@
   "typings": "dist/types/index.d.ts",
   "react-native": "./src/index.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,6 +10,7 @@
   "typings": "dist/types/index.d.ts",
   "style": "dist/index.css",
   "exports": {
+    "./package.json": "./package.json",
     "./dist/index.css": "./dist/index.css",
     ".": {
       "require": "./dist/cjs/index.js",


### PR DESCRIPTION
### Description

Adds `"./package.json": "./package.json"` to the `exports` map of the five published packages that define one: `@knocklabs/client`, `@knocklabs/react`, `@knocklabs/react-core`, `@knocklabs/react-native`, and `@knocklabs/expo`.

**Why:** once a package declares an `exports` field, that field becomes a hard encapsulation boundary — any subpath not explicitly listed (including `./package.json`) becomes unresolvable. A lot of tooling relies on being able to resolve a dependency's manifest: bundlers, version/feature detection, and test mockers like Storybook and Vitest. Without this entry, `sb.mock(import("@knocklabs/react"))` throws `Package subpath './package.json' is not defined by "exports"`.

Exposing `./package.json` is the accepted convention (React, Vite, Zod, most of `@babel/*`, etc. all do it) and is zero-risk — the file is already published.

`@knocklabs/types` is intentionally untouched because it has no `exports` map.

### Checklist
- [x] No tests added — this is a package-manifest metadata change with no runtime code surface. Existing type-check/build cover manifest validity.

Closes #1026
KNO-14073
