### PR TITLE
fix(react-native): order react-native export condition before require

### DIFF
--- a/.changeset/react-native-exports-ordering.md
+++ b/.changeset/react-native-exports-ordering.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/react-native": patch
+---
+
+Fix the `exports` map ordering so React Native's Metro bundler resolves the package to its source entry point (`src/index.ts`) via the `react-native` condition instead of the prebuilt CommonJS bundle. The `require` condition was previously listed first, shadowing `react-native` under Metro's package-exports resolution (enabled by default since React Native 0.79). The ordering now matches the other `@knocklabs/*` packages.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -11,10 +11,11 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts",
       "react-native": "./src/index.ts",
-      "default": "./dist/esm/index.mjs"
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.mjs",
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
### Description

Fixes the `exports` map ordering in `@knocklabs/react-native` so React Native's Metro bundler resolves the package to its **source** entry point (`src/index.ts`) rather than the prebuilt `dist/cjs` bundle.

**Root cause.** Node/Metro conditional-exports matching is *first-match by object-key order*. The `exports["."]` map listed `require` **before** the `react-native` condition:

```jsonc
".": {
  "require": "./dist/cjs/index.js",   // ← matched first
  "types": "./dist/types/index.d.ts",
  "react-native": "./src/index.ts",   // ← never reached
  "default": "./dist/esm/index.mjs"
}
```

React Native's Metro runs with both `require` and `react-native` conditions active, so it matched `require` first and loaded the prebuilt CommonJS bundle instead of the `src/index.ts` source the `react-native` condition exists to serve. Every sibling package (`@knocklabs/client`, `@knocklabs/react-core`, `@knocklabs/react`) already lists `react-native` first — `react-native` was the odd one out.

**Why it started with RN 0.79.** Package-exports resolution is enabled by default in Metro since React Native 0.79. On older RN, Metro used `resolverMainFields` → the top-level `"react-native": "./src/index.ts"` field → source, so it worked. This lines up with [#838](https://github.com/knocklabs/javascript/issues/838) (`Cannot read property 'KnockProvider' of undefined`), reported on RN 0.79.2.

**Fix.** Reorder `exports["."]` so `types` + `react-native` come first, matching `@knocklabs/react-core`.

**Verification.** Ran the real export maps through Metro's own resolver (`metro-resolver`'s `reduceExportsLikeMap`) under RN's active conditions (`{default, require, react-native}`):

| | before | after |
|---|---|---|
| `@knocklabs/react-native` `.` | `./dist/cjs/index.js` ❌ | `./src/index.ts` ✅ |
| `./package.json` subpath | `./package.json` | `./package.json` (unchanged) |

> **Note:** the resolution divergence is proven; the exact Hermes runtime crash from #838 was not reproduced end-to-end without a full RN app (loading the dist in plain Node still re-exports `KnockProvider`). The misconfiguration is unambiguously real and is the most likely trigger. Worth confirming with the reporter or a full Metro/RN repro before closing #838.

Tracked in KNO-14075.
