### PR TITLE
fix(expo): re-register push token on in-place user switch

### DIFF
--- a/.changeset/expo-push-reregister-on-user-switch.md
+++ b/.changeset/expo-push-reregister-on-user-switch.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/expo": patch
+---
+
+Fix Expo push auto-registration not re-running when the signed-in user changes in place. The auto-register effect now depends on the authenticated `userId`, so switching users on the same `KnockProvider` (where `isAuthenticated` never flips) re-registers the device token against the new user's channel data.

--- a/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
+++ b/packages/expo/src/modules/push/KnockExpoPushNotificationProvider.tsx
@@ -67,7 +67,7 @@ const InternalExpoPushNotificationProvider: React.FC<
   autoRegister = true,
 }) => {
   const knockClient = useKnockClient();
-  const { status: authStatus } = useKnockAuthState(knockClient);
+  const { status: authStatus, userId } = useKnockAuthState(knockClient);
   const isAuthenticated = authStatus === "authenticated";
   const { registerPushTokenToChannel, unregisterPushTokenFromChannel } =
     usePushNotifications();
@@ -182,6 +182,9 @@ const InternalExpoPushNotificationProvider: React.FC<
   // Gating on auth defers the OS permission prompt (prompting a logged-out user
   // is hostile) and avoids registering a token against no user. Because
   // `isAuthenticated` is a dependency, enabling auth later re-runs registration.
+  // `userId` is also a dependency so that an in-place user switch (same Knock
+  // instance re-authenticated as a different user, where `isAuthenticated` never
+  // flips) re-registers the device token against the new user's channel data.
   useEffect(() => {
     if (!autoRegister || !isAuthenticated) {
       return;
@@ -210,6 +213,7 @@ const InternalExpoPushNotificationProvider: React.FC<
   }, [
     autoRegister,
     isAuthenticated,
+    userId,
     knockExpoChannelId,
     registerForPushNotifications,
     registerPushTokenToChannel,

--- a/packages/expo/test/modules/push/KnockExpoPushNotificationProvider.test.tsx
+++ b/packages/expo/test/modules/push/KnockExpoPushNotificationProvider.test.tsx
@@ -79,15 +79,20 @@ const mockKnockClient = {
   },
 };
 
+// Controllable signed-in user id so a test can simulate an in-place user switch
+// (same Knock instance re-authenticated as a different user).
+let mockUserId: string | undefined = "user_1";
+
 vi.mock("@knocklabs/react-core", () => ({
   useKnockClient: () => mockKnockClient,
   // Derive auth state from the same `isAuthenticated` mock so tests only have to
-  // toggle it in one place.
+  // toggle it in one place; `mockUserId` lets a test change the signed-in user
+  // while staying authenticated.
   useKnockAuthState: () => ({
     status: mockKnockClient.isAuthenticated()
       ? "authenticated"
       : "unauthenticated",
-    userId: mockKnockClient.isAuthenticated() ? "user_1" : undefined,
+    userId: mockKnockClient.isAuthenticated() ? mockUserId : undefined,
     userToken: undefined,
   }),
 }));
@@ -668,5 +673,51 @@ describe("KnockExpoPushNotificationProvider", () => {
 
     // Should still only be called once
     expect(getTokenSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-registers the push token when the authenticated user changes in place", async () => {
+    const NotificationsMock = await import("expo-notifications");
+    const getTokenSpy = vi.mocked(NotificationsMock.getExpoPushTokenAsync);
+    getTokenSpy.mockClear();
+    getTokenSpy.mockResolvedValue({ data: "test-token" });
+    mockRegisterPushTokenToChannel.mockClear();
+
+    const TestChild = () => <div data-testid="test-child">Test Child</div>;
+
+    try {
+      const { rerender } = render(
+        <KnockExpoPushNotificationProvider
+          knockExpoChannelId="test-channel-id"
+          autoRegister={true}
+        >
+          <TestChild />
+        </KnockExpoPushNotificationProvider>,
+      );
+
+      // Registers once for the initial user.
+      await waitFor(() => {
+        expect(mockRegisterPushTokenToChannel).toHaveBeenCalledTimes(1);
+      });
+
+      // Switch to a different user in place: same Knock instance, still
+      // authenticated, only the signed-in userId changes. `isAuthenticated`
+      // never flips, so the userId dependency is what drives re-registration.
+      mockUserId = "user_2";
+      rerender(
+        <KnockExpoPushNotificationProvider
+          knockExpoChannelId="test-channel-id"
+          autoRegister={true}
+        >
+          <TestChild />
+        </KnockExpoPushNotificationProvider>,
+      );
+
+      // The device token must be registered again for the new user.
+      await waitFor(() => {
+        expect(mockRegisterPushTokenToChannel).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      mockUserId = "user_1";
+    }
   });
 });


### PR DESCRIPTION
## What

Fixes the Cursor BugBot finding on #1038: the Expo push auto-register effect does not re-run when the signed-in user changes in place.

`useAuthenticatedKnockClient` re-authenticates the **same** `Knock` instance when only the userId changes (it returns `currentKnock`), so on a user A -> user B switch the `knockClient` identity is stable and `isAuthenticated` stays `true`. The auto-register effect depended on `isAuthenticated` but not `userId`, so it never re-ran, leaving the device token bound to user A's channel data.

This is the same class as the Slack/Teams "authCheck race on user switch" fix already in this release, applied to the one integration that was missed.

## Change

- `KnockExpoPushNotificationProvider`: destructure `userId` from `useKnockAuthState` and add it to the auto-register effect's dependency array (2 source lines).
- Test: make the mocked `userId` controllable and add a case asserting the token re-registers on an in-place user switch. Verified it fails without the dep and passes with it.
- Changeset: `@knocklabs/expo` patch.

## Release path

Base is `rc` so this rides the same release as #1038: merge here, then merge `rc` -> `main` (#1038) to publish stable with the fix (`@knocklabs/expo@0.7.0`).

Tracks KNO-14229. The secondary point from the finding (no `unregisterPushTokenFromChannel` on auth loss) is intentionally out of scope and captured in the ticket as a separate decision.
