### PR TITLE
fix(client): upgrade Phoenix to 1.8.9

### DIFF
--- a/.changeset/secure-phoenix-client.md
+++ b/.changeset/secure-phoenix-client.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/client": patch
+---
+
+Upgrade Phoenix to 1.8.9 to address CVE-2026-56812.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -75,7 +75,7 @@
     "@types/phoenix": "^1.6.7",
     "eventemitter2": "^6.4.5",
     "nanoid": "^3.3.12",
-    "phoenix": "1.8.5",
+    "phoenix": "1.8.9",
     "urlpattern-polyfill": "^10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4632,7 +4632,7 @@ __metadata:
     eventemitter2: "npm:^6.4.5"
     jsonwebtoken: "npm:^9.0.3"
     nanoid: "npm:^3.3.12"
-    phoenix: "npm:1.8.5"
+    phoenix: "npm:1.8.9"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.1.3"
     rollup: "npm:^4.46.2"
@@ -17150,10 +17150,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"phoenix@npm:1.8.5":
-  version: 1.8.5
-  resolution: "phoenix@npm:1.8.5"
-  checksum: 10c0/11e7a4c75a41524e25aa32001be709ad50d2a8d02650f0c67f30e4e69bd5d85211054137a51b7d4dcf9cfe65d1e65cf7bbefa22c4207506caf1afd36bf7cd551
+"phoenix@npm:1.8.9":
+  version: 1.8.9
+  resolution: "phoenix@npm:1.8.9"
+  checksum: 10c0/9f661db2c0e3986ec3cce4969ec4906a02e15675bd9123fbb8ae7a8caf61213ce20420be505f52dc0a9de9117021a21e9b1344964400530e26474e45d7819c86
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Upgrades the `@knocklabs/client` Phoenix dependency from 1.8.5 to 1.8.9 and refreshes the Yarn lockfile. This resolves [KNO-15131](https://linear.app/knock/issue/KNO-15131/phoenix185-has-cve-2026-56812) and removes the version affected by [GHSA-63mc-hw7g-86rr](https://github.com/advisories/GHSA-63mc-hw7g-86rr).

Includes a patch changeset for `@knocklabs/client`.

### Verification
- `yarn why phoenix` resolves `phoenix@npm:1.8.9`
- `yarn test packages/client` — 21 files and 630 tests passed
- `yarn workspace @knocklabs/client type:check` — passed
- `yarn workspace @knocklabs/client build` — CommonJS and ESM builds passed
- `yarn changeset status` — valid patch changeset detected

### Checklist
- [x] Client tests pass
- [x] Client type checking passes
- [x] Client build succeeds
- [x] Changeset validates
- [ ] Aikido security scan (MCP server unavailable in the agent environment)

### Verification artifacts
[Phoenix 1.8.9 upgrade verification](https://cursor.com/artifacts/c/art-33fc896f-afb5-4f2e-9de9-7ccdb5aa3f3d)
[Changeset validation](https://cursor.com/artifacts/c/art-8ff23396-9603-4e9f-af1a-67902a0af02a)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-15131](https://linear.app/knock/issue/KNO-15131/phoenix185-has-cve-2026-56812)

<div><a href="https://cursor.com/agents/bc-5eb64ca0-4284-4e62-bc92-8f26721b086d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eb64ca0-4284-4e62-bc92-8f26721b086d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

