### PR TITLE
fix(client): respect trigger data in bulk feed status updates

### DIFF
--- a/.changeset/quiet-feeds-filter.md
+++ b/.changeset/quiet-feeds-filter.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+Scope bulk feed status updates to the feed's trigger data filters.

--- a/packages/client/src/clients/feed/feed.ts
+++ b/packages/client/src/clients/feed/feed.ts
@@ -772,6 +772,7 @@ class Feed {
       tenants: this.defaultOptions.tenant
         ? [this.defaultOptions.tenant]
         : undefined,
+      trigger_data: getFormattedTriggerData(this.defaultOptions),
     };
 
     return await this.knock.messages.bulkUpdateAllStatusesInChannel({

--- a/packages/client/src/clients/messages/interfaces.ts
+++ b/packages/client/src/clients/messages/interfaces.ts
@@ -63,6 +63,7 @@ export type BulkUpdateMessagesInChannelProperties = {
     archived?: "exclude" | "include" | "only";
     has_tenant?: boolean;
     tenants?: string[];
+    trigger_data?: string;
   };
 };
 

--- a/packages/client/test/clients/feed/feed.test.ts
+++ b/packages/client/test/clients/feed/feed.test.ts
@@ -429,6 +429,7 @@ describe("Feed", () => {
             engagement_status: undefined,
             has_tenant: undefined,
             tenants: undefined,
+            trigger_data: undefined,
           },
         });
         expect(result).toEqual(bulkResponse);
@@ -466,6 +467,7 @@ describe("Feed", () => {
             engagement_status: undefined,
             has_tenant: undefined,
             tenants: undefined,
+            trigger_data: undefined,
           },
         });
         expect(result).toEqual(bulkResponse);
@@ -503,6 +505,7 @@ describe("Feed", () => {
             engagement_status: undefined,
             has_tenant: undefined,
             tenants: undefined,
+            trigger_data: undefined,
           },
         });
         expect(result).toEqual(bulkResponse);
@@ -1154,6 +1157,7 @@ describe("Feed", () => {
             archived: "exclude",
             has_tenant: true,
             tenant: "tenant-123",
+            trigger_data: { type: "comment", priority: 1 },
           },
           undefined,
         );
@@ -1169,6 +1173,7 @@ describe("Feed", () => {
             archived: "exclude",
             has_tenant: true,
             tenants: ["tenant-123"],
+            trigger_data: '{"type":"comment","priority":1}',
           },
         });
       } finally {
@@ -1191,6 +1196,7 @@ describe("Feed", () => {
           {
             status: "all", // Should not be included in options
             archived: "include",
+            trigger_data: { type: "mention" },
           },
           undefined,
         );
@@ -1206,6 +1212,7 @@ describe("Feed", () => {
             archived: "include",
             has_tenant: undefined,
             tenants: undefined,
+            trigger_data: '{"type":"mention"}',
           },
         });
       } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Ensure bulk feed status operations (`markAllAsSeen`, `markAllAsRead`, and archive variants) pass the feed's `trigger_data` filter to the channel bulk status API. Trigger data is serialized consistently with feed fetch requests, preventing status updates from affecting notifications outside the visible filtered feed.

Adds regression coverage for read and seen bulk operations and a patch changeset for `@knocklabs/client`.

### Checklist
- [x] Tests have been added for the bug fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14292](https://linear.app/knock/issue/KNO-14292/markallasseen-is-not-respecting-triggerdata-filters-although-the-api)

<div><a href="https://cursor.com/agents/bc-bb68a0b2-f76d-498c-b3bc-3a088e33f45a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb68a0b2-f76d-498c-b3bc-3a088e33f45a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

